### PR TITLE
fix: ack RabbitMQ messages immediately to prevent stuck queue

### DIFF
--- a/webex_connector.py
+++ b/webex_connector.py
@@ -1310,36 +1310,34 @@ class WebEXConnector:
 
         try:
             def callback(ch, method, properties, body):
-                """Handle message from queue"""
+                """Handle message from queue - ack immediately to prevent stuck messages"""
+                # ACK immediately upon receipt to prevent stuck/unacked messages in RabbitMQ.
+                # All failures after this point are logged but the message is already removed
+                # from the queue, eliminating infinite retry loops and queue buildup.
+                ch.basic_ack(delivery_tag=method.delivery_tag)
+
                 try:
                     message_data = json.loads(body.decode())
                 except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                    # Malformed message - discard immediately, never requeue
                     print(f"[ERROR] Discarding malformed RabbitMQ message (bad JSON): {e}", file=sys.stderr)
-                    ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                    print(f"[ERROR] Raw body (first 500 chars): {body[:500]}", file=sys.stderr)
                     return
 
                 try:
                     print(f"[DEBUG] Received WebEX message: {message_data}", file=sys.stderr)
 
-                    # Fix 1: Support configurable payload unwrapping for gateway wrappers
+                    # Support configurable payload unwrapping for gateway wrappers
                     payload_key = self.config.config.get("rabbitmq_payload_key")
                     if payload_key and payload_key in message_data and isinstance(message_data[payload_key], dict):
                         message_data = message_data[payload_key]
                         print(f"[DEBUG] Unwrapped payload from key '{payload_key}'", file=sys.stderr)
 
                     self.handle_message(message_data)
-                    # Ack only after successful processing
-                    ch.basic_ack(delivery_tag=method.delivery_tag)
                 except Exception as e:
                     import traceback
                     tb_str = traceback.format_exc()
-                    print("[ERROR] Unexpected exception in callback (discarding, not requeueing):", file=sys.stderr)
+                    print("[ERROR] Exception processing WebEX message (message already acked, discarding):", file=sys.stderr)
                     print(tb_str, file=sys.stderr)
-                    # Always requeue=False — requeueing causes duplicate processing and infinite failure loops.
-                    # handle_message() handles its own errors internally; if we reach here something
-                    # truly unexpected happened. The message cannot be safely retried.
-                    ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
 
             if not self.connect_rabbitmq():
                 print("Failed to connect to RabbitMQ, exiting...", file=sys.stderr)


### PR DESCRIPTION
## Summary

Changes WebEx connector RabbitMQ callback to **ack messages immediately upon receipt** instead of after processing. Prevents stuck/unacked messages in RabbitMQ.

## Problem

When message processing failed (malformed JSON, agent dispatch error, timeout), the error-path `basic_nack(requeue=False)` was the only way to clear the message. If an unexpected exception bypassed the nack, messages could get stuck in an unacked state, blocking the queue.

## Solution

- **ACK first**: `ch.basic_ack()` is now the first line in the callback, before JSON parsing
- **No nacks**: All `basic_nack()` calls removed — messages are never requeued
- **Log everything**: JSON decode errors log raw body (first 500 chars), exceptions log full tracebacks
- **Fail safely**: After ack, any error simply logs and returns

## Test Results

```
🧪 5/5 tests passed:
✅ Valid message: acked immediately, no nacks, handler called
✅ Malformed JSON: acked immediately, no nacks, handler NOT called
✅ Handler exception: acked immediately, no nacks, error logged
✅ Unicode decode error: acked immediately, no nacks
✅ Source verification: no nacks, ack before JSON parse
```

## Changes

| File | Changes |
|------|---------|
| `webex_connector.py` | 9 insertions, 11 deletions |
