### PR TITLE
Fix queue visibility: expand to 33vh when items present

### DIFF
--- a/webui/dist/app.css
+++ b/webui/dist/app.css
@@ -2620,16 +2620,16 @@ html, body {
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid var(--glass-border);
-  flex: 0 0 auto;
-  min-height: 150px;
-  max-height: 33%;
-  overflow-y: auto;
-  transition: min-height 0.3s ease, max-height 0.3s ease;
+  flex: 1 1 0;
+  min-height: 0;
+  max-height: 33vh;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
 }
 
 .queue-section-collapsed {
+  flex: 0 0 auto;
   max-height: 46px;
-  min-height: 0;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Queue section now takes up to 1/3 of right panel height when items are queued.

### Changes
- queue-section uses flex:1 1 0 to compete with todo-section for panel space
- Capped at max-height:33vh so queue never exceeds 1/3 viewport height  
- Collapsed state: flex:0 0 auto, max-height:46px (header only)
- Both states verified via Playwright DOM measurements

### Testing
- Empty queue: todo expands to fill space, queue shows header bar only
- With items: todo shrinks, queue shows up to 33vh of scrollable items