### PR TITLE
Fix #97: wee runtime missing from /api/v1/models + model list returns raw tuples

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1465,6 +1465,23 @@ class SessionManager:
         ],
     }
 
+
+    # WEE native runtime models configuration
+    WEE_MODELS = {
+        "Ollama (local)": [
+            ("ollama/gemma4:e4b", "Gemma 4 E4B (local)", ["gemma4-e4b", "gemma4"]),
+            ("ollama/gemma4:e2b", "Gemma 4 E2B (local)", ["gemma4-e2b"]),
+        ],
+        "OpenRouter": [
+            ("openrouter/meta-llama/llama-4-scout", "Llama 4 Scout via OpenRouter", ["llama-4-scout"]),
+            ("openrouter/meta-llama/llama-4-maverick", "Llama 4 Maverick via OpenRouter", ["llama-4-maverick"]),
+            ("openrouter/google/gemma-3-27b-it", "Gemma 3 27B via OpenRouter", ["gemma-3-27b"]),
+        ],
+        "LM Studio": [
+            ("lmstudio/default", "LM Studio Default Model", ["lmstudio"]),
+        ],
+    }
+
     def __init__(self, config_file: Optional[str] = None, app_env: str = "PROD"):
         # Copilot Paths
         self.copilot_home = Path.home() / ".copilot"
@@ -1553,6 +1570,7 @@ class SessionManager:
         self._env_codex_models = None
         self._env_devin_models = None
         self._env_cursor_models = None
+        self._env_wee_models = None
 
         # Load command timeout from environment
         self.command_timeout = get_command_timeout()
@@ -3311,7 +3329,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "codex": self._env_codex_models,
             "devin": self._env_devin_models,
             "cursor": self._env_cursor_models,
-            "wee": {},
+            "wee": self._env_wee_models,
         }
         env_models = env_models_map.get(runtime)
         if env_models:
@@ -3329,7 +3347,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "opencode": self.OPENCODE_MODELS,
             "devin": self.DEVIN_MODELS,
             "cursor": self.CURSOR_MODELS,
-            "wee": {},
+            "wee": self.WEE_MODELS,
         }
         models_dict = static_map.get(runtime)
         if not models_dict:
@@ -3518,6 +3536,31 @@ You can mention an agent in your prompt and it will auto-delegate:
 
         return self._static_models_to_dict(self.CURSOR_MODELS)
 
+    def fetch_wee_models(self) -> Dict:
+        """Return available Wee native runtime models from environment or fallback to static list.
+
+        Models are read from WEE_MODELS_JSON environment variable, with
+        static WEE_MODELS as fallback.
+        """
+        # Try to load from environment variable first
+        env_models = os.getenv("WEE_MODELS_JSON")
+        if env_models:
+            try:
+                import json
+
+                models_dict = json.loads(env_models)
+                # Cache the full model dict with descriptions for lookup later
+                self._env_wee_models = models_dict
+                # Convert to the expected format {category: [model_ids]}
+                return self._static_models_to_dict(models_dict)
+            except (json.JSONDecodeError, ValueError) as e:
+                print(
+                    f"Warning: Failed to parse WEE_MODELS_JSON: {e}", file=sys.stderr
+                )
+
+        # Fallback to static configuration
+        return self._static_models_to_dict(self.WEE_MODELS)
+
     def get_models_for_runtime(self, runtime: str) -> Dict:
         """Fetch available models for a runtime, using CLI discovery where possible.
 
@@ -3535,7 +3578,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "codex": self.fetch_codex_models,
             "devin": self.fetch_devin_models,
             "cursor": self.fetch_cursor_models,
-            "wee": lambda: {"Wee Native": [("ollama/gemma4:e4b", "Ollama Gemma 4 E4B (local)", []), ("openrouter/meta-llama/llama-4-scout", "Llama 4 Scout via OpenRouter", [])]},
+            "wee": self.fetch_wee_models,
         }
         fetcher = dispatch.get(runtime)
         if fetcher is None:
@@ -4052,7 +4095,7 @@ You can mention an agent in your prompt and it will auto-delegate:
         name_lower = name.lower().strip("\"'")
 
         # Ensure env models are loaded/cached by triggering fetch for this runtime
-        if runtime in ("claude", "gemini", "codex", "devin", "cursor"):
+        if runtime in ("claude", "gemini", "codex", "devin", "cursor", "wee"):
             self.get_models_for_runtime(runtime)
 
         # Step 1: check env-loaded or static alias tables for all runtimes that have them.
@@ -4062,6 +4105,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "codex": self._env_codex_models,
             "devin": self._env_devin_models,
             "cursor": self._env_cursor_models,
+            "wee": self._env_wee_models,
         }
         static_alias_map = {
             "claude": self.CLAUDE_MODELS,
@@ -4070,6 +4114,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "opencode": self.OPENCODE_MODELS,
             "devin": self.DEVIN_MODELS,
             "cursor": self.CURSOR_MODELS,
+            "wee": self.WEE_MODELS,
         }
 
         # Try env-loaded models first, fall back to static
@@ -9170,6 +9215,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             "codex",
             "devin",
             "cursor",
+            "wee",
         }
         if runtime not in known_runtimes:
             return {

--- a/tests/test_issue97_wee_models.py
+++ b/tests/test_issue97_wee_models.py
@@ -1,0 +1,253 @@
+"""Tests for Issue #97: wee runtime model listing fixes.
+
+Bug 1: /api/v1/models excludes wee from known_runtimes
+Bug 2: get_models_for_runtime wee lambda returns raw tuples
+Enhancement: WEE_MODELS_JSON env var support
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from agent_manager import SessionManager
+
+
+class TestIssue97WeeModelsKnownRuntimes(unittest.TestCase):
+    """Bug 1: wee must be in known_runtimes for /api/v1/models endpoint."""
+
+    def test_wee_in_known_runtimes(self):
+        """GET /api/v1/models?runtime=wee should not return 'Unknown runtime'."""
+        # Read the source file and verify wee is in known_runtimes
+        import pathlib
+        src = pathlib.Path(__file__).parent.parent / "agent_manager.py"
+        text = src.read_text()
+        # Find the known_runtimes block
+        idx = text.index("known_runtimes = {")
+        block_end = text.index("}", idx)
+        block = text[idx:block_end]
+        self.assertIn('"wee"', block,
+                       "wee must be in known_runtimes set in get_models endpoint")
+
+
+class TestIssue97WeeModelsFormat(unittest.TestCase):
+    """Bug 2: get_models_for_runtime('wee') must return {cat: [id_str, ...]}."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.shim = SessionManager.__new__(SessionManager)
+        cls.shim._env_claude_models = None
+        cls.shim._env_gemini_models = None
+        cls.shim._env_codex_models = None
+        cls.shim._env_devin_models = None
+        cls.shim._env_cursor_models = None
+        cls.shim._env_wee_models = None
+
+    def test_wee_models_returns_dict_of_string_lists(self):
+        """get_models_for_runtime('wee') values must be lists of strings, not tuples."""
+        result = self.shim.get_models_for_runtime("wee")
+        self.assertIsInstance(result, dict)
+        self.assertGreater(len(result), 0, "Should return at least one category")
+        for category, models in result.items():
+            self.assertIsInstance(category, str)
+            self.assertIsInstance(models, list)
+            for model_id in models:
+                self.assertIsInstance(model_id, str,
+                    f"Model in category '{category}' should be str, got {type(model_id)}: {model_id}")
+
+    def test_wee_models_contains_expected_models(self):
+        """Default WEE_MODELS should include known model IDs."""
+        result = self.shim.get_models_for_runtime("wee")
+        all_models = [m for models in result.values() for m in models]
+        self.assertIn("ollama/gemma4:e4b", all_models)
+        self.assertIn("openrouter/meta-llama/llama-4-scout", all_models)
+
+    def test_wee_models_multiple_categories(self):
+        """Default WEE_MODELS should have multiple categories."""
+        result = self.shim.get_models_for_runtime("wee")
+        self.assertGreaterEqual(len(result), 2, "Should have at least 2 categories")
+
+
+class TestIssue97WeeModelsConstant(unittest.TestCase):
+    """WEE_MODELS class constant follows the standard tuple format."""
+
+    def test_wee_models_class_constant_exists(self):
+        """SessionManager.WEE_MODELS must be defined."""
+        self.assertTrue(hasattr(SessionManager, "WEE_MODELS"))
+
+    def test_wee_models_constant_format(self):
+        """WEE_MODELS entries must be (id, description, aliases) tuples."""
+        for category, entries in SessionManager.WEE_MODELS.items():
+            self.assertIsInstance(category, str)
+            self.assertIsInstance(entries, list)
+            for entry in entries:
+                self.assertIsInstance(entry, tuple, f"Entry should be tuple: {entry}")
+                self.assertEqual(len(entry), 3, f"Entry should be 3-tuple: {entry}")
+                model_id, desc, aliases = entry
+                self.assertIsInstance(model_id, str)
+                self.assertIsInstance(desc, str)
+                self.assertIsInstance(aliases, list)
+
+    def test_wee_models_has_ollama_category(self):
+        """WEE_MODELS should have an Ollama category."""
+        categories = list(SessionManager.WEE_MODELS.keys())
+        ollama_cats = [c for c in categories if "ollama" in c.lower()]
+        self.assertGreater(len(ollama_cats), 0, f"Should have Ollama category, got: {categories}")
+
+
+class TestIssue97FetchWeeModels(unittest.TestCase):
+    """fetch_wee_models method and WEE_MODELS_JSON env var support."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.shim = SessionManager.__new__(SessionManager)
+        cls.shim._env_claude_models = None
+        cls.shim._env_gemini_models = None
+        cls.shim._env_codex_models = None
+        cls.shim._env_devin_models = None
+        cls.shim._env_cursor_models = None
+        cls.shim._env_wee_models = None
+
+    def test_fetch_wee_models_exists(self):
+        """fetch_wee_models method must exist."""
+        self.assertTrue(hasattr(self.shim, "fetch_wee_models"))
+        self.assertTrue(callable(self.shim.fetch_wee_models))
+
+    def test_fetch_wee_models_returns_string_lists(self):
+        """fetch_wee_models must return {cat: [str, ...]} format."""
+        result = self.shim.fetch_wee_models()
+        for cat, models in result.items():
+            for m in models:
+                self.assertIsInstance(m, str, f"Expected str, got {type(m)}: {m}")
+
+    @patch.dict(os.environ, {"WEE_MODELS_JSON": json.dumps({
+        "Custom Ollama": [
+            ["custom/model-1", "Custom Model 1", []],
+            ["custom/model-2", "Custom Model 2", ["cm2"]],
+        ]
+    })})
+    def test_wee_models_json_env_override(self):
+        """WEE_MODELS_JSON env var should override static WEE_MODELS."""
+        shim = SessionManager.__new__(SessionManager)
+        shim._env_wee_models = None
+        result = shim.fetch_wee_models()
+        self.assertIn("Custom Ollama", result)
+        self.assertIn("custom/model-1", result["Custom Ollama"])
+        self.assertIn("custom/model-2", result["Custom Ollama"])
+
+    @patch.dict(os.environ, {"WEE_MODELS_JSON": json.dumps({
+        "Test": [["test/m1", "Test Model", ["tm1"]]]
+    })})
+    def test_wee_models_json_caches_env_models(self):
+        """fetch_wee_models should cache env models in _env_wee_models."""
+        shim = SessionManager.__new__(SessionManager)
+        shim._env_wee_models = None
+        shim.fetch_wee_models()
+        self.assertIsNotNone(shim._env_wee_models)
+        self.assertIn("Test", shim._env_wee_models)
+
+    @patch.dict(os.environ, {"WEE_MODELS_JSON": "{invalid json"})
+    def test_wee_models_json_invalid_falls_back(self):
+        """Invalid WEE_MODELS_JSON should fall back to static models."""
+        shim = SessionManager.__new__(SessionManager)
+        shim._env_wee_models = None
+        result = shim.fetch_wee_models()
+        # Should return static models, not crash
+        self.assertGreater(len(result), 0)
+        # Should include default categories
+        all_models = [m for models in result.values() for m in models]
+        self.assertIn("ollama/gemma4:e4b", all_models)
+
+    def test_fetch_wee_models_no_env_uses_static(self):
+        """Without WEE_MODELS_JSON, fetch_wee_models uses WEE_MODELS constant."""
+        # Ensure no env var
+        with patch.dict(os.environ, {}, clear=False):
+            if "WEE_MODELS_JSON" in os.environ:
+                del os.environ["WEE_MODELS_JSON"]
+            shim = SessionManager.__new__(SessionManager)
+            shim._env_wee_models = None
+            result = shim.fetch_wee_models()
+            all_models = [m for models in result.values() for m in models]
+            self.assertIn("ollama/gemma4:e4b", all_models)
+
+
+class TestIssue97ModelDescription(unittest.TestCase):
+    """_get_model_description should work for wee runtime models."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.shim = SessionManager.__new__(SessionManager)
+        cls.shim._env_claude_models = None
+        cls.shim._env_gemini_models = None
+        cls.shim._env_codex_models = None
+        cls.shim._env_devin_models = None
+        cls.shim._env_cursor_models = None
+        cls.shim._env_wee_models = None
+
+    def test_wee_model_description_from_static(self):
+        """Should find description for wee models from static WEE_MODELS."""
+        desc = self.shim._get_model_description("ollama/gemma4:e4b", "wee")
+        self.assertIsNotNone(desc)
+        self.assertIn("Gemma", desc)
+
+    def test_wee_model_description_unknown_model(self):
+        """Should return None for unknown wee model."""
+        desc = self.shim._get_model_description("nonexistent/model", "wee")
+        self.assertIsNone(desc)
+
+
+class TestIssue97ResolveModelAlias(unittest.TestCase):
+    """get_model_from_name should work for wee runtime aliases."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.shim = SessionManager.__new__(SessionManager)
+        cls.shim._env_claude_models = None
+        cls.shim._env_gemini_models = None
+        cls.shim._env_codex_models = None
+        cls.shim._env_devin_models = None
+        cls.shim._env_cursor_models = None
+        cls.shim._env_wee_models = None
+
+    def test_resolve_wee_alias_exact(self):
+        """Should resolve exact wee model ID."""
+        result = self.shim.get_model_from_name("ollama/gemma4:e4b", "wee")
+        self.assertEqual(result, "ollama/gemma4:e4b")
+
+    def test_resolve_wee_alias_by_alias(self):
+        """Should resolve wee model by alias."""
+        result = self.shim.get_model_from_name("gemma4-e4b", "wee")
+        self.assertEqual(result, "ollama/gemma4:e4b")
+
+    def test_resolve_wee_alias_by_description(self):
+        """Should resolve wee model by description."""
+        result = self.shim.get_model_from_name("Gemma 4 E4B (local)", "wee")
+        self.assertEqual(result, "ollama/gemma4:e4b")
+
+
+class TestIssue97DispatchTable(unittest.TestCase):
+    """Dispatch table in get_models_for_runtime must use fetch_wee_models."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.shim = SessionManager.__new__(SessionManager)
+        cls.shim._env_claude_models = None
+        cls.shim._env_gemini_models = None
+        cls.shim._env_codex_models = None
+        cls.shim._env_devin_models = None
+        cls.shim._env_cursor_models = None
+        cls.shim._env_wee_models = None
+
+    def test_dispatch_wee_is_not_lambda(self):
+        """The wee dispatch entry should be a bound method, not an inline lambda."""
+        import inspect
+        source = inspect.getsource(self.shim.get_models_for_runtime)
+        # Should NOT contain a lambda for wee
+        self.assertNotIn('lambda:', source.split('"wee"')[1].split('\n')[0] if '"wee"' in source else "",
+                         "wee dispatch should use fetch_wee_models, not a lambda")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #97 — three changes:

### Bug 1: wee missing from known_runtimes
Added  to the  set in , so the endpoint no longer returns .

### Bug 2: raw tuples in model list
Replaced the inline lambda that returned raw  tuples with a proper  method that passes through .

### Enhancement: WEE_MODELS_JSON env var
Added  env var support following the same pattern as , , etc. Models can now be configured without code changes.

### Additional changes
- Added  class constant with Ollama, OpenRouter, and LM Studio categories
- Updated  and  to support wee runtime aliases
- 19 new tests covering all three fixes

### Test results
1122 passed, 9 skipped, 0 failures (19 new tests for this issue)

Commit: 81c6dd8