### PR TITLE
Deploy: Fix opencode model listing, scheduler improvements, queue panel overlay fixes

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -359,6 +359,7 @@ def find_executable(name: str) -> Optional[str]:
 
     # Search additional common locations
     search_paths = [
+        Path.home() / ".local" / "bin" / name,  # User-local installs
         Path("/opt/homebrew/bin") / name,  # Homebrew ARM64 (M1/M2 Macs)
         Path("/usr/local/bin") / name,      # Homebrew Intel / manual installs
         Path("/usr/bin") / name,            # Standard system location
@@ -776,7 +777,11 @@ class SessionManager:
 
         # OpenCode Paths
         self.opencode_home = Path.home() / ".opencode"
-        self.opencode_bin = self.opencode_home / "bin" / "opencode"
+        # Resolve OpenCode executable like other runtimes; keep legacy path as fallback.
+        self.opencode_bin = Path(
+            find_executable("opencode")
+            or str(self.opencode_home / "bin" / "opencode")
+        )
         self.opencode_session_storage = (
             Path.home()
             / ".local"

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -210,6 +210,35 @@ class TestSessionPersistence(unittest.TestCase):
         session_2 = manager2.get_or_create_session_data("persistent_session")
         self.assertEqual(session_2["session_id"], original_id)
 
+    @patch("agent_manager.shutil.which", return_value=None)
+    def test_find_executable_in_user_local_bin(self, _mock_which):
+        """find_executable should discover binaries under ~/.local/bin."""
+        local_bin = self.temp_path / ".local" / "bin"
+        local_bin.mkdir(parents=True, exist_ok=True)
+        exe = local_bin / "opencode"
+        exe.write_text("#!/bin/sh\nexit 0\n")
+        exe.chmod(0o755)
+
+        found = agent_manager.find_executable("opencode")
+        self.assertEqual(found, str(exe))
+
+    @patch("agent_manager.find_executable")
+    def test_session_manager_resolves_opencode_from_discovery(self, mock_find):
+        """SessionManager should use discovered opencode executable path."""
+        discovered = self.temp_path / ".local" / "bin" / "opencode"
+        discovered.parent.mkdir(parents=True, exist_ok=True)
+        discovered.write_text("#!/bin/sh\nexit 0\n")
+        discovered.chmod(0o755)
+
+        def _resolver(name):
+            if name == "opencode":
+                return str(discovered)
+            return None
+
+        mock_find.side_effect = _resolver
+        manager = SessionManager(str(self.config_file))
+        self.assertEqual(manager.opencode_bin, discovered)
+
 
 class TestSlashCommands(unittest.TestCase):
     """Test slash command parsing and execution"""


### PR DESCRIPTION
## Changes
- Fix opencode model listing by resolving CLI from PATH
- Fix queue panel overlay flicker (issue #34) — GPU layer isolation, -webkit-backdrop-filter
- Fix scheduler: add second/week support and fix rstrip('s') unit parsing bug
- Add second unit to 'every X' schedule parser in management.py

## Files Changed
- `agent_manager.py` - opencode model listing fix
- `scheduler/executor.py` - second/week support
- `scheduler/management.py` - unit parsing fix
- `tests/test_agent_manager.py` - new tests
- `webui/dist/app.css` - queue panel overlay fixes
- `webui/dist/index.html` - minor update