### PR TITLE
feat: permissions system, mobile UI, tool call display, .env editor

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1787,6 +1787,7 @@ class SessionManager:
             "render_type": "markdown",
             "channel": channel,
             "last_activity": time.time(),
+            "permissions": None,  # Inherited from agent config on session create
         }
         
         # Store identity if provided, so we can find sessions by user later
@@ -6167,6 +6168,19 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
         if body.agent:
             session_mgr.update_session_field(session_id, "agent", body.agent)
+
+        # Inherit agent default permissions into session
+        effective_agent = body.agent or get_default_agent()
+        if effective_agent and effective_agent in session_mgr.AGENTS:
+            agent_cfg = session_mgr.AGENTS[effective_agent]
+            default_perms = agent_cfg.get("permissions", {
+                "mode": "restricted",
+                "directories": {"allow_read": [], "allow_write": [], "deny": []},
+                "tools": {"allow": ["*"], "deny": []},
+                "network": {"allow_urls": ["*"], "deny_urls": []},
+                "mcp": {"allow": [], "deny": ["*"]},
+            })
+            session_mgr.update_session_field(session_id, "permissions", default_perms)
         if body.model:
             session_mgr.update_session_field(session_id, "model", body.model)
         if body.runtime:
@@ -6610,6 +6624,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             "runtime": data.get("runtime"),
             "model": data.get("model"),
             "yolo_mode": data.get("yolo_mode", "restricted"),
+            "permissions": data.get("permissions"),
         }
 
         # Include running query info so the frontend can reconnect streams
@@ -8813,6 +8828,197 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 "name": sess.get("name"),
             }
         return {"sessions": sessions, "count": len(_canvas_sessions)}
+
+
+
+    # --- Session Permissions API ---
+    @app.get("/api/v1/sessions/{session_id}/permissions")
+    async def get_session_permissions(session_id: str, request: Request):
+        """Return current session permissions (inherited from agent or overridden)."""
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        data = session_mgr.load_session_data(session_id)
+        if not data:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        perms = data.get("permissions")
+        agent_name = data.get("agent", get_default_agent())
+        agent_cfg = session_mgr.AGENTS.get(agent_name, {})
+        agent_default_perms = agent_cfg.get("permissions", {
+            "mode": "restricted",
+            "directories": {"allow_read": [], "allow_write": [], "deny": []},
+            "tools": {"allow": ["*"], "deny": []},
+            "network": {"allow_urls": ["*"], "deny_urls": []},
+            "mcp": {"allow": [], "deny": ["*"]},
+        })
+
+        return {
+            "session_id": session_id,
+            "permissions": perms or agent_default_perms,
+            "agent_default_permissions": agent_default_perms,
+            "is_overridden": perms is not None and perms != agent_default_perms,
+        }
+
+    @app.put("/api/v1/sessions/{session_id}/permissions")
+    async def set_session_permissions(session_id: str, request: Request):
+        """Override session-level permissions."""
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        data = session_mgr.load_session_data(session_id)
+        if not data:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        body = await request.json()
+        valid_modes = ("elevated", "restricted", "sandboxed")
+
+        # Accept either a full permissions object or just a mode string
+        if isinstance(body, dict) and "mode" in body:
+            # If just mode is provided, build full permissions from agent default + new mode
+            new_mode = body["mode"]
+            if new_mode not in valid_modes:
+                raise HTTPException(status_code=400, detail=f"Invalid mode. Must be one of: {valid_modes}")
+
+            # Get current permissions and update mode
+            current_perms = data.get("permissions") or {}
+            if not current_perms:
+                agent_name = data.get("agent", get_default_agent())
+                agent_cfg = session_mgr.AGENTS.get(agent_name, {})
+                current_perms = agent_cfg.get("permissions", {
+                    "mode": "restricted",
+                    "directories": {"allow_read": [], "allow_write": [], "deny": []},
+                    "tools": {"allow": ["*"], "deny": []},
+                    "network": {"allow_urls": ["*"], "deny_urls": []},
+                    "mcp": {"allow": [], "deny": ["*"]},
+                })
+            current_perms["mode"] = new_mode
+            session_mgr.update_session_field(session_id, "permissions", current_perms)
+            return {"updated": True, "permissions": current_perms}
+
+        elif isinstance(body, dict) and "permissions" in body:
+            # Full permissions object provided
+            perms = body["permissions"]
+            if not isinstance(perms, dict) or "mode" not in perms:
+                raise HTTPException(status_code=400, detail="permissions must be an object with at least a 'mode' key")
+            if perms["mode"] not in valid_modes:
+                raise HTTPException(status_code=400, detail=f"Invalid mode. Must be one of: {valid_modes}")
+            session_mgr.update_session_field(session_id, "permissions", perms)
+            return {"updated": True, "permissions": perms}
+
+        else:
+            raise HTTPException(status_code=400, detail="Request body must include 'mode' or 'permissions'")
+
+    @app.get("/api/v1/permissions/templates")
+    async def get_permission_templates(request: Request):
+        """Return available permission templates."""
+        await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        return {
+            "templates": [
+                {
+                    "mode": "elevated",
+                    "label": "Full Access",
+                    "description": "Agent has unrestricted access to all tools, directories, and network",
+                    "icon": "⚡",
+                },
+                {
+                    "mode": "restricted",
+                    "label": "Restricted",
+                    "description": "Agent uses curated tool and directory allowlists only",
+                    "icon": "🔒",
+                },
+                {
+                    "mode": "sandboxed",
+                    "label": "Sandboxed",
+                    "description": "Agent has no external access — fully isolated environment",
+                    "icon": "🏖️",
+                },
+            ]
+        }
+
+
+
+    # --- .env File Editor API ---
+    _env_file_path = Path(SCRIPT_BASE_DIR) / ".env"
+
+    @app.get("/api/v1/settings/env")
+    async def get_env_file(request: Request):
+        """Return .env file contents for editing."""
+        auth = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        try:
+            content = _env_file_path.read_text() if _env_file_path.exists() else ""
+            return {"content": content, "path": str(_env_file_path), "exists": _env_file_path.exists()}
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to read .env: {e}")
+
+    @app.put("/api/v1/settings/env")
+    async def put_env_file(request: Request):
+        """Save updated .env file contents."""
+        auth = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        body = await request.json()
+        content = body.get("content", "")
+        if not isinstance(content, str):
+            raise HTTPException(status_code=400, detail="content must be a string")
+
+        try:
+            # Create backup before overwrite
+            if _env_file_path.exists():
+                backup_path = Path(str(_env_file_path) + ".bak")
+                shutil.copy2(_env_file_path, backup_path)
+
+            _env_file_path.write_text(content)
+            return {"saved": True, "path": str(_env_file_path), "warning": "Changes require a service restart to take effect."}
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to save .env: {e}")
+
+    @app.post("/api/v1/settings/restart-services")
+    async def restart_services(request: Request):
+        """Restart dev services (agent-manager-api-dev, etc.)."""
+        auth = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        import subprocess
+        services = [
+            "agent-manager-api-dev.service",
+            "task-scheduler-executor-dev.service",
+            "webex-connector-dev.service",
+            "telegram-bot-listener-dev.service",
+        ]
+        results = {}
+        for svc in services:
+            try:
+                proc = subprocess.run(
+                    ["systemctl", "restart", svc],
+                    capture_output=True, text=True, timeout=30
+                )
+                results[svc] = "restarted" if proc.returncode == 0 else f"failed: {proc.stderr.strip()}"
+            except Exception as e:
+                results[svc] = f"error: {e}"
+        return {"results": results, "note": "Services are restarting. The API will briefly disconnect."}
 
     # --- Settings & Logs API ──────────────────────────────────────────────────
 

--- a/webui/dist/app.css
+++ b/webui/dist/app.css
@@ -6036,3 +6036,78 @@ html, body {
     -webkit-backdrop-filter: none !important;
   }
 }
+
+
+/* ── Session Permissions Pill ──────────────────────────────────────────────── */
+.meta-permissions {
+  cursor: pointer;
+  font-size: 0.72rem;
+  transition: background 0.2s, color 0.2s;
+}
+.meta-permissions.perm-elevated {
+  background: rgba(255, 165, 0, 0.25);
+  color: #ffb347;
+  border-color: rgba(255, 165, 0, 0.4);
+}
+.meta-permissions.perm-sandboxed {
+  background: rgba(100, 149, 237, 0.25);
+  color: #87CEFA;
+  border-color: rgba(100, 149, 237, 0.4);
+}
+
+/* ── .env Editor ───────────────────────────────────────────────────────────── */
+.asf-env-editor-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.asf-env-toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.asf-env-textarea {
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  min-height: 200px;
+  resize: vertical;
+  white-space: pre;
+  overflow-x: auto;
+  tab-size: 4;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 12px;
+  color: #e0e0e0;
+}
+.asf-env-textarea:focus {
+  border-color: rgba(16, 185, 129, 0.5);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.15);
+}
+.asf-env-status {
+  font-size: 0.78rem;
+  padding: 6px 10px;
+  border-radius: 6px;
+  transition: opacity 0.3s;
+}
+.asf-env-ok {
+  background: rgba(16, 185, 129, 0.15);
+  color: #6ee7b7;
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+.asf-env-error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+.asf-env-warning {
+  font-size: 0.75rem;
+  color: #fbbf24;
+  opacity: 0.8;
+  margin: 0;
+}
+.asf-btn-restart {
+  margin-left: auto;
+}

--- a/webui/dist/app.js
+++ b/webui/dist/app.js
@@ -207,6 +207,20 @@ function updateSessionMeta(data) {
   modeEl.classList.toggle('yolo', isYolo);
   modeEl.classList.remove('empty');
 
+  // Permissions pill
+  const permEl = $('meta-permissions');
+  if (permEl) {
+    const perms = data?.permissions;
+    const permMode = perms?.mode || 'restricted';
+    const permIcons = { elevated: '⚡', restricted: '🔒', sandboxed: '🏖️' };
+    const permLabels = { elevated: 'Full Access', restricted: 'Restricted', sandboxed: 'Sandboxed' };
+    permEl.textContent = (permIcons[permMode] || '🔒') + ' ' + (permLabels[permMode] || permMode);
+    permEl.dataset.permMode = permMode;
+    permEl.classList.remove('empty');
+    permEl.classList.toggle('perm-elevated', permMode === 'elevated');
+    permEl.classList.toggle('perm-sandboxed', permMode === 'sandboxed');
+  }
+
 
   // Refresh TODOs when agent changes
   if (typeof fetchAndRenderTodos === 'function') {
@@ -356,6 +370,33 @@ const PILL_OPTIONS = {
       { label: '🔒 restricted',     cmd: '/mode restricted' },
     ],
   },
+  'meta-permissions': {
+    label: 'Session Permissions',
+    options: null,
+    dynamicLoad: async () => {
+      try {
+        const data = await apiRequest('GET', '/permissions/templates');
+        return (data.templates || []).map(t => ({
+          label: t.icon + ' ' + t.label,
+          value: t.mode,
+          cmd: null,
+          action: async () => {
+            if (!STATE.currentSessionId) return;
+            try {
+              await apiRequest('PUT', '/sessions/' + STATE.currentSessionId + '/permissions', { mode: t.mode });
+              fetchAndUpdateMeta(STATE.currentSessionId);
+            } catch (e) { console.error('Failed to set permissions:', e); }
+          },
+        }));
+      } catch (e) {
+        return [
+          { label: '⚡ Full Access', value: 'elevated', action: async () => { if (STATE.currentSessionId) { await apiRequest('PUT', '/sessions/' + STATE.currentSessionId + '/permissions', { mode: 'elevated' }); fetchAndUpdateMeta(STATE.currentSessionId); } } },
+          { label: '🔒 Restricted', value: 'restricted', action: async () => { if (STATE.currentSessionId) { await apiRequest('PUT', '/sessions/' + STATE.currentSessionId + '/permissions', { mode: 'restricted' }); fetchAndUpdateMeta(STATE.currentSessionId); } } },
+          { label: '🏖️ Sandboxed', value: 'sandboxed', action: async () => { if (STATE.currentSessionId) { await apiRequest('PUT', '/sessions/' + STATE.currentSessionId + '/permissions', { mode: 'sandboxed' }); fetchAndUpdateMeta(STATE.currentSessionId); } } },
+        ];
+      }
+    },
+  },
 };
 
 let _pillPopover = null;
@@ -375,19 +416,19 @@ function buildPopoverDOM(pillEl, label, options) {
     const item = document.createElement('button');
     item.className = 'pill-popover-item';
     item.innerHTML = opt.label;
-    if (!opt.cmd) { item.disabled = true; item.style.opacity = '0.5'; }
+    if (!opt.cmd && !opt.action) { item.disabled = true; item.style.opacity = '0.5'; }
     item.addEventListener('mousedown', e => {
       e.preventDefault();
-      if (!opt.cmd) return;
+      if (!opt.cmd && !opt.action) return;
       hidePillPopover();
-      sendCommand(opt.cmd);
+      if (opt.action) { opt.action(); } else { sendCommand(opt.cmd); }
     });
     item.addEventListener('click', e => {
       if (!isMobileViewport()) return;
       e.preventDefault();
-      if (!opt.cmd) return;
+      if (!opt.cmd && !opt.action) return;
       hidePillPopover();
-      sendCommand(opt.cmd);
+      if (opt.action) { opt.action(); } else { sendCommand(opt.cmd); }
     });
     popover.appendChild(item);
   });
@@ -2328,7 +2369,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // --- Meta pill popovers ---
-  ['meta-agent', 'meta-runtime', 'meta-model', 'meta-mode'].forEach(id => {
+  ['meta-agent', 'meta-runtime', 'meta-model', 'meta-mode', 'meta-permissions'].forEach(id => {
     $(id).addEventListener('click', e => { e.stopPropagation(); showPillPopover($(id), id); });
   });
   document.addEventListener('mousedown', e => {
@@ -5900,6 +5941,75 @@ if (document.readyState !== 'loading') {
         updateModeBadge(permModeEl.value);
         updatePermChangedIndicator();
       });
+    }
+  }
+
+
+  /* ── .env File Editor ──────────────────────────────────────────────────── */
+  const envEditor   = document.getElementById('asf-env-editor');
+  const btnEnvLoad  = document.getElementById('btn-env-load');
+  const btnEnvSave  = document.getElementById('btn-env-save');
+  const btnEnvRestart = document.getElementById('btn-env-restart');
+  const envStatus   = document.getElementById('asf-env-status');
+
+  function showEnvStatus(msg, isError) {
+    if (!envStatus) return;
+    envStatus.textContent = msg;
+    envStatus.className = 'asf-env-status' + (isError ? ' asf-env-error' : ' asf-env-ok');
+    envStatus.classList.remove('hidden');
+    setTimeout(() => envStatus.classList.add('hidden'), 5000);
+  }
+
+  async function loadEnvFile() {
+    if (!envEditor) return;
+    envEditor.value = 'Loading...';
+    try {
+      const data = await apiRequest('GET', '/settings/env');
+      envEditor.value = data.content || '';
+      if (!data.exists) showEnvStatus('No .env file found — a new one will be created on save.', false);
+    } catch (e) {
+      envEditor.value = '';
+      showEnvStatus('Failed to load .env: ' + e.message, true);
+    }
+  }
+
+  async function saveEnvFile() {
+    if (!envEditor) return;
+    try {
+      const data = await apiRequest('PUT', '/settings/env', { content: envEditor.value });
+      showEnvStatus('✓ .env saved. ' + (data.warning || ''), false);
+    } catch (e) {
+      showEnvStatus('Failed to save: ' + e.message, true);
+    }
+  }
+
+  async function restartDevServices() {
+    if (!confirm('Restart all dev services? The API will briefly disconnect.')) return;
+    showEnvStatus('Restarting services...', false);
+    try {
+      const data = await apiRequest('POST', '/settings/restart-services');
+      const summary = Object.entries(data.results || {}).map(([s, r]) => s.replace('.service', '') + ': ' + r).join('\n');
+      showEnvStatus('✓ ' + summary, false);
+    } catch (e) {
+      showEnvStatus('Restart request sent. API may reconnect shortly.', false);
+    }
+  }
+
+  if (btnEnvLoad)    btnEnvLoad.addEventListener('click', loadEnvFile);
+  if (btnEnvSave)    btnEnvSave.addEventListener('click', saveEnvFile);
+  if (btnEnvRestart) btnEnvRestart.addEventListener('click', restartDevServices);
+
+  // Auto-load .env when settings panel opens
+  const _origOpenSettings = typeof openSettings === 'function' ? openSettings : null;
+  if (_origOpenSettings) {
+    // Monkey-patch openSettings to also load .env
+    const _wrappedOpen = async function() {
+      await _origOpenSettings();
+      loadEnvFile();
+    };
+    if (btnSettings) {
+      btnSettings.removeEventListener('click', openSettings);
+      btnSettings.addEventListener('click', _wrappedOpen);
     }
   }
 

--- a/webui/dist/index.html
+++ b/webui/dist/index.html
@@ -108,6 +108,7 @@
           <span id="meta-runtime" class="meta-pill meta-runtime" title="Runtime">—</span>
           <span id="meta-model"   class="meta-pill meta-model"   title="Model">—</span>
           <span id="meta-mode"    class="meta-pill meta-mode"    title="Mode">restricted</span>
+          <span id="meta-permissions" class="meta-pill meta-permissions" title="Permissions">🔒 restricted</span>
 <button id="btn-nav-notifications" class="meta-pill meta-alerts" title="Alerts">🔔<span id="notif-badge" class="nav-badge notif-badge-red hidden">0</span></button>
         </div>
       </header>
@@ -549,6 +550,22 @@
           </details>
 
         </div><!-- /Permissions -->
+
+
+        <!-- .env File Editor -->
+        <div class="asf-section">
+          <div class="asf-section-title">🔧 Environment Configuration (.env)</div>
+          <div class="asf-env-editor-wrap">
+            <div class="asf-env-toolbar">
+              <button id="btn-env-load" class="btn btn-ghost btn-xs">📥 Load</button>
+              <button id="btn-env-save" class="btn btn-primary btn-xs">💾 Save .env</button>
+              <button id="btn-env-restart" class="btn btn-ghost btn-xs asf-btn-restart" title="Restart all dev services">🔄 Restart Services</button>
+            </div>
+            <textarea id="asf-env-editor" class="glass-input asf-env-textarea" rows="12" placeholder="# Loading .env file..." spellcheck="false"></textarea>
+            <div id="asf-env-status" class="asf-env-status hidden"></div>
+            <p class="asf-env-warning">⚠️ Changes to .env require a service restart to take effect.</p>
+          </div>
+        </div>
 
         <!-- Danger Zone -->
         <div class="asf-section asf-danger-section">


### PR DESCRIPTION
## Summary

- **Agent permissions system** — default + session-level permission overrides, stored in agents.json and session state
- **Permissions dropdown in WebUI** — session settings panel lets users override permission level per session
- **.env editor in Settings** — view and edit the Wee Orchestrator .env file from the WebUI with restart button
- **Mobile responsive improvements** — comprehensive mobile layout fixes across the WebUI
- **Tool call display fixes** — tool calls rendered inside chat bubble on new lines, not as separate rows; interleaved tool call blocks with spinner
- **Devin runtime tool visibility** — fixed tool call visibility for Devin runtime in WebUI
- **Credential redaction** — sensitive credentials redacted from tool_call UI display

## Test plan

- [ ] Verify permissions dropdown appears in session settings
- [ ] Verify session-level permission override persists for session duration
- [ ] Verify .env editor loads current file and saves changes
- [ ] Verify mobile layout on small screens
- [ ] Verify tool calls render correctly in chat bubbles
- [ ] Verify Devin runtime shows tool calls in WebUI
- [ ] Verify no credentials visible in tool_call display

🤖 Generated with [Claude Code](https://claude.com/claude-code)