### PR TITLE
Deploy: streaming + tool calls for copilot-sdk & claude-sdk (#86, #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Issue #87] Feature: Streaming + Tool Call Support for copilot-sdk and claude-sdk
-**Status:** 🔄 In QA Review
+**Status:** ✅ QA Approved (Commit: 001015e)
 
 ### Summary
 Added real-time streaming response delivery and tool call event tracking for both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Issue #86] Bug Fix: claude-sdk Runtime Stalls on 2nd Turn
-**Status:** ✅ Fixed (pending QA)
+**Status:** ✅ QA Approved (commit 4785965 on dev)
 
 ### Root Cause
 Multi-turn conversations used `ClaudeSDKClient.receive_messages()` — an **infinite** async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [Issue #87] Feature: Streaming + Tool Call Support for copilot-sdk and claude-sdk
+**Status:** 🔄 In QA Review
+
+### Summary
+Added real-time streaming response delivery and tool call event tracking for both
+`copilot-sdk` and `claude-sdk` runtimes, achieving feature parity with CLI-based
+runtimes for WebUI SSE consumers.
+
+### Changes
+
+#### copilot-sdk (`run_copilot_sdk`)
+- **Streaming:** `on_event` callback now handles `ASSISTANT_STREAMING_DELTA` and
+  `ASSISTANT_MESSAGE_DELTA` events, pushing text chunks to `_StreamBuffer` in real-time
+- **Tool calls:** `TOOL_EXECUTION_START`, `TOOL_EXECUTION_COMPLETE`, and `COMMAND_EXECUTE`
+  events generate standardized tool_call events with id, name, input, runtime, timestamp
+- **Done sentinel:** Pushed on all exit paths (success, error, session failure)
+- **Graceful fallback:** Uses `getattr(self, "_stream_buffers", {})` for test compatibility
+
+#### claude-sdk (`run_claude_sdk`)
+- **Streaming:** `TextBlock` content pushed as chunks during async iteration over `query()`
+- **Tool calls:** `ToolUseBlock` emits "detected" events with block.id/name/input;
+  `ToolResultBlock` emits "completed" events with tool_use_id and is_error flag
+- **Done sentinel:** Pushed on all exit paths including SDK exceptions
+- **New imports:** `ToolUseBlock`, `ToolResultBlock` from `claude_agent_sdk`
+
+#### Tool Event Format (both runtimes)
+```json
+{
+  "event": "detected|started|completed",
+  "id": "tc_<runtime>_N or block.id",
+  "name": "tool_name",
+  "input": "truncated_input (max 200 chars)",
+  "runtime": "copilot-sdk|claude-sdk",
+  "timestamp": "ISO 8601 UTC"
+}
+```
+
+### Tests
+- **18 new tests** in `tests/test_sdk_streaming_tools.py`:
+  - `TestCopilotSdkStreaming` (4 tests): streaming deltas, done sentinel, error paths, no-buffer
+  - `TestCopilotSdkToolCalls` (3 tests): tool start, command execute, start+complete lifecycle
+  - `TestClaudeSdkStreaming` (4 tests): text chunks, done sentinel, error, no-buffer
+  - `TestClaudeSdkToolCalls` (5 tests): ToolUseBlock, ToolResultBlock, error flag, multiple tools, session ID
+  - `TestToolEventStructure` (2 tests): required field validation for both runtimes
+- **47 existing SDK tests pass** (test_copilot_sdk_runtime.py + test_claude_sdk_runtime.py)
+- **1056 total tests pass**, 9 skipped, 0 failures
+
+
 ## [Issue #86] Bug Fix: claude-sdk Runtime Stalls on 2nd Turn
 **Status:** ✅ QA Approved (commit 4785965 on dev)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [Issue #86] Bug Fix: claude-sdk Runtime Stalls on 2nd Turn
+**Status:** ✅ Fixed (pending QA)
+
+### Root Cause
+Multi-turn conversations used `ClaudeSDKClient.receive_messages()` — an **infinite** async
+generator designed for interactive bidirectional sessions. It never terminates after a single
+response, causing the 2nd turn to hang indefinitely. The `ClaudeSDKClient` was also spawning
+a new subprocess per turn without loading prior conversation context.
+
+### Fix
+Unified both first-turn and multi-turn code paths to use the stateless `query()` function
+from `claude_agent_sdk`. For multi-turn, `options.resume` is set to the session ID, which
+passes `--resume <session_id>` to the CLI subprocess, loading prior conversation context
+and completing naturally when the response finishes.
+
+### Changes
+- **agent_manager.py:**
+  - Removed `ClaudeSDKClient` import (no longer needed)
+  - Replaced dual-path logic (ClaudeSDKClient vs query()) with unified `claude_sdk_query()` path
+  - Multi-turn sets `options.resume = session_id` for proper session resumption
+- **tests/test_claude_sdk_runtime.py:**
+  - Removed `_FakeClaudeSDKClient` mock class (no longer needed)
+  - Updated `TestSessionResumption` to verify `options.resume` is set correctly
+  - Added 3 new Issue #86 regression tests:
+    - `test_multiturn_uses_query_with_resume` — verifies query() path with resume option
+    - `test_multiturn_completes_without_stall` — verifies 2nd turn returns output
+    - `test_multiturn_stores_session_id_from_result` — verifies session_id stored on resume
+    - `test_resume_false_with_session_id_starts_new` — verifies resume=False ignores session_id
+  - Total: 28 tests (up from 24), all passing
+
+### Testing
+- 28/28 claude-sdk tests pass
+- 1038/1038 full regression tests pass, 9 skipped, 0 failures
+
+
 ## [Issue #84] Bug Fix: Remove Non-Functional Auto Runtime
 **Status:** ✅ Fixed (commit 266bee9 on dev)
 

--- a/README.md
+++ b/README.md
@@ -545,17 +545,20 @@ All AI runtimes in this system are configured with **full tool access** to enabl
   - `elevated` → `bypassPermissions` (full access, no prompts)
   - `sandboxed` → `plan` (read-only + approval for writes)
   - `restricted` → `default` (standard safety checks)
+- **Streaming:** Real-time text chunks pushed to WebUI SSE consumers via `_StreamBuffer`
+- **Tool Calls:** `ToolUseBlock`/`ToolResultBlock` detection emits standardized tool_call events
 - **Usage:** `/runtime set claude-agent-sdk`
-- **Issue:** [#77](../../issues/77)
+- **Issues:** [#77](../../issues/77), [#87](../../issues/87)
 
 #### GitHub Copilot SDK (Python)
 - **Package:** `github-copilot-sdk>=0.1.0` (install via `pip install github-copilot-sdk`)
 - **Enables:**
   - In-process async execution via `CopilotClient`
-  - Streaming via `ASSISTANT_MESSAGE` event handlers
+  - Real-time streaming via `ASSISTANT_STREAMING_DELTA`/`ASSISTANT_MESSAGE_DELTA` events
+  - Tool call tracking via `TOOL_EXECUTION_START`/`COMPLETE` and `COMMAND_EXECUTE` events
   - Session resumption and structured error handling
 - **Usage:** `/runtime set copilot-sdk`
-- **Issue:** [#76](../../issues/76)
+- **Issues:** [#76](../../issues/76), [#87](../../issues/87)
 
 ### Security Considerations
 

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -6392,6 +6392,9 @@ User Request:
         Uses the github-copilot-sdk package for direct API integration.
         Benefits over CLI: persistent client, ~100ms startup, streaming
         events, structured error handling, custom tool support.
+
+        Supports real-time streaming to WebUI SSE consumers and tool call
+        tracking for background task progress (Issue #87).
         """
         try:
             from copilot import CopilotClient
@@ -6419,6 +6422,10 @@ User Request:
         agent_dir = self.AGENTS.get(agent, self.AGENTS["orchestrator"])["path"]
         effective_timeout = timeout if timeout is not None else self.command_timeout
         channel = session_data.get("channel", "webui")
+
+        # Streaming infrastructure — push chunks to SSE consumers in real-time
+        stream_buffer = getattr(self, "_stream_buffers", {}).get(n8n_session_id)
+        _tool_call_counter = [0]
 
         # Build context prompt
         if resume and session_id:
@@ -6457,11 +6464,82 @@ User Request:
             collected_messages: list = []
 
             async with CopilotClient() as client:
-                # Event handler to collect assistant messages
+                # Event handler — streams chunks and detects tool calls
                 def on_event(event):
-                    if event.type == SessionEventType.ASSISTANT_MESSAGE:
+                    # ── Streaming deltas ──
+                    if event.type in (
+                        SessionEventType.ASSISTANT_STREAMING_DELTA,
+                        SessionEventType.ASSISTANT_MESSAGE_DELTA,
+                    ):
+                        delta_text = None
+                        if hasattr(event, "data"):
+                            if isinstance(event.data, str):
+                                delta_text = event.data
+                            elif hasattr(event.data, "content"):
+                                delta_text = str(event.data.content)
+                            elif hasattr(event.data, "delta"):
+                                delta_text = str(event.data.delta)
+                            elif hasattr(event.data, "text"):
+                                delta_text = str(event.data.text)
+                        if delta_text and stream_buffer:
+                            stream_buffer.push("chunk", delta_text)
+
+                    # ── Full assistant message ──
+                    elif event.type == SessionEventType.ASSISTANT_MESSAGE:
                         if hasattr(event, "data") and hasattr(event.data, "content"):
                             collected_messages.append(str(event.data.content))
+
+                    # ── Tool execution tracking ──
+                    elif event.type == SessionEventType.TOOL_EXECUTION_START:
+                        _tool_call_counter[0] += 1
+                        tool_name = "tool"
+                        tool_input = ""
+                        if hasattr(event, "data"):
+                            tool_name = getattr(event.data, "name", None) or getattr(event.data, "tool_name", None) or "tool"
+                            tool_input = str(getattr(event.data, "input", "") or getattr(event.data, "arguments", "") or "")
+                        tc_evt = {
+                            "event": "started",
+                            "id": f"tc_copilot-sdk_{_tool_call_counter[0]}",
+                            "name": str(tool_name),
+                            "input": tool_input[:200],
+                            "runtime": "copilot-sdk",
+                            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                        }
+                        if stream_buffer:
+                            stream_buffer.push("tool_call", tc_evt)
+
+                    elif event.type == SessionEventType.TOOL_EXECUTION_COMPLETE:
+                        tool_name = "tool"
+                        if hasattr(event, "data"):
+                            tool_name = getattr(event.data, "name", None) or getattr(event.data, "tool_name", None) or "tool"
+                        tc_evt = {
+                            "event": "completed",
+                            "id": f"tc_copilot-sdk_{_tool_call_counter[0]}",
+                            "name": str(tool_name),
+                            "input": "",
+                            "runtime": "copilot-sdk",
+                            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                        }
+                        if stream_buffer:
+                            stream_buffer.push("tool_call", tc_evt)
+
+                    elif event.type == SessionEventType.COMMAND_EXECUTE:
+                        _tool_call_counter[0] += 1
+                        cmd_text = ""
+                        if hasattr(event, "data"):
+                            cmd_text = str(getattr(event.data, "command", "") or getattr(event.data, "text", "") or event.data)
+                        tc_evt = {
+                            "event": "detected",
+                            "id": f"tc_copilot-sdk_{_tool_call_counter[0]}",
+                            "name": "shell",
+                            "input": cmd_text[:200],
+                            "runtime": "copilot-sdk",
+                            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                        }
+                        if stream_buffer:
+                            stream_buffer.push("tool_call", tc_evt)
+
+                    # ── Errors ──
                     elif event.type == SessionEventType.SESSION_ERROR:
                         if hasattr(event, "data"):
                             err_msg = str(getattr(event.data, "message", event.data))
@@ -6495,6 +6573,8 @@ User Request:
                         )
                         session = await client.create_session(**session_kwargs)
                 except Exception as sess_err:
+                    if stream_buffer:
+                        stream_buffer.push("done", "")
                     return f"Error (Copilot SDK session): {type(sess_err).__name__}: {sess_err}"
 
                 try:
@@ -6513,11 +6593,17 @@ User Request:
                     # Extract response from result event
                     if result_event and hasattr(result_event, "data"):
                         if hasattr(result_event.data, "content"):
-                            return str(result_event.data.content)
+                            result_text = str(result_event.data.content)
+                            if stream_buffer:
+                                stream_buffer.push("done", result_text)
+                            return result_text
 
                     # Fall back to collected messages from event handler
                     if collected_messages:
-                        return "\n".join(collected_messages)
+                        result_text = "\n".join(collected_messages)
+                        if stream_buffer:
+                            stream_buffer.push("done", result_text)
+                        return result_text
 
                     # Fall back to full message history
                     messages = session.get_messages()
@@ -6529,8 +6615,13 @@ User Request:
                     if assistant_msgs:
                         last = assistant_msgs[-1]
                         if hasattr(last, "data") and hasattr(last.data, "content"):
-                            return str(last.data.content)
+                            result_text = str(last.data.content)
+                            if stream_buffer:
+                                stream_buffer.push("done", result_text)
+                            return result_text
 
+                    if stream_buffer:
+                        stream_buffer.push("done", "")
                     return ""
                 finally:
                     try:
@@ -6542,6 +6633,8 @@ User Request:
             output = asyncio.run(_run_sdk())
         except Exception as e:
             print(f"[SDK] Error: {type(e).__name__}: {e}", file=sys.stderr)
+            if stream_buffer:
+                stream_buffer.push("done", "")
             return f"Error (Copilot SDK): {type(e).__name__}: {e}"
 
         return self.strip_metadata(output, "copilot-sdk")
@@ -6564,6 +6657,9 @@ User Request:
         Benefits over CLI: in-process custom tools, subagents, session
         forking, streaming events, structured error handling.
 
+        Supports real-time streaming to WebUI SSE consumers and tool call
+        tracking via ToolUseBlock/ToolResultBlock detection (Issue #87).
+
         Requires Claude Pro, Team, or Enterprise subscription.
         User must run `claude login` to authenticate first.
         """
@@ -6574,6 +6670,8 @@ User Request:
                 AssistantMessage,
                 TextBlock,
                 ResultMessage,
+                ToolUseBlock,
+                ToolResultBlock,
             )
         except ImportError:
             return (
@@ -6600,6 +6698,10 @@ User Request:
         effective_timeout = timeout if timeout is not None else self.command_timeout
 
         channel = session_data.get("channel", "api")
+
+        # Streaming infrastructure — push chunks to SSE consumers in real-time
+        stream_buffer = getattr(self, "_stream_buffers", {}).get(n8n_session_id)
+        _tool_call_counter = [0]
 
         # Build context prompt
         sdk_session_id = session_id if resume and session_id else None
@@ -6671,6 +6773,32 @@ User Request:
                         for block in message.content:
                             if isinstance(block, TextBlock):
                                 collected_text.append(block.text)
+                                if stream_buffer:
+                                    stream_buffer.push("chunk", block.text)
+                            elif isinstance(block, ToolUseBlock):
+                                _tool_call_counter[0] += 1
+                                tc_evt = {
+                                    "event": "detected",
+                                    "id": block.id or f"tc_claude-sdk_{_tool_call_counter[0]}",
+                                    "name": block.name or "tool",
+                                    "input": str(block.input)[:200] if block.input else "",
+                                    "runtime": "claude-sdk",
+                                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                                }
+                                if stream_buffer:
+                                    stream_buffer.push("tool_call", tc_evt)
+                            elif isinstance(block, ToolResultBlock):
+                                tc_evt = {
+                                    "event": "completed",
+                                    "id": block.tool_use_id or f"tc_claude-sdk_{_tool_call_counter[0]}",
+                                    "name": "tool",
+                                    "input": str(block.content)[:200] if block.content else "",
+                                    "is_error": getattr(block, "is_error", False),
+                                    "runtime": "claude-sdk",
+                                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                                }
+                                if stream_buffer:
+                                    stream_buffer.push("tool_call", tc_evt)
                     elif isinstance(message, ResultMessage):
                         if message.session_id:
                             self.update_session_field(n8n_session_id, "session_id", message.session_id)
@@ -6678,10 +6806,14 @@ User Request:
                         for block in getattr(message, "content", []):
                             if hasattr(block, "text"):
                                 collected_text.append(block.text)
+                                if stream_buffer:
+                                    stream_buffer.push("chunk", block.text)
 
             except Exception as e:
                 error_type = type(e).__name__
                 error_msg = str(e).lower()
+                if stream_buffer:
+                    stream_buffer.push("done", "")
                 if "clinotfound" in error_type.lower():
                     return (
                         "Error: Claude Code CLI not found. "
@@ -6700,6 +6832,8 @@ User Request:
                     return f"Error (Claude Agent SDK): {error_type}: {e}"
 
             output = "\n".join(collected_text)
+            if stream_buffer:
+                stream_buffer.push("done", output)
             if not output.strip():
                 return "Error: No response received from Claude Agent SDK"
             return output
@@ -6720,12 +6854,16 @@ User Request:
             else:
                 output = asyncio.run(_run_sdk())
         except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
+            if stream_buffer:
+                stream_buffer.push("done", "")
             return f"Error: Claude Agent SDK timed out after {effective_timeout}s"
         except Exception as e:
             print(
                 f"[Claude-Agent-SDK] Error: {type(e).__name__}: {e}",
                 file=sys.stderr,
             )
+            if stream_buffer:
+                stream_buffer.push("done", "")
             return f"Error (Claude Agent SDK): {type(e).__name__}: {e}"
 
         return self.strip_metadata(output, "claude")

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -6574,7 +6574,6 @@ User Request:
                 AssistantMessage,
                 TextBlock,
                 ResultMessage,
-                ClaudeSDKClient,
             )
         except ImportError:
             return (
@@ -6653,44 +6652,32 @@ User Request:
             if model:
                 options.model = model
 
+            # For multi-turn, use options.resume to continue the existing
+            # session.  The stateless query() function spawns a subprocess
+            # with --resume <id> which loads prior conversation context.
+            # Previous implementation used ClaudeSDKClient.receive_messages()
+            # which is an infinite async generator designed for interactive
+            # use — it never terminates after a single response, causing the
+            # 2nd-turn stall described in Issue #86.
+            if sdk_session_id:
+                options.resume = sdk_session_id
+
             try:
-                if sdk_session_id:
-                    # Multi-turn conversation: use ClaudeSDKClient for state management
-                    client = ClaudeSDKClient(options=options)
-                    async with client:
-                        await client.query(
-                            prompt=context_prompt,
-                            session_id=sdk_session_id,
-                        )
-                        async for message in client.receive_messages():
-                            if isinstance(message, AssistantMessage):
-                                for block in message.content:
-                                    if isinstance(block, TextBlock):
-                                        collected_text.append(block.text)
-                            elif isinstance(message, ResultMessage):
-                                if message.session_id:
-                                    self.update_session_field(n8n_session_id, "session_id", message.session_id)
-                            elif hasattr(message, "content"):
-                                for block in getattr(message, "content", []):
-                                    if hasattr(block, "text"):
-                                        collected_text.append(block.text)
-                else:
-                    # One-shot query: use stateless query() function
-                    async for message in claude_sdk_query(
-                        prompt=context_prompt,
-                        options=options,
-                    ):
-                        if isinstance(message, AssistantMessage):
-                            for block in message.content:
-                                if isinstance(block, TextBlock):
-                                    collected_text.append(block.text)
-                        elif isinstance(message, ResultMessage):
-                            if message.session_id:
-                                self.update_session_field(n8n_session_id, "session_id", message.session_id)
-                        elif hasattr(message, "content"):
-                            for block in getattr(message, "content", []):
-                                if hasattr(block, "text"):
-                                    collected_text.append(block.text)
+                async for message in claude_sdk_query(
+                    prompt=context_prompt,
+                    options=options,
+                ):
+                    if isinstance(message, AssistantMessage):
+                        for block in message.content:
+                            if isinstance(block, TextBlock):
+                                collected_text.append(block.text)
+                    elif isinstance(message, ResultMessage):
+                        if message.session_id:
+                            self.update_session_field(n8n_session_id, "session_id", message.session_id)
+                    elif hasattr(message, "content"):
+                        for block in getattr(message, "content", []):
+                            if hasattr(block, "text"):
+                                collected_text.append(block.text)
 
             except Exception as e:
                 error_type = type(e).__name__

--- a/tests/test_claude_sdk_runtime.py
+++ b/tests/test_claude_sdk_runtime.py
@@ -1,10 +1,11 @@
-"""Tests for Claude Agent SDK runtime integration (Issue #77).
+"""Tests for Claude Agent SDK runtime integration (Issue #77, #86).
 
 Tests cover:
 - Import handling (missing package)
 - Mode parsing (elevated, sandboxed, restricted)
 - Permission mode mapping (bypassPermissions, plan, default)
-- Session resumption
+- Session resumption via options.resume (Issue #86 fix)
+- Multi-turn conversation handling
 - Streaming message collection
 - Error handling (CLINotFound, CLIConnection, ProcessError, generic)
 - Runtime registration across all integration points
@@ -39,31 +40,6 @@ _ClaudeAgentOptions = type("ClaudeAgentOptions", (), {
 })
 
 
-class _FakeClaudeSDKClient:
-    """Fake ClaudeSDKClient for testing."""
-    _captured = {}  # Class variable for capturing across instances
-    
-    def __init__(self, options=None):
-        self.options = options
-        self._query_fn = None
-    
-    async def __aenter__(self):
-        return self
-    
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        pass
-    
-    async def query(self, prompt, session_id=None):
-        # Capture for test inspection
-        _FakeClaudeSDKClient._captured["prompt"] = prompt
-        _FakeClaudeSDKClient._captured["session_id"] = session_id
-        _FakeClaudeSDKClient._captured["options_permission_mode"] = getattr(self.options, "permission_mode", None)
-    
-    async def receive_messages(self):
-        return
-        yield
-
-
 def _build_fake_module(query_fn=None):
     """Build a fake claude_agent_sdk module."""
     mod = types.ModuleType("claude_agent_sdk")
@@ -74,7 +50,6 @@ def _build_fake_module(query_fn=None):
 
     mod.query = query_fn or _default_query
     mod.ClaudeAgentOptions = _ClaudeAgentOptions
-    mod.ClaudeSDKClient = _FakeClaudeSDKClient
     mod.AssistantMessage = _AssistantMessage
     mod.TextBlock = _TextBlock
     mod.ResultMessage = _ResultMessage
@@ -245,7 +220,7 @@ class TestErrorHandling(unittest.TestCase):
 
         async def error_query(prompt, options=None):
             raise error_cls(error_msg)
-            yield  # noqa: unreachable — needed for async generator
+            yield  # noqa: unreachable -- needed for async generator
 
         fake_mod = _build_fake_module(error_query)
         with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
@@ -278,32 +253,37 @@ class TestErrorHandling(unittest.TestCase):
 
 
 class TestSessionResumption(unittest.TestCase):
-    """Test session resumption behavior."""
+    """Test session resumption behavior (Issue #86 fix)."""
 
-    def test_resume_sets_session_id(self):
+    def test_resume_sets_options_resume(self):
+        """Resuming a session should set options.resume to the session_id."""
         mgr = _make_manager()
-        
-        fake_mod = _build_fake_module()
+        captured = {}
+
+        async def cap_query(prompt, options=None):
+            captured["resume"] = getattr(options, "resume", None)
+            captured["prompt"] = prompt
+            return
+            yield
+
+        fake_mod = _build_fake_module(cap_query)
         with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
-            # Reset captured data
-            _FakeClaudeSDKClient._captured = {}
-            
             mgr.run_claude_sdk(
-                "test", "haiku", "orchestrator",
+                "test prompt", "haiku", "orchestrator",
                 "existing-sess-123", True, "sess1",
             )
 
-        # When resuming, ClaudeSDKClient.query() should be called with session_id
-        self.assertEqual(_FakeClaudeSDKClient._captured.get("session_id"), "existing-sess-123")
-        # Resuming should use raw prompt
-        self.assertEqual(_FakeClaudeSDKClient._captured.get("prompt"), "test prompt")
+        # options.resume should be set to the session_id for --resume flag
+        self.assertEqual(captured["resume"], "existing-sess-123")
+        # Resuming should use raw prompt (not full context)
+        self.assertEqual(captured["prompt"], "test prompt")
 
     def test_no_resume_uses_full_context(self):
         mgr = _make_manager()
         captured = {}
 
         async def cap_query(prompt, options=None):
-            captured["session_id"] = getattr(options, "session_id", None)
+            captured["resume"] = getattr(options, "resume", None)
             captured["prompt"] = prompt
             return
             yield
@@ -315,7 +295,7 @@ class TestSessionResumption(unittest.TestCase):
                 None, False, "sess1",
             )
 
-        self.assertIsNone(captured["session_id"])
+        self.assertIsNone(captured["resume"])
         self.assertEqual(captured["prompt"], "[context] test prompt")
 
     def test_model_passed_to_options(self):
@@ -334,7 +314,6 @@ class TestSessionResumption(unittest.TestCase):
             )
 
         self.assertEqual(captured["model"], "opus")
-
 
     def test_result_message_stores_session_id(self):
         """ResultMessage with session_id must call update_session_field."""
@@ -357,26 +336,90 @@ class TestSessionResumption(unittest.TestCase):
         )
         self.assertIn("response text", result)
 
-    def test_multiturn_uses_clausdesdk_client(self):
-        """Verify multi-turn conversations use ClaudeSDKClient for state management."""
+    def test_multiturn_uses_query_with_resume(self):
+        """Issue #86: multi-turn must use query() with options.resume, not ClaudeSDKClient."""
         mgr = _make_manager()
-        
-        fake_mod = _build_fake_module()
+        captured = {}
+
+        async def cap_query(prompt, options=None):
+            captured["resume"] = getattr(options, "resume", None)
+            captured["permission_mode"] = getattr(options, "permission_mode", None)
+            captured["cwd"] = getattr(options, "cwd", None)
+            yield _AssistantMessage([_TextBlock("turn-2 response")])
+            yield _ResultMessage(session_id="session-abc-123")
+
+        fake_mod = _build_fake_module(cap_query)
         with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
-            # Reset captured data
-            _FakeClaudeSDKClient._captured = {}
-            
-            # Call with resume=True and session_id set (simulating multi-turn)
-            mgr.run_claude_sdk(
+            result = mgr.run_claude_sdk(
                 "Follow-up question", "haiku", "orchestrator",
                 "session-abc-123", True, "sess1",
             )
 
-        # Verify ClaudeSDKClient was used (not module-level query)
-        # When resuming, the session_id should be passed to client.query()
-        self.assertEqual(_FakeClaudeSDKClient._captured.get("session_id"), "session-abc-123")
-        # Verify that client received a prompt (exact content depends on mocks)
-        self.assertIsNotNone(_FakeClaudeSDKClient._captured.get("prompt"))
+        # Verify query() was used with options.resume set
+        self.assertEqual(captured["resume"], "session-abc-123")
+        # Verify response was collected (the core bug fix -- previously stalled)
+        self.assertIn("turn-2 response", result)
+
+    def test_multiturn_completes_without_stall(self):
+        """Issue #86: 2nd turn must complete and return output, not hang."""
+        mgr = _make_manager()
+
+        async def mock_query(prompt, options=None):
+            yield _AssistantMessage([_TextBlock("second turn output")])
+            yield _ResultMessage(session_id="updated-session")
+
+        fake_mod = _build_fake_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "follow-up", "haiku", "orchestrator",
+                "prev-session-id", True, "sess1",
+            )
+
+        self.assertIn("second turn output", result)
+        self.assertNotIn("Error", result)
+        mgr.update_session_field.assert_called_once_with(
+            "sess1", "session_id", "updated-session"
+        )
+
+    def test_multiturn_stores_session_id_from_result(self):
+        """Issue #86: session_id from ResultMessage must be stored on resume path."""
+        mgr = _make_manager()
+
+        async def mock_query(prompt, options=None):
+            yield _AssistantMessage([_TextBlock("ok")])
+            yield _ResultMessage(session_id="new-session-from-turn-2")
+
+        fake_mod = _build_fake_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator",
+                "old-session-id", True, "sess1",
+            )
+
+        mgr.update_session_field.assert_called_once_with(
+            "sess1", "session_id", "new-session-from-turn-2"
+        )
+
+    def test_resume_false_with_session_id_starts_new(self):
+        """When resume=False even with a session_id, should start fresh (no resume)."""
+        mgr = _make_manager()
+        captured = {}
+
+        async def cap_query(prompt, options=None):
+            captured["resume"] = getattr(options, "resume", None)
+            return
+            yield
+
+        fake_mod = _build_fake_module(cap_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator",
+                "some-session-id", False, "sess1",
+            )
+
+        # resume=False should NOT set options.resume even if session_id is present
+        self.assertIsNone(captured["resume"])
+
 
 class TestRuntimeRegistration(unittest.TestCase):
     """Test that claude-sdk is registered in all integration points."""

--- a/tests/test_claude_sdk_runtime.py
+++ b/tests/test_claude_sdk_runtime.py
@@ -35,6 +35,17 @@ _ResultMessage = type("ResultMessage", (), {
     "__init__": lambda self, session_id="": setattr(self, "session_id", session_id),
 })
 
+_ToolUseBlock = type("ToolUseBlock", (), {
+    "__init__": lambda self, id="", name="", input=None: (
+        setattr(self, "id", id) or setattr(self, "name", name) or setattr(self, "input", input)
+    ),
+})
+_ToolResultBlock = type("ToolResultBlock", (), {
+    "__init__": lambda self, tool_use_id="", content=None, is_error=False: (
+        setattr(self, "tool_use_id", tool_use_id) or setattr(self, "content", content) or setattr(self, "is_error", is_error)
+    ),
+})
+
 _ClaudeAgentOptions = type("ClaudeAgentOptions", (), {
     "__init__": lambda self, **kw: self.__dict__.update(kw),
 })
@@ -53,6 +64,8 @@ def _build_fake_module(query_fn=None):
     mod.AssistantMessage = _AssistantMessage
     mod.TextBlock = _TextBlock
     mod.ResultMessage = _ResultMessage
+    mod.ToolUseBlock = _ToolUseBlock
+    mod.ToolResultBlock = _ToolResultBlock
     return mod
 
 

--- a/tests/test_sdk_streaming_tools.py
+++ b/tests/test_sdk_streaming_tools.py
@@ -1,0 +1,781 @@
+"""New tests for Issue #87 — streaming + tool calls for copilot-sdk and claude-sdk.
+
+Tests verify:
+- Streaming text chunks pushed to _stream_buffers (copilot-sdk + claude-sdk)
+- Tool call events (detected/started/completed) pushed to _stream_buffers
+- 'done' sentinel pushed on normal completion and errors
+- Graceful behavior when no stream buffer exists
+- Tool event structure validation (required fields)
+"""
+
+import asyncio
+import os
+import sys
+import time
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)) + "/..")
+os.environ.setdefault("API_SHARED_KEY", "test_key_123")
+
+
+# ─── Shared helpers ───
+
+def _make_stream_buffer():
+    """Create a mock stream buffer that records pushes."""
+    pushes = []
+    buf = MagicMock()
+    buf.push = MagicMock(side_effect=lambda kind, data: pushes.append((kind, data)))
+    return buf, pushes
+
+
+def _get_session_mgr():
+    """Create a minimal SessionManager for testing (same as existing test pattern)."""
+    from agent_manager import SessionManager
+    mgr = SessionManager.__new__(SessionManager)
+    mgr.mode = None
+    mgr.command_timeout = 300
+    mgr._session_map_lock = __import__("threading").Lock()
+    mgr.session_map_file = __import__("pathlib").Path("/tmp/_test_sdk_stream_map.json")
+    mgr.session_state_dir = __import__("pathlib").Path("/tmp/_test_sdk_stream_sessions")
+    mgr.session_state_dir.mkdir(parents=True, exist_ok=True)
+    mgr.copilot_bin = "/usr/local/bin/copilot"
+    mgr.AGENTS = {
+        "orchestrator": {
+            "path": "/opt/n8n-copilot-shim-dev",
+            "description": "Test",
+            "name": "orchestrator",
+        }
+    }
+    mgr.skill_repositories = []
+    mgr._bg_identity = None
+    if not mgr.session_map_file.exists():
+        mgr.session_map_file.write_text("{}")
+    return mgr
+
+
+# ═══════════════════════════════════════════════════════
+#  COPILOT-SDK Streaming + Tool Call Tests
+# ═══════════════════════════════════════════════════════
+
+class TestCopilotSdkStreaming(unittest.TestCase):
+    """Test copilot-sdk streaming chunks are pushed to stream buffer."""
+
+    @patch("copilot.CopilotClient")
+    def test_streaming_delta_pushes_chunks(self, mock_client_cls):
+        """Verify on_event streaming deltas push text chunks to stream buffer."""
+        mgr = _get_session_mgr()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        mock_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session.session_id = "sdk-sess-stream"
+        mock_session.disconnect = AsyncMock()
+        mock_session.get_messages = MagicMock(return_value=[])
+
+        captured_on_event = None
+
+        async def capture_create_session(**kwargs):
+            nonlocal captured_on_event
+            captured_on_event = kwargs.get("on_event")
+            return mock_session
+
+        mock_client.create_session = AsyncMock(side_effect=capture_create_session)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        # Import the real SessionEventType after patching
+        from copilot.session import SessionEventType
+
+        async def send_and_wait_with_events(prompt, timeout=300.0):
+            if captured_on_event:
+                # Fire streaming delta events
+                evt1 = MagicMock()
+                evt1.type = SessionEventType.ASSISTANT_STREAMING_DELTA
+                evt1.data = "Hello "
+                captured_on_event(evt1)
+
+                evt2 = MagicMock()
+                evt2.type = SessionEventType.ASSISTANT_STREAMING_DELTA
+                evt2.data = "World"
+                captured_on_event(evt2)
+
+            result_data = MagicMock()
+            result_data.content = "Hello World"
+            result_event = MagicMock()
+            result_event.data = result_data
+            return result_event
+
+        mock_session.send_and_wait = AsyncMock(side_effect=send_and_wait_with_events)
+
+        with patch.object(mgr, "build_agent_context_prompt", return_value="test prompt"):
+            result = mgr.run_copilot_sdk(
+                "test prompt", "gpt-5", "orchestrator", None, False, "sess1"
+            )
+
+        chunk_pushes = [(k, d) for k, d in pushes if k == "chunk"]
+        self.assertGreaterEqual(len(chunk_pushes), 2)
+        self.assertEqual(chunk_pushes[0][1], "Hello ")
+        self.assertEqual(chunk_pushes[1][1], "World")
+
+    @patch("copilot.CopilotClient")
+    def test_done_sentinel_pushed_on_completion(self, mock_client_cls):
+        """Verify 'done' sentinel is pushed when SDK completes."""
+        mgr = _get_session_mgr()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        mock_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session.session_id = "sdk-sess-done"
+        mock_session.disconnect = AsyncMock()
+        mock_session.get_messages = MagicMock(return_value=[])
+
+        mock_client.create_session = AsyncMock(return_value=mock_session)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result_data = MagicMock()
+        result_data.content = "done result"
+        result_event = MagicMock()
+        result_event.data = result_data
+        mock_session.send_and_wait = AsyncMock(return_value=result_event)
+
+        with patch.object(mgr, "build_agent_context_prompt", return_value="test"):
+            result = mgr.run_copilot_sdk(
+                "test", "gpt-5", "orchestrator", None, False, "sess1"
+            )
+
+        done_pushes = [(k, d) for k, d in pushes if k == "done"]
+        self.assertGreaterEqual(len(done_pushes), 1)
+
+    @patch("copilot.CopilotClient")
+    def test_no_crash_without_stream_buffer(self, mock_client_cls):
+        """Verify function works when no _stream_buffers exists."""
+        mgr = _get_session_mgr()
+        # No _stream_buffers set — uses getattr fallback
+
+        mock_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session.session_id = "sdk-sess-no-buf"
+        mock_session.disconnect = AsyncMock()
+        mock_session.get_messages = MagicMock(return_value=[])
+
+        mock_client.create_session = AsyncMock(return_value=mock_session)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result_data = MagicMock()
+        result_data.content = "response"
+        result_event = MagicMock()
+        result_event.data = result_data
+        mock_session.send_and_wait = AsyncMock(return_value=result_event)
+
+        with patch.object(mgr, "build_agent_context_prompt", return_value="test"):
+            result = mgr.run_copilot_sdk(
+                "test", "gpt-5", "orchestrator", None, False, "sess1"
+            )
+
+        self.assertIn("response", result)
+
+    @patch("copilot.CopilotClient")
+    def test_done_pushed_on_session_error(self, mock_client_cls):
+        """Verify 'done' sentinel pushed when session creation fails."""
+        mgr = _get_session_mgr()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        mock_client = AsyncMock()
+        mock_client.create_session = AsyncMock(
+            side_effect=ConnectionError("SDK not available")
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        with patch.object(mgr, "build_agent_context_prompt", return_value="test"):
+            result = mgr.run_copilot_sdk(
+                "test", "gpt-5", "orchestrator", None, False, "sess1"
+            )
+
+        self.assertIn("Error", result)
+        done_pushes = [(k, d) for k, d in pushes if k == "done"]
+        self.assertGreaterEqual(len(done_pushes), 1)
+
+
+class TestCopilotSdkToolCalls(unittest.TestCase):
+    """Test copilot-sdk tool call event tracking via on_event handler."""
+
+    @patch("copilot.CopilotClient")
+    def test_tool_execution_start_pushes_tool_call(self, mock_client_cls):
+        """Verify TOOL_EXECUTION_START fires tool_call push with 'started' event."""
+        mgr = _get_session_mgr()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        mock_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session.session_id = "sdk-tc-1"
+        mock_session.disconnect = AsyncMock()
+        mock_session.get_messages = MagicMock(return_value=[])
+
+        captured_on_event = None
+
+        async def capture_create_session(**kwargs):
+            nonlocal captured_on_event
+            captured_on_event = kwargs.get("on_event")
+            return mock_session
+
+        mock_client.create_session = AsyncMock(side_effect=capture_create_session)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        from copilot.session import SessionEventType
+
+        async def send_with_tool(prompt, timeout=300.0):
+            if captured_on_event:
+                tool_data = MagicMock()
+                tool_data.name = "read_file"
+                tool_data.tool_name = "read_file"
+                tool_data.input = "/tmp/test.txt"
+                tool_data.arguments = "/tmp/test.txt"
+
+                evt = MagicMock()
+                evt.type = SessionEventType.TOOL_EXECUTION_START
+                evt.data = tool_data
+                captured_on_event(evt)
+
+            result_data = MagicMock()
+            result_data.content = "done"
+            result_event = MagicMock()
+            result_event.data = result_data
+            return result_event
+
+        mock_session.send_and_wait = AsyncMock(side_effect=send_with_tool)
+
+        with patch.object(mgr, "build_agent_context_prompt", return_value="test"):
+            mgr.run_copilot_sdk("test", "gpt-5", "orchestrator", None, False, "sess1")
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertGreaterEqual(len(tool_pushes), 1)
+        tc = tool_pushes[0][1]
+        self.assertEqual(tc["event"], "started")
+        self.assertEqual(tc["name"], "read_file")
+        self.assertEqual(tc["runtime"], "copilot-sdk")
+        self.assertIn("id", tc)
+        self.assertIn("timestamp", tc)
+
+    @patch("copilot.CopilotClient")
+    def test_command_execute_pushes_shell_tool_call(self, mock_client_cls):
+        """Verify COMMAND_EXECUTE fires tool_call with 'shell' name."""
+        mgr = _get_session_mgr()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        mock_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session.session_id = "sdk-tc-cmd"
+        mock_session.disconnect = AsyncMock()
+        mock_session.get_messages = MagicMock(return_value=[])
+
+        captured_on_event = None
+
+        async def capture_create_session(**kwargs):
+            nonlocal captured_on_event
+            captured_on_event = kwargs.get("on_event")
+            return mock_session
+
+        mock_client.create_session = AsyncMock(side_effect=capture_create_session)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        from copilot.session import SessionEventType
+
+        async def send_with_cmd(prompt, timeout=300.0):
+            if captured_on_event:
+                cmd_data = MagicMock()
+                cmd_data.command = "ls -la /tmp"
+                cmd_data.text = "ls -la /tmp"
+
+                evt = MagicMock()
+                evt.type = SessionEventType.COMMAND_EXECUTE
+                evt.data = cmd_data
+                captured_on_event(evt)
+
+            result_data = MagicMock()
+            result_data.content = "done"
+            result_event = MagicMock()
+            result_event.data = result_data
+            return result_event
+
+        mock_session.send_and_wait = AsyncMock(side_effect=send_with_cmd)
+
+        with patch.object(mgr, "build_agent_context_prompt", return_value="test"):
+            mgr.run_copilot_sdk("test", "gpt-5", "orchestrator", None, False, "sess1")
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertGreaterEqual(len(tool_pushes), 1)
+        tc = tool_pushes[0][1]
+        self.assertEqual(tc["event"], "detected")
+        self.assertEqual(tc["name"], "shell")
+        self.assertIn("ls -la", tc["input"])
+
+    @patch("copilot.CopilotClient")
+    def test_tool_start_and_complete_sequence(self, mock_client_cls):
+        """Verify TOOL_EXECUTION_START + COMPLETE push started/completed pair."""
+        mgr = _get_session_mgr()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        mock_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session.session_id = "sdk-tc-seq"
+        mock_session.disconnect = AsyncMock()
+        mock_session.get_messages = MagicMock(return_value=[])
+
+        captured_on_event = None
+
+        async def capture_create_session(**kwargs):
+            nonlocal captured_on_event
+            captured_on_event = kwargs.get("on_event")
+            return mock_session
+
+        mock_client.create_session = AsyncMock(side_effect=capture_create_session)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        from copilot.session import SessionEventType
+
+        async def send_with_tool_lifecycle(prompt, timeout=300.0):
+            if captured_on_event:
+                start_data = MagicMock()
+                start_data.name = "edit_file"
+                start_data.tool_name = "edit_file"
+                start_data.input = "path=/tmp/x"
+                start_data.arguments = "path=/tmp/x"
+
+                start_evt = MagicMock()
+                start_evt.type = SessionEventType.TOOL_EXECUTION_START
+                start_evt.data = start_data
+                captured_on_event(start_evt)
+
+                end_data = MagicMock()
+                end_data.name = "edit_file"
+                end_data.tool_name = "edit_file"
+
+                end_evt = MagicMock()
+                end_evt.type = SessionEventType.TOOL_EXECUTION_COMPLETE
+                end_evt.data = end_data
+                captured_on_event(end_evt)
+
+            result_data = MagicMock()
+            result_data.content = "done"
+            result_event = MagicMock()
+            result_event.data = result_data
+            return result_event
+
+        mock_session.send_and_wait = AsyncMock(side_effect=send_with_tool_lifecycle)
+
+        with patch.object(mgr, "build_agent_context_prompt", return_value="test"):
+            mgr.run_copilot_sdk("test", "gpt-5", "orchestrator", None, False, "sess1")
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertEqual(len(tool_pushes), 2)
+        self.assertEqual(tool_pushes[0][1]["event"], "started")
+        self.assertEqual(tool_pushes[1][1]["event"], "completed")
+
+
+# ═══════════════════════════════════════════════════════
+#  CLAUDE-SDK Streaming + Tool Call Tests
+# ═══════════════════════════════════════════════════════
+
+# --- Fake claude_agent_sdk types ---
+
+_TextBlock = type("TextBlock", (), {
+    "__init__": lambda self, text="": setattr(self, "text", text),
+})
+_AssistantMessage = type("AssistantMessage", (), {
+    "__init__": lambda self, content=None: setattr(self, "content", content or []),
+})
+_ResultMessage = type("ResultMessage", (), {
+    "__init__": lambda self, session_id="": setattr(self, "session_id", session_id),
+})
+_ToolUseBlock = type("ToolUseBlock", (), {
+    "__init__": lambda self, id="", name="", input=None: (
+        setattr(self, "id", id) or setattr(self, "name", name) or setattr(self, "input", input)
+    ),
+})
+_ToolResultBlock = type("ToolResultBlock", (), {
+    "__init__": lambda self, tool_use_id="", content=None, is_error=False: (
+        setattr(self, "tool_use_id", tool_use_id) or setattr(self, "content", content) or setattr(self, "is_error", is_error)
+    ),
+})
+_ClaudeAgentOptions = type("ClaudeAgentOptions", (), {
+    "__init__": lambda self, **kw: self.__dict__.update(kw),
+})
+
+
+def _build_fake_claude_module(query_fn=None):
+    """Build a fake claude_agent_sdk module with all required exports."""
+    mod = types.ModuleType("claude_agent_sdk")
+
+    async def _default_query(prompt, options=None):
+        return
+        yield
+
+    mod.query = query_fn or _default_query
+    mod.ClaudeAgentOptions = _ClaudeAgentOptions
+    mod.AssistantMessage = _AssistantMessage
+    mod.TextBlock = _TextBlock
+    mod.ResultMessage = _ResultMessage
+    mod.ToolUseBlock = _ToolUseBlock
+    mod.ToolResultBlock = _ToolResultBlock
+    return mod
+
+
+def _make_claude_manager():
+    """Create a minimal SessionManager for claude-sdk testing."""
+    from agent_manager import SessionManager
+    mgr = SessionManager.__new__(SessionManager)
+    mgr.session_state_dir = MagicMock()
+    mgr.session_map_file = MagicMock()
+    mgr.session_map = {}
+    mgr._session_map_lock = MagicMock()
+    mgr.command_timeout = 300
+    mgr.mode = None
+    mgr.claude_bin = "/usr/bin/claude"
+    mgr.AGENTS = {
+        "orchestrator": {"path": "/opt/n8n-copilot-shim-dev", "name": "orchestrator"},
+    }
+    mgr.get_or_create_session_data = MagicMock(return_value={
+        "channel": "api",
+        "runtime": "claude-sdk",
+        "model": "haiku",
+        "session_id": None,
+        "mode": None,
+    })
+    mgr.build_agent_context_prompt = MagicMock(return_value="[context] test prompt")
+    mgr._parse_mode_command = MagicMock(return_value=("test prompt", None))
+    mgr._resolve_permission_mode = MagicMock(side_effect=lambda m, s: m)
+    mgr.strip_metadata = MagicMock(side_effect=lambda text, rt: text)
+    mgr.update_session_field = MagicMock()
+    mgr.touch_session = MagicMock()
+    return mgr
+
+
+class TestClaudeSdkStreaming(unittest.TestCase):
+    """Test claude-sdk streaming text chunks to stream buffer."""
+
+    def test_text_blocks_pushed_as_chunks(self):
+        """Verify TextBlock content is pushed as 'chunk' to stream buffer."""
+        mgr = _make_claude_manager()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        msg1 = _AssistantMessage([_TextBlock("Hello ")])
+        msg2 = _AssistantMessage([_TextBlock("World")])
+
+        async def mock_query(prompt, options=None):
+            for m in [msg1, msg2]:
+                yield m
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        chunk_pushes = [(k, d) for k, d in pushes if k == "chunk"]
+        self.assertGreaterEqual(len(chunk_pushes), 2)
+        self.assertEqual(chunk_pushes[0][1], "Hello ")
+        self.assertEqual(chunk_pushes[1][1], "World")
+
+    def test_done_sentinel_on_completion(self):
+        """Verify 'done' sentinel pushed after all messages collected."""
+        mgr = _make_claude_manager()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        msg = _AssistantMessage([_TextBlock("Result")])
+
+        async def mock_query(prompt, options=None):
+            yield msg
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        done_pushes = [(k, d) for k, d in pushes if k == "done"]
+        self.assertGreaterEqual(len(done_pushes), 1)
+        self.assertIn("Result", done_pushes[0][1])
+
+    def test_done_pushed_on_error(self):
+        """Verify 'done' sentinel pushed even when SDK errors."""
+        mgr = _make_claude_manager()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        async def mock_query(prompt, options=None):
+            raise RuntimeError("test error")
+            yield  # make it a generator
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        self.assertIn("Error", result)
+        done_pushes = [(k, d) for k, d in pushes if k == "done"]
+        self.assertGreaterEqual(len(done_pushes), 1)
+
+    def test_no_crash_without_stream_buffer(self):
+        """Verify function works without _stream_buffers attribute."""
+        mgr = _make_claude_manager()
+        # No _stream_buffers
+
+        msg = _AssistantMessage([_TextBlock("works")])
+
+        async def mock_query(prompt, options=None):
+            yield msg
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        self.assertIn("works", result)
+
+
+class TestClaudeSdkToolCalls(unittest.TestCase):
+    """Test claude-sdk tool call event tracking."""
+
+    def test_tool_use_block_pushes_detected_event(self):
+        """Verify ToolUseBlock in content pushes 'detected' tool_call."""
+        mgr = _make_claude_manager()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        tool_block = _ToolUseBlock(id="tu_123", name="read_file", input={"path": "/tmp/x"})
+        text_block = _TextBlock("I'll read that file")
+        msg = _AssistantMessage([text_block, tool_block])
+
+        async def mock_query(prompt, options=None):
+            yield msg
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertGreaterEqual(len(tool_pushes), 1)
+        tc = tool_pushes[0][1]
+        self.assertEqual(tc["event"], "detected")
+        self.assertEqual(tc["name"], "read_file")
+        self.assertEqual(tc["id"], "tu_123")
+        self.assertEqual(tc["runtime"], "claude-sdk")
+        self.assertIn("timestamp", tc)
+
+    def test_tool_result_block_pushes_completed_event(self):
+        """Verify ToolResultBlock pushes 'completed' tool_call."""
+        mgr = _make_claude_manager()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        tool_use = _ToolUseBlock(id="tu_456", name="bash", input={"cmd": "ls"})
+        tool_result = _ToolResultBlock(
+            tool_use_id="tu_456", content="file1.txt\nfile2.txt", is_error=False
+        )
+        msg1 = _AssistantMessage([tool_use])
+        msg2 = _AssistantMessage([tool_result])
+
+        async def mock_query(prompt, options=None):
+            yield msg1
+            yield msg2
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertEqual(len(tool_pushes), 2)
+        self.assertEqual(tool_pushes[0][1]["event"], "detected")
+        self.assertEqual(tool_pushes[0][1]["name"], "bash")
+        self.assertEqual(tool_pushes[1][1]["event"], "completed")
+        self.assertEqual(tool_pushes[1][1]["id"], "tu_456")
+
+    def test_tool_result_error_tracked(self):
+        """Verify ToolResultBlock with is_error=True has is_error field."""
+        mgr = _make_claude_manager()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        tool_result = _ToolResultBlock(
+            tool_use_id="tu_err", content="Permission denied", is_error=True
+        )
+        msg = _AssistantMessage([tool_result])
+
+        async def mock_query(prompt, options=None):
+            yield msg
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertGreaterEqual(len(tool_pushes), 1)
+        tc = tool_pushes[0][1]
+        self.assertEqual(tc["event"], "completed")
+        self.assertTrue(tc["is_error"])
+
+    def test_multiple_tools_tracked_with_unique_ids(self):
+        """Verify multiple tool calls get unique IDs."""
+        mgr = _make_claude_manager()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        tool1 = _ToolUseBlock(id="tu_1", name="read_file", input={"path": "a"})
+        tool2 = _ToolUseBlock(id="tu_2", name="write_file", input={"path": "b"})
+        text = _TextBlock("Done")
+        msg = _AssistantMessage([tool1, tool2, text])
+
+        async def mock_query(prompt, options=None):
+            yield msg
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            result = mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertEqual(len(tool_pushes), 2)
+        ids = [tp[1]["id"] for tp in tool_pushes]
+        self.assertEqual(len(set(ids)), 2)
+
+    def test_result_message_stores_session_id(self):
+        """Verify ResultMessage.session_id stored in session data."""
+        mgr = _make_claude_manager()
+
+        msg = _AssistantMessage([_TextBlock("hi")])
+        result_msg = _ResultMessage(session_id="new-session-abc")
+
+        async def mock_query(prompt, options=None):
+            yield msg
+            yield result_msg
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            mgr.run_claude_sdk(
+                "test", "haiku", "orchestrator", None, False, "sess1"
+            )
+
+        mgr.update_session_field.assert_any_call("sess1", "session_id", "new-session-abc")
+
+
+# ═══════════════════════════════════════════════════════
+#  Tool Event Structure Validation
+# ═══════════════════════════════════════════════════════
+
+class TestToolEventStructure(unittest.TestCase):
+    """Validate required fields in tool call events for both runtimes."""
+
+    REQUIRED_FIELDS = {"event", "id", "name", "input", "runtime", "timestamp"}
+
+    @patch("copilot.CopilotClient")
+    def test_copilot_sdk_event_has_required_fields(self, mock_client_cls):
+        """All copilot-sdk tool events must have the standard field set."""
+        mgr = _get_session_mgr()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        mock_client = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session.session_id = "sdk-structure"
+        mock_session.disconnect = AsyncMock()
+        mock_session.get_messages = MagicMock(return_value=[])
+
+        captured_on_event = None
+
+        async def capture_create(**kwargs):
+            nonlocal captured_on_event
+            captured_on_event = kwargs.get("on_event")
+            return mock_session
+
+        mock_client.create_session = AsyncMock(side_effect=capture_create)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        from copilot.session import SessionEventType
+
+        async def send_with_tool(prompt, timeout=300.0):
+            if captured_on_event:
+                td = MagicMock()
+                td.name = "grep"
+                td.tool_name = "grep"
+                td.input = "pattern"
+                td.arguments = "pattern"
+                evt = MagicMock()
+                evt.type = SessionEventType.TOOL_EXECUTION_START
+                evt.data = td
+                captured_on_event(evt)
+            rd = MagicMock()
+            rd.content = "done"
+            re_ = MagicMock()
+            re_.data = rd
+            return re_
+
+        mock_session.send_and_wait = AsyncMock(side_effect=send_with_tool)
+
+        with patch.object(mgr, "build_agent_context_prompt", return_value="test"):
+            mgr.run_copilot_sdk("test", "gpt-5", "orchestrator", None, False, "sess1")
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertTrue(len(tool_pushes) > 0, "Expected at least one tool_call push")
+        for _, tc in tool_pushes:
+            missing = self.REQUIRED_FIELDS - tc.keys()
+            self.assertEqual(missing, set(), f"Missing fields: {missing}")
+
+    def test_claude_sdk_event_has_required_fields(self):
+        """All claude-sdk tool events must have the standard field set."""
+        mgr = _make_claude_manager()
+        stream_buf, pushes = _make_stream_buffer()
+        mgr._stream_buffers = {"sess1": stream_buf}
+
+        tool = _ToolUseBlock(id="tu_x", name="bash", input={"cmd": "echo"})
+        msg = _AssistantMessage([tool])
+
+        async def mock_query(prompt, options=None):
+            yield msg
+
+        fake_mod = _build_fake_claude_module(mock_query)
+        with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
+            mgr.run_claude_sdk("test", "haiku", "orchestrator", None, False, "sess1")
+
+        tool_pushes = [(k, d) for k, d in pushes if k == "tool_call"]
+        self.assertTrue(len(tool_pushes) > 0, "Expected at least one tool_call push")
+        for _, tc in tool_pushes:
+            missing = self.REQUIRED_FIELDS - tc.keys()
+            self.assertEqual(missing, set(), f"Missing fields: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes

- **fix(#86)**: claude-sdk multi-turn stall — use `query()` with `options.resume`
- **docs**: Issue #86 QA Approved status update
- **feat(#87)**: add streaming + tool call support for copilot-sdk and claude-sdk
- **docs**: Issue #87 QA Approved status update

## QA Status
Both issues passed QA review before this deploy.

## Test Plan
- [ ] Verify copilot-sdk runtime streams responses correctly
- [ ] Verify claude-sdk multi-turn conversations no longer stall
- [ ] Smoke test background task dispatch on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)