### PR TITLE
fix(webex): never requeue messages on exception to prevent duplicate processing

### DIFF
--- a/webex_connector.py
+++ b/webex_connector.py
@@ -1313,19 +1313,33 @@ class WebEXConnector:
                 """Handle message from queue"""
                 try:
                     message_data = json.loads(body.decode())
+                except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                    # Malformed message - discard immediately, never requeue
+                    print(f"[ERROR] Discarding malformed RabbitMQ message (bad JSON): {e}", file=sys.stderr)
+                    ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                    return
+
+                try:
                     print(f"[DEBUG] Received WebEX message: {message_data}", file=sys.stderr)
-                    
+
                     # Fix 1: Support configurable payload unwrapping for gateway wrappers
                     payload_key = self.config.config.get("rabbitmq_payload_key")
                     if payload_key and payload_key in message_data and isinstance(message_data[payload_key], dict):
                         message_data = message_data[payload_key]
                         print(f"[DEBUG] Unwrapped payload from key '{payload_key}'", file=sys.stderr)
-                    
+
                     self.handle_message(message_data)
+                    # Ack only after successful processing
                     ch.basic_ack(delivery_tag=method.delivery_tag)
                 except Exception as e:
-                    print(f"Error processing queue message: {e}", file=sys.stderr)
-                    ch.basic_nack(delivery_tag=method.delivery_tag)
+                    import traceback
+                    tb_str = traceback.format_exc()
+                    print("[ERROR] Unexpected exception in callback (discarding, not requeueing):", file=sys.stderr)
+                    print(tb_str, file=sys.stderr)
+                    # Always requeue=False — requeueing causes duplicate processing and infinite failure loops.
+                    # handle_message() handles its own errors internally; if we reach here something
+                    # truly unexpected happened. The message cannot be safely retried.
+                    ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
 
             if not self.connect_rabbitmq():
                 print("Failed to connect to RabbitMQ, exiting...", file=sys.stderr)


### PR DESCRIPTION
## Problem
`basic_nack()` defaults to `requeue=True`, causing WebEx messages to be re-enqueued and processed multiple times whenever any exception occurs in the RabbitMQ callback.

## Fix
- **JSON decode errors** → `nack(requeue=False)` immediately — malformed messages can never succeed, requeueing just spams the queue
- **All other callback exceptions** → `nack(requeue=False)` with full traceback logged
- Added inline comment explaining why `requeue=True` is always wrong here

## Why requeue=False is always correct here
`handle_message()` already wraps its entire body in try/except and handles all errors internally (sends error message to WebEx room). It should never raise to the callback. If something unexpected does bubble up, retrying will just cause an infinite failure loop — not a successful recovery.

## Changes
- `webex_connector.py` — split callback into 2 try/except blocks, both nack with `requeue=False`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>