### PR TITLE
fix(webui): add /update to slash command autocomplete list

### DIFF
--- a/webui/dist/app.js
+++ b/webui/dist/app.js
@@ -442,6 +442,7 @@ const COMMANDS = [
   { cmd: '/session',      usage: '/session',                               desc: 'Show session info' },
   { cmd: '/timeout',      usage: '/timeout <seconds>',                     desc: 'Set the command timeout' },
   { cmd: '/render',       usage: '/render <text|markdown>',                desc: 'Set render output type' },
+  { cmd: '/update',       usage: '/update',                                desc: 'Pull latest code and restart dev services (aliases: /upgrade, /pull)' },
 ];
 
 const SUBCOMMANDS = {


### PR DESCRIPTION
## Summary
- Adds `/update` to the `COMMANDS` array in `app.js` so it appears in the WebUI slash command autocomplete dropdown, matching behavior of other slash commands like `/agent`, `/model`, etc.

## Test plan
- [ ] Type `/upd` in WebUI input — autocomplete suggestion appears
- [ ] All 4 production services healthy after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)