### PR TITLE
Fix: Ollama preset port 11436 → 11434 (#95)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -7622,7 +7622,7 @@ User Request:
 
         # Provider presets
         _PRESETS = {
-            "ollama": ("http://192.168.1.101:11436/v1", "ollama"),
+            "ollama": ("http://192.168.1.101:11434/v1", "ollama"),
             "openrouter": ("https://openrouter.ai/api/v1", None),
             "lmstudio": ("http://localhost:1234/v1", "lm-studio"),
         }
@@ -7638,7 +7638,7 @@ User Request:
                 break
 
         if not api_base:
-            api_base = "http://192.168.1.101:11436/v1"
+            api_base = "http://192.168.1.101:11434/v1"
         if not api_key:
             # Try keyring for OpenRouter
             if "openrouter" in api_base.lower():

--- a/tests/test_wee_native_runtime.py
+++ b/tests/test_wee_native_runtime.py
@@ -180,7 +180,7 @@ class TestWeeRuntimeDispatch(unittest.TestCase):
         _run_wee_native_test(mgr, test_session, model="ollama/gemma4:e4b")
 
         init_kwargs = mock_openai_cls.call_args[1]
-        self.assertEqual(init_kwargs["base_url"], "http://192.168.1.101:11436/v1")
+        self.assertEqual(init_kwargs["base_url"], "http://192.168.1.101:11434/v1")
         self.assertEqual(init_kwargs["api_key"], "ollama")
 
     @patch("openai.OpenAI")

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -17,7 +17,7 @@ import time
 
 # Provider presets: prefix → (api_base, default_api_key)
 PROVIDER_PRESETS = {
-    "ollama": ("http://192.168.1.101:11436/v1", "ollama"),
+    "ollama": ("http://192.168.1.101:11434/v1", "ollama"),
     "openrouter": ("https://openrouter.ai/api/v1", None),
     "lmstudio": ("http://localhost:1234/v1", "lm-studio"),
 }
@@ -49,7 +49,7 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
     # Defaults
     if not resolved_base:
         resolved_base = os.environ.get(
-            "WEE_API_BASE", "http://192.168.1.101:11436/v1"
+            "WEE_API_BASE", "http://192.168.1.101:11434/v1"
         )
     if not resolved_key:
         # Try environment variables


### PR DESCRIPTION
## Summary
Fixes #95 — Ollama provider preset used wrong port (11436) instead of the correct default (11434).

## Changes
- **wee_runtime.py**: Fixed `PROVIDER_PRESETS["ollama"]` and fallback default port
- **agent_manager.py**: Fixed `_PRESETS["ollama"]` and fallback default in `run_wee_native()`
- **tests/test_wee_native_runtime.py**: Updated assertion to match corrected port

## Testing
All 1103 tests pass, 9 skipped.