### PR TITLE
feat: F004 — Live Status Updates for Mobile Channels

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -2593,10 +2593,9 @@ class SessionManager:
         return "restricted"
 
     def strip_metadata(self, text: str, runtime: str) -> str:
-        # Strip [STATUS_UPDATE: ...] markers (F004 — mobile channel progress)
-        import re as _re_sm
-        text = _re_sm.sub(r"\[STATUS_UPDATE[:\s]*[^\]]*\]\s*\n?", "", text)
         """Remove CLI metadata from output"""
+        # Strip [STATUS_UPDATE: ...] markers (F004 — mobile channel progress)
+        text = re.sub(r"\[STATUS_UPDATE[:\s]*[^\]]*\]\s*\n?", "", text)
         # First, strip thinking tags from the raw output
         text = self.strip_thinking_tags(text)
 
@@ -4498,8 +4497,7 @@ User Request:
                                     _su_match = None
                                     try:
                                         _su_line = line if isinstance(line, str) else line.decode("utf-8", errors="replace")
-                                        import re as _re_su
-                                        _su_match = _re_su.search(
+                                        _su_match = re.search(
                                             r"\[STATUS_UPDATE[:\s]*(.+?)\]", _su_line
                                         )
                                     except Exception:
@@ -4545,10 +4543,9 @@ User Request:
                 # Read stdout line-by-line instead of communicate() so we can
                 # capture [STATUS_UPDATE: ...] markers in real-time for mobile
                 # channel progress updates.
-                import re as _re_bl
                 import threading as _thr_bl
 
-                _status_pattern = _re_bl.compile(
+                _status_pattern = re.compile(
                     r"\[STATUS_UPDATE[:\s]*(.+?)\]"
                 )
                 _stderr_buf_bl: list = []

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1331,6 +1331,31 @@ class SessionManager:
         # Last subprocess exit code per n8n_session_id (for debugging/monitoring)
         self._last_exit_codes: Dict[str, int] = {}
 
+        # Per-session live status for mobile channel progress updates (F004).
+        # Maps n8n_session_id -> {"text": str, "updated_at": float}
+        self._live_status: Dict[str, Dict] = {}
+        self._live_status_lock = threading.Lock()
+
+    # ── Live status helpers for mobile channel progress (F004) ──────────
+
+    def set_live_status(self, n8n_session_id: str, text: str) -> None:
+        """Store a live status update for a session (thread-safe)."""
+        with self._live_status_lock:
+            self._live_status[n8n_session_id] = {
+                "text": text,
+                "updated_at": time.time(),
+            }
+
+    def get_live_status(self, n8n_session_id: str) -> Optional[Dict]:
+        """Return the latest live status for a session, or None."""
+        with self._live_status_lock:
+            return self._live_status.get(n8n_session_id)
+
+    def clear_live_status(self, n8n_session_id: str) -> None:
+        """Remove live status for a session (call when execution finishes)."""
+        with self._live_status_lock:
+            self._live_status.pop(n8n_session_id, None)
+
     def _load_agents_config(self, config_file: Optional[str] = None) -> Dict:
         """Load agents configuration from JSON file
 
@@ -2568,6 +2593,9 @@ class SessionManager:
         return "restricted"
 
     def strip_metadata(self, text: str, runtime: str) -> str:
+        # Strip [STATUS_UPDATE: ...] markers (F004 — mobile channel progress)
+        import re as _re_sm
+        text = _re_sm.sub(r"\[STATUS_UPDATE[:\s]*[^\]]*\]\s*\n?", "", text)
         """Remove CLI metadata from output"""
         # First, strip thinking tags from the raw output
         text = self.strip_thinking_tags(text)
@@ -3594,6 +3622,29 @@ Example: python3 {SCRIPT_BASE_DIR}/agent_manager.py --agent research-dev --runti
                 file=sys.stderr,
             )
 
+        # Mobile channel context: instruct LLM to emit periodic status updates
+        mobile_channel_instruction = ""
+        if channel in ("telegram", "webex"):
+            mobile_channel_instruction = f"""
+[Mobile Channel: {channel}]
+You are communicating through {channel} (a mobile messaging app). Your responses are delivered
+via message editing in {channel}. During long-running operations (installing packages, running
+tests, scanning networks, deploying services, or any task taking more than ~15 seconds),
+periodically output a status line in this exact format:
+
+[STATUS_UPDATE: Brief description of current step]
+
+Examples:
+[STATUS_UPDATE: Installing Python dependencies...]
+[STATUS_UPDATE: Running 357 unit tests...]
+[STATUS_UPDATE: Scanning subnet 192.168.1.0/24...]
+[STATUS_UPDATE: Deploying service to dev host...]
+
+These lines are intercepted and shown to the user as live progress indicators in {channel},
+replacing the generic "Still working on it..." placeholder. Emit one every ~30 seconds during
+long tasks. Your final answer must NOT contain these markers — they are stripped automatically.
+Do NOT emit status updates for quick operations (< 15 seconds)."""
+
         # Channel-specific injected context files
         injection_dir = Path(
             os.environ.get("INJECTION_DIR", Path(SCRIPT_BASE_DIR) / "injections")
@@ -3608,7 +3659,7 @@ Example: python3 {SCRIPT_BASE_DIR}/agent_manager.py --agent research-dev --runti
             injection_text = ""
 
         context = f"""{handoff_prefix}[Session ID: {n8n_session_id}]
-{runtime_instruction}{injection_text}{agent_desc}{files_context}{render_instruction}{bg_task_instruction}{canvas_instruction}{timeout_instruction}
+{runtime_instruction}{injection_text}{mobile_channel_instruction}{agent_desc}{files_context}{render_instruction}{bg_task_instruction}{canvas_instruction}{timeout_instruction}
 
 User Request:
 {prompt}"""
@@ -4443,16 +4494,32 @@ User Request:
                                         )
 
                                 else:
-                                    # Only push as text chunk when NOT a tool call line
-                                    if stream_buffer:
-                                        stream_buffer.push("chunk", line)
-                                    else:
-                                        loop.call_soon_threadsafe(
-                                            queue.put_nowait, ("chunk", line)
+                                    # Detect [STATUS_UPDATE: ...] markers (F004)
+                                    _su_match = None
+                                    try:
+                                        _su_line = line if isinstance(line, str) else line.decode("utf-8", errors="replace")
+                                        import re as _re_su
+                                        _su_match = _re_su.search(
+                                            r"\[STATUS_UPDATE[:\s]*(.+?)\]", _su_line
                                         )
+                                    except Exception:
+                                        pass
+                                    if _su_match:
+                                        self.set_live_status(
+                                            n8n_session_id, _su_match.group(1).strip()
+                                        )
+                                    else:
+                                        # Only push as text chunk when NOT a tool call/status line
+                                        if stream_buffer:
+                                            stream_buffer.push("chunk", line)
+                                        else:
+                                            loop.call_soon_threadsafe(
+                                                queue.put_nowait, ("chunk", line)
+                                            )
                     except Exception:
                         pass
                     finally:
+                        self.clear_live_status(n8n_session_id)
                         process.stdout.close()
                         stderr_thread.join(timeout=5)
                         process.wait()
@@ -4474,23 +4541,68 @@ User Request:
                 return output
 
             else:
-                # ── Original blocking path ───────────────────────────────────
+                # ── Blocking path with live status capture (F004) ────────────
+                # Read stdout line-by-line instead of communicate() so we can
+                # capture [STATUS_UPDATE: ...] markers in real-time for mobile
+                # channel progress updates.
+                import re as _re_bl
+                import threading as _thr_bl
+
+                _status_pattern = _re_bl.compile(
+                    r"\[STATUS_UPDATE[:\s]*(.+?)\]"
+                )
+                _stderr_buf_bl: list = []
+
+                def _drain_stderr_bl():
+                    try:
+                        for _err_ln in process.stderr:
+                            _stderr_buf_bl.append(_err_ln)
+                    except Exception:
+                        pass
+
+                _stderr_t = _thr_bl.Thread(
+                    target=_drain_stderr_bl, daemon=True
+                )
+                _stderr_t.start()
+
+                _stdout_lines_bl: list = []
                 try:
-                    stdout, stderr = process.communicate(timeout=timeout)
-                    output = stdout + (stderr if stderr else "")
+                    for _line_bl in process.stdout:
+                        _stdout_lines_bl.append(_line_bl)
+                        _su_m = _status_pattern.search(_line_bl)
+                        if _su_m:
+                            self.set_live_status(
+                                n8n_session_id, _su_m.group(1).strip()
+                            )
+
+                    # Wait for process to fully exit
+                    try:
+                        process.wait(timeout=timeout)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait()
+                        self.clear_live_status(n8n_session_id)
+                        timeout_min = timeout / 60
+                        return f"Error: Command timed out (exceeded {timeout}s / {timeout_min:.1f}min)"
+                    finally:
+                        _stderr_t.join(timeout=5)
+
+                    output = "".join(_stdout_lines_bl) + "".join(
+                        _stderr_buf_bl
+                    )
+                    # Strip STATUS_UPDATE markers from final output
+                    output = _re_bl.sub(
+                        r"\[STATUS_UPDATE[:\s]*[^\]]*\]\s*\n?", "", output
+                    )
                     self.update_query_output(n8n_session_id, output)
-                    # Record exit code for debugging subprocess errors.
-                    # rate-limit detection on successful AI responses.
                     self._last_exit_codes[n8n_session_id] = (
-                        process.returncode if process.returncode is not None else 0
+                        process.returncode
+                        if process.returncode is not None
+                        else 0
                     )
                     return output
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait()
-                    timeout_min = timeout / 60
-                    return f"Error: Command timed out (exceeded {timeout}s / {timeout_min:.1f}min)"
                 finally:
+                    self.clear_live_status(n8n_session_id)
                     self.clear_running_query(n8n_session_id)
 
         except Exception as e:
@@ -7777,6 +7889,33 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
         return result
 
+    @app.get("/api/v1/sessions/{session_id}/live-status")
+    async def get_live_status(session_id: str, request: Request):
+        """Return the latest live status update for a running session (F004).
+
+        Mobile channel connectors poll this endpoint to replace static
+        "Still working on it..." messages with real LLM progress updates.
+        Requires only bearer token auth (no user identity needed).
+        """
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="Missing auth")
+        token = auth_header[7:]
+        # Accept shared key (used by connectors) or session token
+        if token.startswith("shared_"):
+            if not auth_mgr.validate_shared_key(token):
+                raise HTTPException(status_code=401, detail="Invalid auth")
+        elif not auth_mgr.validate_token(token):
+            raise HTTPException(status_code=401, detail="Invalid auth")
+
+        status = session_mgr.get_live_status(session_id)
+        if status:
+            return {
+                "status": status["text"],
+                "updated_at": status["updated_at"],
+            }
+        return {"status": None, "updated_at": None}
+
     @app.post("/api/v1/sessions/{session_id}/cancel")
     async def cancel_session(session_id: str, request: Request):
         """Cancel a running query for a session.
@@ -8791,6 +8930,15 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 if line_text:
                     bg_task_mgr.append_output(task_id, line_text)
 
+                # Capture [STATUS_UPDATE: ...] markers for mobile channel progress (F004)
+                _su_bg_match = _re.search(
+                    r"\[STATUS_UPDATE[:\s]*(.+?)\]", line_text
+                )
+                if _su_bg_match:
+                    session_mgr.set_live_status(
+                        n8n_session_id, _su_bg_match.group(1).strip()
+                    )
+
                 # ── Structured JSON parsing for stream-json runtimes ──
                 # Gemini (stream-json) emits {"type":"tool_use",...} and {"type":"tool_result",...}
                 # Claude (stream-json) emits nested stream_event objects with tool_use blocks
@@ -8880,6 +9028,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 )
                 if not final_output.strip():
                     final_output = output or "Task completed successfully"
+                session_mgr.clear_live_status(n8n_session_id)
                 bg_task_mgr.complete_task(task_id, final_output)
                 if task_id.startswith("sched_"):
                     try:

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -4588,7 +4588,7 @@ User Request:
                         _stderr_buf_bl
                     )
                     # Strip STATUS_UPDATE markers from final output
-                    output = _re_bl.sub(
+                    output = re.sub(
                         r"\[STATUS_UPDATE[:\s]*[^\]]*\]\s*\n?", "", output
                     )
                     self.update_query_output(n8n_session_id, output)

--- a/telegram_connector.py
+++ b/telegram_connector.py
@@ -1369,6 +1369,27 @@ class TelegramConnector:
 
         return result_container["response"] or "Error: Command timed out"
 
+    def _poll_live_status(self, session_id: str) -> Optional[str]:
+        """Poll the live-status endpoint for real-time LLM progress (F004).
+
+        Returns the latest status text, or None if no live status is available.
+        """
+        try:
+            headers = {
+                "Authorization": f"Bearer shared_{self.api_shared_key}",
+            }
+            resp = requests.get(
+                f"{self.api_url_copilot}/api/v1/sessions/{session_id}/live-status",
+                headers=headers,
+                timeout=3,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("status")
+        except Exception:
+            pass
+        return None
+
     def _query_agent_with_status(
         self,
         query: str,
@@ -1378,7 +1399,10 @@ class TelegramConnector:
         chat_id: int,
         timeout: int = 300,
     ) -> tuple:
-        """Query agent with status updates at 30s intervals.
+        """Query agent with live status updates at 30s intervals.
+
+        Polls the live-status API endpoint for LLM-generated progress updates
+        (F004). Falls back to static messages if no live status is available.
 
         Returns (response_text, status_msg_id) where status_msg_id is the
         message to edit with the final response, or None if no status was sent.
@@ -1386,7 +1410,13 @@ class TelegramConnector:
         # Container for result and thread control
         result_container = {"response": None, "done": False}
 
-        # Status messages
+        # Determine session ID for live-status polling
+        if self.bot_id:
+            _poll_session_id = f"telegram_{self.bot_id}_{user_id}"
+        else:
+            _poll_session_id = f"telegram_{user_id}"
+
+        # Fallback static status messages (used when no live status from LLM)
         status_msgs = [
             "Still working on it...",
             "Sorry it's taking so long, still working on it...",
@@ -1397,7 +1427,6 @@ class TelegramConnector:
 
         def run_query():
             """Run query in background thread"""
-            # Log what's being sent
             print(f"[DEBUG] Query to agent: {query[:200]}", file=sys.stderr)
             result_container["response"] = self._query_agent(
                 query, agent, model, user_id, timeout
@@ -1411,26 +1440,34 @@ class TelegramConnector:
         # Wait for result with status updates
         elapsed = 0
         status_idx = 0
-        status_msg_id = None  # Track the status message to edit it
+        status_msg_id = None
+        _last_live_status = None  # Track last live status to avoid redundant edits
         while not result_container["done"] and elapsed < timeout:
             # Re-send typing every 5 seconds to keep indicator alive
             if elapsed % 5 == 0:
                 self.send_typing(chat_id)
 
-            if elapsed == 30:
-                # First status at 30s - send new message
-                status_msg_id = self.send_message(chat_id, status_msgs[0])
-                self.send_typing(chat_id)
-                status_idx = 1
-            elif elapsed > 30 and (elapsed - 30) % 30 == 0:
-                # Edit existing status message
-                msg = status_msgs[status_idx % len(status_msgs)]
-                if status_msg_id:
-                    self.edit_message(chat_id, status_msg_id, msg)
+            if elapsed >= 30 and (elapsed - 30) % 10 == 0:
+                # Poll live-status endpoint for LLM-generated progress
+                live_status = self._poll_live_status(_poll_session_id)
+
+                if live_status and live_status != _last_live_status:
+                    # Use LLM-generated status update
+                    msg = f"⚙️ {live_status}"
+                    _last_live_status = live_status
+                elif elapsed == 30 or (elapsed > 30 and (elapsed - 30) % 30 == 0):
+                    # Fall back to static message on 30s boundaries
+                    msg = status_msgs[status_idx % len(status_msgs)]
+                    status_idx += 1
                 else:
-                    status_msg_id = self.send_message(chat_id, msg)
-                self.send_typing(chat_id)
-                status_idx += 1
+                    msg = None
+
+                if msg:
+                    if status_msg_id:
+                        self.edit_message(chat_id, status_msg_id, msg)
+                    else:
+                        status_msg_id = self.send_message(chat_id, msg)
+                    self.send_typing(chat_id)
 
             time.sleep(1)
             elapsed += 1

--- a/tests/test_live_status.py
+++ b/tests/test_live_status.py
@@ -2,8 +2,8 @@
 
 import os
 import sys
-import time
 import threading
+import time
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/test_live_status.py
+++ b/tests/test_live_status.py
@@ -1,0 +1,220 @@
+"""Tests for F004: Live status updates for mobile channels."""
+
+import os
+import sys
+import time
+import threading
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ["API_SHARED_KEY"] = "test_key_123"
+os.environ["APP_ENV"] = "DEV"
+os.environ["API_PORT"] = "8099"
+
+
+class TestLiveStatusStore(unittest.TestCase):
+    """Test SessionManager live status dict operations."""
+
+    @classmethod
+    def setUpClass(cls):
+        import agent_manager
+
+        cls.agent_manager = agent_manager
+
+    def _make_session_mgr(self):
+        mgr = self.agent_manager.SessionManager.__new__(
+            self.agent_manager.SessionManager
+        )
+        mgr._live_status = {}
+        mgr._live_status_lock = threading.Lock()
+        return mgr
+
+    def test_set_and_get_live_status(self):
+        """set_live_status stores a value retrievable by get_live_status."""
+        mgr = self._make_session_mgr()
+        mgr.set_live_status("sess1", "Installing deps")
+        result = mgr.get_live_status("sess1")
+        self.assertEqual(result["text"], "Installing deps")
+        self.assertIn("updated_at", result)
+
+    def test_get_live_status_missing(self):
+        """get_live_status returns None for unknown session."""
+        mgr = self._make_session_mgr()
+        self.assertIsNone(mgr.get_live_status("nonexistent"))
+
+    def test_clear_live_status(self):
+        """clear_live_status removes the entry."""
+        mgr = self._make_session_mgr()
+        mgr.set_live_status("sess1", "Working")
+        mgr.clear_live_status("sess1")
+        self.assertIsNone(mgr.get_live_status("sess1"))
+
+    def test_clear_live_status_noop_on_missing(self):
+        """clear_live_status does not raise for missing session."""
+        mgr = self._make_session_mgr()
+        mgr.clear_live_status("nonexistent")  # Should not raise
+
+    def test_set_live_status_overwrites(self):
+        """set_live_status overwrites previous value."""
+        mgr = self._make_session_mgr()
+        mgr.set_live_status("sess1", "Step 1")
+        mgr.set_live_status("sess1", "Step 2")
+        result = mgr.get_live_status("sess1")
+        self.assertEqual(result["text"], "Step 2")
+
+
+class TestLiveStatusEndpoint(unittest.TestCase):
+    """Test the GET /api/v1/sessions/{id}/live-status endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        cls._telegram_patch = patch.object(
+            agent_manager,
+            "_resolve_telegram_identity",
+            side_effect=lambda identity: identity,
+        )
+        cls._telegram_patch.start()
+        cls.app = agent_manager.create_api_app()
+        cls.client = TestClient(cls.app)
+        cls.shared_header = {"Authorization": "Bearer shared_test_key_123"}
+        cls.agent_manager = agent_manager
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._telegram_patch.stop()
+
+    def test_live_status_no_status(self):
+        """Endpoint returns null status when no live status set."""
+        resp = self.client.get(
+            "/api/v1/sessions/test_sess_no_status/live-status",
+            headers=self.shared_header,
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIsNone(data["status"])
+        self.assertIsNone(data["updated_at"])
+
+    def test_live_status_requires_auth(self):
+        """Endpoint requires bearer auth."""
+        resp = self.client.get("/api/v1/sessions/test_sess/live-status")
+        self.assertIn(resp.status_code, [401, 403])
+
+    def test_live_status_rejects_bad_key(self):
+        """Endpoint rejects invalid shared key."""
+        resp = self.client.get(
+            "/api/v1/sessions/test_sess/live-status",
+            headers={"Authorization": "Bearer shared_wrong_key"},
+        )
+        self.assertEqual(resp.status_code, 401)
+
+
+class TestStatusUpdateStripping(unittest.TestCase):
+    """Test that STATUS_UPDATE markers are stripped from output."""
+
+    @classmethod
+    def setUpClass(cls):
+        import agent_manager
+
+        cls.agent_manager = agent_manager
+
+    def test_strip_status_update_from_output(self):
+        """strip_metadata removes STATUS_UPDATE markers."""
+        mgr = self.agent_manager.SessionManager.__new__(
+            self.agent_manager.SessionManager
+        )
+        text = "Hello\n[STATUS_UPDATE: Installing deps]\nWorld\n[STATUS_UPDATE: Running tests]\nDone"
+        result = mgr.strip_metadata(text, "copilot")
+        self.assertNotIn("[STATUS_UPDATE", result)
+        self.assertIn("Hello", result)
+        self.assertIn("Done", result)
+
+    def test_strip_status_update_empty_content(self):
+        """strip_metadata handles content that is only STATUS_UPDATE lines."""
+        mgr = self.agent_manager.SessionManager.__new__(
+            self.agent_manager.SessionManager
+        )
+        text = "[STATUS_UPDATE: Working]\n[STATUS_UPDATE: Done]"
+        result = mgr.strip_metadata(text, "copilot")
+        self.assertNotIn("[STATUS_UPDATE", result)
+
+
+class TestStatusUpdateRegex(unittest.TestCase):
+    """Test STATUS_UPDATE regex pattern matching."""
+
+    def test_status_update_capture(self):
+        """Regex captures the status text from STATUS_UPDATE markers."""
+        import re
+
+        pattern = re.compile(r"\[STATUS_UPDATE[:\s]*(.+?)\]")
+        line = "Some output [STATUS_UPDATE: Installing dependencies] more text"
+        m = pattern.search(line)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1).strip(), "Installing dependencies")
+
+    def test_status_update_strip(self):
+        """Regex strips STATUS_UPDATE markers from text."""
+        import re
+
+        pattern = re.compile(r"\[STATUS_UPDATE[:\s]*[^\]]*\]\s*\n?")
+        text = "Hello\n[STATUS_UPDATE: Working]\nWorld"
+        result = pattern.sub("", text)
+        self.assertNotIn("[STATUS_UPDATE", result)
+        self.assertIn("Hello", result)
+        self.assertIn("World", result)
+
+    def test_status_update_no_match_on_similar(self):
+        """Regex does not match on similar but different patterns."""
+        import re
+
+        pattern = re.compile(r"\[STATUS_UPDATE[:\s]*(.+?)\]")
+        self.assertIsNone(pattern.search("[STATUS: Working]"))
+        self.assertIsNone(pattern.search("[UPDATE: Working]"))
+        self.assertIsNotNone(pattern.search("[STATUS_UPDATE: Working]"))
+
+
+class TestMobileChannelDetection(unittest.TestCase):
+    """Test channel detection logic used for mobile context injection."""
+
+    def test_telegram_session_detected(self):
+        """Telegram session IDs are correctly detected."""
+        sid = "telegram_123_456"
+        if sid.startswith("telegram_"):
+            channel = "telegram"
+        elif sid.startswith("webex_"):
+            channel = "webex"
+        else:
+            channel = "webui"
+        self.assertEqual(channel, "telegram")
+
+    def test_webex_session_detected(self):
+        """WebEx session IDs are correctly detected."""
+        sid = "webex_abc123"
+        if sid.startswith("telegram_"):
+            channel = "telegram"
+        elif sid.startswith("webex_"):
+            channel = "webex"
+        else:
+            channel = "webui"
+        self.assertEqual(channel, "webex")
+
+    def test_webui_session_no_injection(self):
+        """WebUI sessions should not get mobile context."""
+        sid = "abcdef-1234"
+        if sid.startswith("telegram_"):
+            channel = "telegram"
+        elif sid.startswith("webex_"):
+            channel = "webex"
+        else:
+            channel = "webui"
+        self.assertEqual(channel, "webui")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webex_connector.py
+++ b/webex_connector.py
@@ -1495,6 +1495,27 @@ class WebEXConnector:
         cmd_thread.join(timeout=5)
         return result_container["response"] or "Error: Command timed out"
 
+    def _poll_live_status(self, session_id: str) -> Optional[str]:
+        """Poll the live-status endpoint for real-time LLM progress (F004).
+
+        Returns the latest status text, or None if no live status is available.
+        """
+        try:
+            headers = {
+                "Authorization": f"Bearer shared_{self.api_shared_key}",
+            }
+            resp = requests.get(
+                f"{self.api_url}/api/v1/sessions/{session_id}/live-status",
+                headers=headers,
+                timeout=3,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("status")
+        except Exception:
+            pass
+        return None
+
     def _query_agent_with_status(
         self,
         query: str,
@@ -1504,13 +1525,20 @@ class WebEXConnector:
         room_id: str,
         timeout: int = 300,
     ) -> tuple:
-        """Query agent with status updates at 30s intervals.
+        """Query agent with live status updates at 30s intervals.
+
+        Polls the live-status API endpoint for LLM-generated progress updates
+        (F004). Falls back to static messages if no live status is available.
 
         Returns (response_text, status_msg_id) where status_msg_id tracks
         the status message for potential editing with the final response.
         """
         result_container = {"response": None, "done": False}
 
+        # Determine session ID for live-status polling
+        _poll_session_id = f"webex_{person_id}"
+
+        # Fallback static status messages (used when no live status from LLM)
         status_msgs = [
             "Still working on it...",
             "Sorry it's taking so long, still working on it...",
@@ -1531,26 +1559,34 @@ class WebEXConnector:
 
         elapsed = 0
         status_idx = 0
-        status_msg_id = None  # Track the status message
+        status_msg_id = None
+        _last_live_status = None  # Track last live status to avoid redundant edits
         while not result_container["done"] and elapsed < timeout:
             # Send typing indicator every 5 seconds to keep it alive
             if elapsed % 5 == 0:
                 self.send_typing(room_id)
 
-            if elapsed == 30:
-                # First status at 30s - send new message
-                status_msg_id = self.send_message(room_id, status_msgs[0])
-                self.send_typing(room_id)
-                status_idx = 1
-            elif elapsed > 30 and (elapsed - 30) % 30 == 0:
-                # Edit status message every 30s with new message
-                msg = status_msgs[status_idx % len(status_msgs)]
-                if status_msg_id:
-                    self.edit_message(status_msg_id, room_id, msg)
+            if elapsed >= 30 and (elapsed - 30) % 10 == 0:
+                # Poll live-status endpoint for LLM-generated progress
+                live_status = self._poll_live_status(_poll_session_id)
+
+                if live_status and live_status != _last_live_status:
+                    # Use LLM-generated status update
+                    msg = f"⚙️ {live_status}"
+                    _last_live_status = live_status
+                elif elapsed == 30 or (elapsed > 30 and (elapsed - 30) % 30 == 0):
+                    # Fall back to static message on 30s boundaries
+                    msg = status_msgs[status_idx % len(status_msgs)]
+                    status_idx += 1
                 else:
-                    status_msg_id = self.send_message(room_id, msg)
-                self.send_typing(room_id)
-                status_idx += 1
+                    msg = None
+
+                if msg:
+                    if status_msg_id:
+                        self.edit_message(status_msg_id, room_id, msg)
+                    else:
+                        status_msg_id = self.send_message(room_id, msg)
+                    self.send_typing(room_id)
 
             time.sleep(1)
             elapsed += 1


### PR DESCRIPTION
## F004 — Live Status Updates for Mobile Channels

### Summary
Injects mobile channel context into agent prompts so that live status/progress updates are routed correctly to Telegram and WebEx channels.

### Commits
- `b537716` feat: F004 — inject mobile channel context for live status updates
- `27eff10` fix: F004 QA fixes — restore docstring, remove redundant re imports
- `fba3951` fix: F004 QA re-review — replace _re_bl.sub with re.sub, fix isort in test file

### QA Verdict: ✅ APPROVE
**QA Agent:** wee-qa  
**Reviewed:** fba3951 on dev branch

| Check | Result |
|-------|--------|
| py_compile | ✅ PASS |
| pytest | ✅ 409 passed / 9 skipped |
| flake8 F821 (NameError BLOCKER) | ✅ Clean |
| isort (MINOR) | ✅ PASS |

### Issues Resolved
- **BLOCKER:** `_re_bl.sub` → `re.sub` (NameError) — fixed in fba3951
- **MINOR:** isort formatting in `test_live_status.py` — fixed in fba3951

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>