### PR TITLE
Issue #128: Token usage tracking + cost estimation + WebUI footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,49 @@
 # Changelog
 
-## [Issue #100] Feature: GitHub Issues Integration for TODO Endpoints
+### [Issue #128] Feature: Token Usage Tracking + Cost Estimation + WebUI Footer
+**Status:** ✅ Implemented
+
+### Summary
+Adds end-to-end token usage tracking for the wee runtime: token counts are captured from the OpenAI streaming API, costs are calculated using OpenRouter pricing (with 1h cache), and displayed in the WebUI message footer. Usage is logged to a JSONL file and exposed via a new `/api/v1/usage` endpoint.
+
+### Changes
+
+**wee_runtime.py (standalone CLI)**
+- Added `stream_options={"include_usage": True}` to OpenAI streaming calls
+- Parses `chunk.usage` from final streaming chunk (prompt/completion/total tokens)
+- `fetch_openrouter_pricing()` — fetches model pricing from OpenRouter API, caches 1h in `/tmp/openrouter_pricing.json`
+- `calculate_cost()` — returns `(cost_usd, label)` where label is `local`, `free`, or `$X.XXXX`
+- `log_token_usage()` — appends entry to `~/.copilot/logs/token_usage.jsonl`
+- Outputs `__WEE_META__ {...}` line at end of stream (stripped by backend before sending to UI)
+- Fixed Ollama port: 11436 → 11434
+
+**agent_manager.py (backend)**
+- `_fetch_openrouter_pricing()` — same 1h-cached pricing fetch (for interactive sessions)
+- `_calculate_wee_cost()` — cost+label for wee/ollama/openrouter models
+- `_calculate_anthropic_cost()` — cost+label for claude-sdk models
+- `_get_cost_label()` — formats cost as `$0.0001` or `free`
+- `_log_token_usage()` — appends to `logs/token_usage.jsonl`
+- `run_wee_native()` — captures usage from final streaming chunk, stores `wee_meta` in session
+- `run_claude_sdk()` — captures usage from `ResultMessage`, stores `wee_meta` in session
+- SSE `done_payload` — includes `wee_meta` (tokens, cost, model), cleared after send
+- **GET /api/v1/usage** — aggregates JSONL log by model; supports `?period=today|7d|30d`
+
+**webui/dist/app.js (frontend)**
+- `buildTimingText(elapsedSec, weeMeta)` helper — returns footer string:
+  - Paid: `Generated in 3.4s · 229 tokens · $0.0001`
+  - Free: `Generated in 3.4s · 229 tokens · free`
+  - Local (Ollama): `Generated in 3.4s · 229 tokens · local`
+  - No data: `Generated in 3.4s`
+- Streaming done path updated to pass `evt.wee_meta` to `buildTimingText`
+- `renderMessage()` signature updated with `weeMeta` param; timing block uses `buildTimingText`
+
+**Tests**
+- `tests/test_issue128_token_usage.py` — 28 new tests
+- `tests/test_wee_native_runtime.py` — fixed Ollama port assertion (11436 → 11434)
+- Total: 1170 passed, 9 skipped (no regressions)
+
+
+# [Issue #100] Feature: GitHub Issues Integration for TODO Endpoints
 **Status:** ✅ QA Approved (Commit: ca21379)
 
 ### Summary

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -6859,6 +6859,27 @@ User Request:
                     elif isinstance(message, ResultMessage):
                         if message.session_id:
                             self.update_session_field(n8n_session_id, "session_id", message.session_id)
+                        # Issue #128: capture token usage
+                        if hasattr(message, "usage") and message.usage is not None:
+                            try:
+                                _u = message.usage
+                                _pt = _u.get("input_tokens", 0) if isinstance(_u, dict) else getattr(_u, "input_tokens", 0)
+                                _ct = _u.get("output_tokens", 0) if isinstance(_u, dict) else getattr(_u, "output_tokens", 0)
+                                _pt = _pt or 0; _ct = _ct or 0
+                                _cost, _label = self._calculate_anthropic_cost(model or "", _pt, _ct)
+                                self.update_session_field(n8n_session_id, "wee_meta", {
+                                    "tokens": _pt + _ct, "prompt_tokens": _pt,
+                                    "completion_tokens": _ct, "cost_usd": _cost,
+                                    "cost_label": _label, "model": model or "", "runtime": "claude-sdk",
+                                })
+                                self._log_token_usage(
+                                    session_id=n8n_session_id, model=model or "claude",
+                                    runtime="claude-sdk", provider="anthropic",
+                                    prompt_tokens=_pt, completion_tokens=_ct,
+                                    total_tokens=_pt + _ct, cost_usd=_cost, duration_ms=0,
+                                )
+                            except Exception as _ue:
+                                print(f"[claude-sdk] usage capture error: {_ue}", file=sys.stderr)
                     elif hasattr(message, "content"):
                         for block in getattr(message, "content", []):
                             if hasattr(block, "text"):
@@ -7571,6 +7592,131 @@ User Request:
 
         return self.strip_metadata(output, "cursor")
 
+    # ── Issue #128: Token usage tracking helpers ─────────────────────────────
+
+    def _fetch_openrouter_pricing(self) -> dict:
+        """Fetch and cache OpenRouter model pricing (1h TTL)."""
+        import time as _time
+        import json as _json
+        import urllib.request
+
+        cache_path = Path('/tmp/openrouter_pricing.json')
+        now = _time.time()
+        if cache_path.exists() and (now - cache_path.stat().st_mtime) < 3600:
+            try:
+                with open(cache_path) as f:
+                    return _json.load(f)
+            except Exception:
+                pass
+        try:
+            with urllib.request.urlopen(
+                'https://openrouter.ai/api/v1/models', timeout=10
+            ) as resp:
+                data = _json.loads(resp.read().decode())
+            pricing = {}
+            for model_info in data.get('data', []):
+                mid = model_info.get('id', '')
+                p = model_info.get('pricing', {})
+                try:
+                    pricing[mid] = {
+                        'prompt': float(p.get('prompt', 0) or 0),
+                        'completion': float(p.get('completion', 0) or 0),
+                    }
+                except (ValueError, TypeError):
+                    pass
+            with open(cache_path, 'w') as f:
+                _json.dump(pricing, f)
+            return pricing
+        except Exception as e:
+            print(f'[TokenUsage] Could not fetch OpenRouter pricing: {e}', file=sys.stderr)
+            return {}
+
+    def _calculate_wee_cost(
+        self, model: str, prompt_tokens: int, completion_tokens: int, pricing: dict
+    ):
+        """Calculate cost and label for wee runtime (Ollama/OpenRouter)."""
+        model_lower = model.lower()
+        if model_lower.startswith('ollama/') or '192.168' in model_lower:
+            return 0.0, 'local'
+        bare_model = model
+        for prefix in ('openrouter/', 'lmstudio/', 'wee/'):
+            if model_lower.startswith(prefix):
+                bare_model = model[len(prefix):]
+                break
+        if bare_model not in pricing:
+            return 0.0, 'free'
+        p = pricing[bare_model]
+        cost = (prompt_tokens * p['prompt']) + (completion_tokens * p['completion'])
+        return cost, self._get_cost_label(cost)
+
+    def _calculate_anthropic_cost(self, model: str, prompt_tokens: int, completion_tokens: int):
+        """Calculate cost for Anthropic / claude-sdk models."""
+        ANTHROPIC_PRICING = {
+            'claude-haiku-4-5':  (0.80, 4.00),
+            'claude-haiku-4':    (0.80, 4.00),
+            'claude-haiku':      (0.80, 4.00),
+            'claude-sonnet-4-5': (3.00, 15.00),
+            'claude-sonnet-4':   (3.00, 15.00),
+            'claude-sonnet':     (3.00, 15.00),
+            'claude-opus-4-5':   (15.00, 75.00),
+            'claude-opus-4':     (15.00, 75.00),
+            'claude-opus':       (15.00, 75.00),
+        }
+        model_lower = model.lower()
+        input_price, output_price = 3.00, 15.00
+        for key, (inp, out) in ANTHROPIC_PRICING.items():
+            if key in model_lower:
+                input_price, output_price = inp, out
+                break
+        cost = (prompt_tokens * input_price / 1_000_000) + (completion_tokens * output_price / 1_000_000)
+        return cost, self._get_cost_label(cost)
+
+    def _get_cost_label(self, cost_usd: float) -> str:
+        """Format cost as display label."""
+        if cost_usd == 0.0:
+            return 'free'
+        if cost_usd < 0.00001:
+            return f'${cost_usd:.8f}'.rstrip('0')
+        if cost_usd < 0.001:
+            return f'${cost_usd:.6f}'.rstrip('0')
+        return f'${cost_usd:.4f}'.rstrip('0').rstrip('.')
+
+    def _log_token_usage(
+        self,
+        session_id: str,
+        model: str,
+        runtime: str,
+        provider: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        total_tokens: int,
+        cost_usd: float,
+        duration_ms: int,
+    ):
+        """Append a usage entry to logs/token_usage.jsonl."""
+        import time as _time
+        import json as _json
+        try:
+            self.logs_dir.mkdir(parents=True, exist_ok=True)
+            entry = {
+                'timestamp': _time.time(),
+                'session_id': session_id,
+                'model': model,
+                'runtime': runtime,
+                'provider': provider,
+                'prompt_tokens': prompt_tokens,
+                'completion_tokens': completion_tokens,
+                'total_tokens': total_tokens,
+                'cost_usd': cost_usd,
+                'duration_ms': duration_ms,
+            }
+            with open(self.logs_dir / 'token_usage.jsonl', 'a') as f:
+                f.write(_json.dumps(entry) + '\n')
+        except Exception as e:
+            print(f'[TokenUsage] Failed to log usage: {e}', file=sys.stderr)
+
+    # ── End Issue #128 helpers ─────────────────────────────────────────────────
+
     def run_wee_native(
         self,
         prompt: str,
@@ -7626,7 +7772,7 @@ User Request:
 
         # Provider presets
         _PRESETS = {
-            "ollama": ("http://192.168.1.101:11436/v1", "ollama"),
+            "ollama": ("http://192.168.1.101:11434/v1", "ollama"),
             "openrouter": ("https://openrouter.ai/api/v1", None),
             "lmstudio": ("http://localhost:1234/v1", "lm-studio"),
         }
@@ -7679,24 +7825,58 @@ User Request:
         collected_output = []
 
         try:
+            import time as _time
+            _wee_start = _time.time()
+            _last_usage = [None]
+
             stream = client.chat.completions.create(
                 model=resolved_model,
                 messages=messages,
                 stream=True,
+                stream_options={"include_usage": True},
             )
 
             for chunk in stream:
                 if chunk.choices and chunk.choices[0].delta.content:
                     token = chunk.choices[0].delta.content
                     collected_output.append(token)
-
-                    # Push to SSE stream buffer for WebUI
                     if stream_buffer:
                         stream_buffer.push("chunk", {"text": token})
+                if hasattr(chunk, "usage") and chunk.usage is not None:
+                    _last_usage[0] = chunk.usage
 
             output = "".join(collected_output)
 
-            # Push done sentinel
+            # Compute cost + attach wee_meta (Issue #128)
+            try:
+                _duration_ms = int((_time.time() - _wee_start) * 1000)
+                if _last_usage[0] is not None:
+                    _u = _last_usage[0]
+                    _prompt_tokens = getattr(_u, "prompt_tokens", 0) or 0
+                    _completion_tokens = getattr(_u, "completion_tokens", 0) or 0
+                    _total = getattr(_u, "total_tokens", _prompt_tokens + _completion_tokens)
+                    _provider = "ollama" if "192.168" in api_base else ("openrouter" if "openrouter" in api_base else "wee")
+                    _pricing = self._fetch_openrouter_pricing() if _provider == "openrouter" else {}
+                    _cost_usd, _cost_label = self._calculate_wee_cost(model, _prompt_tokens, _completion_tokens, _pricing)
+                    _wee_meta = {
+                        "tokens": _total,
+                        "prompt_tokens": _prompt_tokens,
+                        "completion_tokens": _completion_tokens,
+                        "cost_usd": _cost_usd,
+                        "cost_label": _cost_label,
+                        "model": model,
+                        "runtime": "wee",
+                    }
+                    self.update_session_field(n8n_session_id, "wee_meta", _wee_meta)
+                    self._log_token_usage(
+                        session_id=n8n_session_id, model=model, runtime="wee",
+                        provider=_provider, prompt_tokens=_prompt_tokens,
+                        completion_tokens=_completion_tokens, total_tokens=_total,
+                        cost_usd=_cost_usd, duration_ms=_duration_ms,
+                    )
+            except Exception as _meta_err:
+                print(f"[Wee Native] wee_meta error: {_meta_err}", file=sys.stderr)
+
             if stream_buffer:
                 stream_buffer.push("done", output)
 
@@ -9701,14 +9881,12 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
                 session_data = session_mgr.get_or_create_session_data(session_id)
                 runtime = session_data.get("runtime", "copilot")
-                done_payload = _json.dumps(
-                    {
-                        "type": "done",
-                        "response": result,
-                        "runtime": runtime,
-                        "model": session_data.get("model"),
-                    }
-                )
+                _wm = session_data.get("wee_meta")
+                _done_obj = {"type": "done", "response": result, "runtime": runtime, "model": session_data.get("model")}
+                if _wm:
+                    _done_obj["wee_meta"] = _wm
+                    session_mgr.update_session_field(session_id, "wee_meta", None)
+                done_payload = _json.dumps(_done_obj)
                 yield f"data: {done_payload}\n\n"
                 done_delivered = True
             finally:
@@ -9996,6 +10174,84 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 "cancelled": False,
                 "message": f"Failed to cancel query (PID: {pid})",
             }
+
+    # --- Token usage analytics endpoint (Issue #128) ---
+
+    @app.get("/api/v1/usage")
+    async def get_token_usage(request: Request, period: str = "all_time"):
+        """Return token usage and cost analytics.
+
+        Query params:
+            period: today | 7d | 30d | all_time (default)
+        """
+        import time as _time
+        import json as _json
+        import datetime as _datetime
+        await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        log_file = session_mgr.logs_dir / "token_usage.jsonl"
+
+        now = _time.time()
+        if period == "today":
+            cutoff = _datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
+        elif period == "7d":
+            cutoff = now - 7 * 86400
+        elif period == "30d":
+            cutoff = now - 30 * 86400
+        else:
+            cutoff = 0
+
+        entries = []
+        if log_file.exists():
+            try:
+                with open(log_file) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            e = _json.loads(line)
+                            if e.get("timestamp", 0) >= cutoff:
+                                entries.append(e)
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+
+        total_cost = sum(e.get("cost_usd", 0) or 0 for e in entries)
+        total_tokens = sum(e.get("total_tokens", 0) or 0 for e in entries)
+
+        by_model_map = {}
+        for e in entries:
+            m = e.get("model", "unknown")
+            if m not in by_model_map:
+                by_model_map[m] = {
+                    "model": m,
+                    "runtime": e.get("runtime", "unknown"),
+                    "total_tokens": 0,
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "cost_usd": 0.0,
+                    "requests": 0,
+                }
+            bm = by_model_map[m]
+            bm["total_tokens"] += e.get("total_tokens", 0) or 0
+            bm["prompt_tokens"] += e.get("prompt_tokens", 0) or 0
+            bm["completion_tokens"] += e.get("completion_tokens", 0) or 0
+            bm["cost_usd"] += e.get("cost_usd", 0) or 0
+            bm["requests"] += 1
+
+        return {
+            "period": period,
+            "total_cost_usd": round(total_cost, 8),
+            "total_tokens": total_tokens,
+            "total_requests": len(entries),
+            "by_model": sorted(by_model_map.values(), key=lambda x: x["cost_usd"], reverse=True),
+        }
 
     # --- Runtime usage endpoint ---
 

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -4432,6 +4432,9 @@ You can mention an agent in your prompt and it will auto-delegate:
             for line in lines:
                 if not line.strip() and not result:
                     continue
+                # Strip __WEE_META__ markers to keep internal metadata out of user output
+                if line.strip().startswith("__WEE_META__"):
+                    continue
                 result.append(line)
 
         # Remove trailing empty lines
@@ -11314,6 +11317,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                     sys.executable, _wee_script,
                     "--model", model,
                     "--timeout", str(timeout or 300),
+                    "--session-id", session_id,
                 ]
                 # Resolve api_base and api_key from session/env
                 _wee_api_base = os.environ.get("WEE_API_BASE", "")

--- a/tests/test_issue128_token_usage.py
+++ b/tests/test_issue128_token_usage.py
@@ -1,0 +1,359 @@
+"""Tests for Issue #128: Token usage tracking + cost estimation + WebUI footer."""
+import json
+import os
+import sys
+import time
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, mock_open
+import pytest
+
+# Add dev path
+sys.path.insert(0, '/opt/n8n-copilot-shim-dev')
+
+
+# ─── Helper method tests via AgentManager ────────────────────────────────────
+
+class TestTokenHelpers:
+    """Tests for SessionManager token tracking helper methods."""
+
+    def setup_method(self):
+        """Import SessionManager and instantiate with minimal setup."""
+        import importlib
+        self.am_mod = importlib.import_module('agent_manager')
+        # Mock minimal required setup to get a usable instance
+        with patch.object(self.am_mod.SessionManager, '__init__', lambda self, *a, **kw: None):
+            self.mgr = self.am_mod.SessionManager.__new__(self.am_mod.SessionManager)
+        # Set required attributes
+        self.mgr.logs_dir = Path(tempfile.mkdtemp())
+
+    def test_calculate_wee_cost_ollama(self):
+        """Ollama models should always return cost_usd=0, label='local'."""
+        cost, label = self.mgr._calculate_wee_cost('ollama/llama3', 1000, 500, {})
+        assert cost == 0.0
+        assert label == 'local'
+
+    def test_calculate_wee_cost_openrouter_no_pricing(self):
+        """Models with no pricing in cache should return free."""
+        cost, label = self.mgr._calculate_wee_cost('openrouter/some-model', 1000, 500, {})
+        assert cost == 0.0
+        assert label == 'free'
+
+    def test_calculate_wee_cost_openrouter_with_pricing(self):
+        """Models with pricing data should return calculated cost."""
+        pricing = {
+            'google/gemini-flash': {  # bare model name (prefix stripped internally)
+                'prompt': 0.000000075,
+                'completion': 0.0000003,
+            }
+        }
+        cost, label = self.mgr._calculate_wee_cost(
+            'openrouter/google/gemini-flash', 1000, 500, pricing
+        )
+        expected = (1000 * 0.000000075) + (500 * 0.0000003)
+        assert abs(cost - expected) < 1e-10
+        assert label.startswith('$')
+
+    def test_calculate_anthropic_cost_haiku(self):
+        """Claude haiku pricing should be applied correctly."""
+        cost, label = self.mgr._calculate_anthropic_cost('claude-haiku-4-5', 1000, 500)
+        # $0.80/$4.00 per 1M tokens
+        expected = (1000 * 0.80 / 1_000_000) + (500 * 4.00 / 1_000_000)
+        assert abs(cost - expected) < 1e-10
+        assert label.startswith('$')
+
+    def test_calculate_anthropic_cost_sonnet(self):
+        """Claude sonnet pricing should be applied correctly."""
+        cost, label = self.mgr._calculate_anthropic_cost('claude-sonnet-4-5', 1000, 500)
+        expected = (1000 * 3.0 / 1_000_000) + (500 * 15.0 / 1_000_000)
+        assert abs(cost - expected) < 1e-10
+
+    def test_calculate_anthropic_cost_unknown(self):
+        """Unknown Anthropic model should return default pricing."""
+        cost, label = self.mgr._calculate_anthropic_cost('claude-unknown-model', 100, 100)
+        assert cost >= 0.0
+        assert isinstance(label, str)
+
+    def test_get_cost_label_zero(self):
+        """Zero cost should return 'free'."""
+        label = self.mgr._get_cost_label(0.0)
+        assert label == 'free'
+
+    def test_get_cost_label_small(self):
+        """Small cost should be formatted as $0.XXXX."""
+        label = self.mgr._get_cost_label(0.000012)
+        assert label.startswith('$')
+        assert '0.0000' in label or '0.00' in label
+
+    def test_log_token_usage_writes_jsonl(self):
+        """_log_token_usage should write a valid JSONL entry."""
+        log_file = self.mgr.logs_dir / 'token_usage.jsonl'
+        self.mgr._log_token_usage(
+            session_id='test-session-1',
+            model='openrouter/google/gemini-flash',
+            runtime='wee',
+            provider='openrouter',
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+            cost_usd=0.0000125,
+            duration_ms=1234,
+        )
+        assert log_file.exists()
+        with open(log_file) as f:
+            entry = json.loads(f.readline())
+        assert entry['session_id'] == 'test-session-1'
+        assert entry['model'] == 'openrouter/google/gemini-flash'
+        assert entry['prompt_tokens'] == 100
+        assert entry['completion_tokens'] == 50
+        assert entry['total_tokens'] == 150
+        assert abs(entry['cost_usd'] - 0.0000125) < 1e-12
+        assert entry['duration_ms'] == 1234
+        assert 'timestamp' in entry
+
+    def test_log_token_usage_multiple_appends(self):
+        """Multiple calls should append to the same file."""
+        for i in range(3):
+            self.mgr._log_token_usage(
+                session_id=f'session-{i}',
+                model='ollama/llama3',
+                runtime='wee',
+                provider='ollama',
+                prompt_tokens=10 * i,
+                completion_tokens=5 * i,
+                total_tokens=15 * i,
+                cost_usd=0.0,
+                duration_ms=100,
+            )
+        log_file = self.mgr.logs_dir / 'token_usage.jsonl'
+        lines = log_file.read_text().strip().split('\n')
+        assert len(lines) == 3
+
+
+# ─── /api/v1/usage endpoint tests ────────────────────────────────────────────
+
+class TestUsageEndpoint:
+    """Tests for GET /api/v1/usage endpoint."""
+
+    def setup_method(self):
+        """Setup test client."""
+        import os
+        from fastapi.testclient import TestClient
+        import importlib
+        self._orig_api_key = os.environ.get('API_SHARED_KEY')
+        os.environ['API_SHARED_KEY'] = 'testkey'
+        self.am_mod = importlib.import_module('agent_manager')
+        self.app = self.am_mod.create_api_app()
+        self.client = TestClient(self.app, raise_server_exceptions=False)
+        self.tmp_dir = Path(tempfile.mkdtemp())
+        self.auth_headers = {'Authorization': 'Bearer shared_testkey'}
+
+    def teardown_method(self):
+        """Restore env to avoid leaking API_SHARED_KEY to other tests."""
+        import os
+        if self._orig_api_key is None:
+            os.environ.pop('API_SHARED_KEY', None)
+        else:
+            os.environ['API_SHARED_KEY'] = self._orig_api_key
+
+    def _write_usage_log(self, entries, logs_dir=None):
+        """Write test entries to token_usage.jsonl."""
+        d = logs_dir or self.tmp_dir
+        log_file = d / 'token_usage.jsonl'
+        with open(log_file, 'w') as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + '\n')
+        return log_file
+
+    def _make_entry(self, days_ago=0, model='ollama/llama3', runtime='wee',
+                    prompt_tokens=100, completion_tokens=50, cost_usd=0.0):
+        """Create a test log entry."""
+        ts = time.time() - (days_ago * 86400)
+        return {
+            'timestamp': ts,
+            'session_id': 'test',
+            'model': model,
+            'runtime': runtime,
+            'provider': 'ollama' if 'ollama' in model else 'openrouter',
+            'prompt_tokens': prompt_tokens,
+            'completion_tokens': completion_tokens,
+            'total_tokens': prompt_tokens + completion_tokens,
+            'cost_usd': cost_usd,
+            'duration_ms': 1000,
+        }
+
+    def test_usage_today_filter(self):
+        """?period=today should be accepted and return valid structure."""
+        resp = self.client.get(
+            '/api/v1/usage?period=today',
+            headers=self.auth_headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data['period'] == 'today'
+        assert data['total_cost_usd'] >= 0
+
+    def test_usage_endpoint_exists(self):
+        """GET /api/v1/usage should return 200 with proper structure."""
+        resp = self.client.get(
+            '/api/v1/usage',
+            headers=self.auth_headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert 'total_cost_usd' in data
+        assert 'total_tokens' in data
+        assert 'by_model' in data
+        assert isinstance(data['by_model'], list)
+
+    def test_usage_period_7d(self):
+        """?period=7d should be accepted."""
+        resp = self.client.get(
+            '/api/v1/usage?period=7d',
+            headers=self.auth_headers
+        )
+        assert resp.status_code == 200
+
+    def test_usage_period_30d(self):
+        """?period=30d should be accepted."""
+        resp = self.client.get(
+            '/api/v1/usage?period=30d',
+            headers=self.auth_headers
+        )
+        assert resp.status_code == 200
+
+
+# ─── wee_runtime.py standalone tests ─────────────────────────────────────────
+
+class TestWeeRuntime:
+    """Tests for the wee_runtime.py standalone CLI functions."""
+
+    def setup_method(self):
+        """Import wee_runtime module."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            'wee_runtime',
+            '/opt/n8n-copilot-shim-dev/wee_runtime.py'
+        )
+        self.wr = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.wr)
+
+    def test_fetch_openrouter_pricing_cache_path(self):
+        """Pricing should be cached to /tmp/openrouter_pricing.json."""
+        mock_data = {
+            'data': [
+                {'id': 'google/gemini-flash-1.5', 'pricing': {'prompt': '0.000000075', 'completion': '0.0000003'}}
+            ]
+        }
+        with patch('builtins.open', mock_open(read_data=json.dumps(mock_data))), \
+             patch('os.path.exists', return_value=True), \
+             patch('os.path.getmtime', return_value=time.time()):
+            pricing = self.wr.fetch_openrouter_pricing()
+            assert isinstance(pricing, dict)
+
+    def test_calculate_cost_ollama(self):
+        """Ollama models should always be $0, label=local."""
+        cost, label = self.wr.calculate_cost('ollama/llama3', 500, 300, {})
+        assert cost == 0.0
+        assert label == 'local'
+
+    def test_calculate_cost_free_model(self):
+        """Unknown models not in pricing = free."""
+        cost, label = self.wr.calculate_cost('openrouter/some-free-model', 100, 50, {})
+        assert cost == 0.0
+        assert label == 'free'
+
+    def test_calculate_cost_paid_model(self):
+        """Paid model should multiply token counts by per-token price."""
+        pricing = {'google/gemini-flash-1.5': {'prompt': 0.000000075, 'completion': 0.0000003}}
+        cost, label = self.wr.calculate_cost('openrouter/google/gemini-flash-1.5', 1000, 500, pricing)
+        expected = (1000 * 0.000000075) + (500 * 0.0000003)
+        assert abs(cost - expected) < 1e-12
+        assert label.startswith('$')
+
+    def test_log_token_usage_creates_file(self):
+        """log_token_usage should create the log file if it doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / 'token_usage.jsonl'
+            with patch.object(self.wr, 'LOG_FILE', log_path):
+                self.wr.log_token_usage(
+                    session_id='test',
+                    model='ollama/llama3',
+                    provider='ollama',
+                    prompt_tokens=10,
+                    completion_tokens=5,
+                    total_tokens=15,
+                    cost_usd=0.0,
+                    duration_ms=500,
+                )
+            if log_path.exists():
+                with open(log_path) as f:
+                    entry = json.loads(f.readline())
+                assert entry['model'] == 'ollama/llama3'
+                assert entry['prompt_tokens'] == 10
+
+    def test_stream_options_included(self):
+        """wee_runtime should pass stream_options to the API."""
+        import inspect
+        source = inspect.getsource(self.wr)
+        assert 'stream_options' in source
+        assert 'include_usage' in source
+
+    def test_wee_meta_output_format(self):
+        """__WEE_META__ marker should be present in output code."""
+        import inspect
+        source = inspect.getsource(self.wr)
+        assert '__WEE_META__' in source
+
+
+# ─── app.js WebUI update tests ────────────────────────────────────────────────
+
+class TestAppJsUpdate:
+    """Verify that app.js was updated with token/cost display logic."""
+
+    def setup_method(self):
+        self.app_js = Path('/opt/n8n-copilot-shim-dev/webui/dist/app.js').read_text()
+
+    def test_buildTimingText_function_exists(self):
+        """buildTimingText function should be present in app.js."""
+        assert 'function buildTimingText(' in self.app_js
+
+    def test_buildTimingText_handles_wee_meta(self):
+        """buildTimingText should reference weeMeta/tokens/cost_label."""
+        assert 'weeMeta' in self.app_js
+        assert 'cost_label' in self.app_js
+        assert 'tokens' in self.app_js
+
+    def test_streaming_path_uses_buildTimingText(self):
+        """The streaming done handler should call buildTimingText."""
+        assert 'buildTimingText(elapsedSec, evt.wee_meta' in self.app_js
+
+    def test_renderMessage_accepts_weeMeta(self):
+        """renderMessage should accept weeMeta as 5th param."""
+        assert 'renderMessage(role, content, files = [], timing = null, weeMeta = null)' in self.app_js
+
+    def test_renderMessage_timing_uses_buildTimingText(self):
+        """renderMessage timing block should use buildTimingText."""
+        assert 'buildTimingText(timing, weeMeta)' in self.app_js
+
+    def test_copilot_label_handled(self):
+        """copilot-sdk label should be handled in buildTimingText."""
+        assert "copilot-sdk" in self.app_js or "copilot request" in self.app_js
+
+
+# ─── SSE done_payload wee_meta inclusion ─────────────────────────────────────
+
+class TestSSEDonePayload:
+    """Verify that SSE done_payload includes wee_meta."""
+
+    def test_wee_meta_in_stream_session(self):
+        """stream_session / done_payload should include wee_meta."""
+        am_path = Path('/opt/n8n-copilot-shim-dev/agent_manager.py')
+        source = am_path.read_text()
+        assert 'wee_meta' in source
+        # Verify SSE done path contains wee_meta key
+        assert '"wee_meta"' in source or "'wee_meta'" in source
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/test_wee_native_runtime.py
+++ b/tests/test_wee_native_runtime.py
@@ -180,7 +180,7 @@ class TestWeeRuntimeDispatch(unittest.TestCase):
         _run_wee_native_test(mgr, test_session, model="ollama/gemma4:e4b")
 
         init_kwargs = mock_openai_cls.call_args[1]
-        self.assertEqual(init_kwargs["base_url"], "http://192.168.1.101:11436/v1")
+        self.assertEqual(init_kwargs["base_url"], "http://192.168.1.101:11434/v1")
         self.assertEqual(init_kwargs["api_key"], "ollama")
 
     @patch("openai.OpenAI")

--- a/webui/dist/app.js
+++ b/webui/dist/app.js
@@ -2164,16 +2164,19 @@ async function sendMessageStreaming(query, sessionId) {
             if (streamBubble) {
               streamBubble.classList.remove('streaming');
               applyMarkdownToBubble(streamBubble, finalContent);
-              // Add timing indicator
-              const timingDiv = document.createElement('div');
-              timingDiv.className = 'message-timing';
-              timingDiv.textContent = `⏱️ Generated in ${elapsedSec.toFixed(1)}s`;
-              streamBubble.appendChild(timingDiv);
+              // Add timing/token info (Issue #128)
+              const _timingText = buildTimingText(elapsedSec, evt.wee_meta || null);
+              if (_timingText) {
+                const timingDiv = document.createElement('div');
+                timingDiv.className = 'message-timing';
+                timingDiv.textContent = _timingText;
+                streamBubble.appendChild(timingDiv);
+              }
               streamBubble.appendChild(createTtsButton(streamBubble));
               scrollToBottom();
             } else {
               // Command/no-chunk path: render fresh bubble
-              await renderMessage('assistant', finalContent, [], elapsedSec);
+              await renderMessage('assistant', finalContent, [], elapsedSec, evt.wee_meta || null);
             }
             return evt;  // caller can read runtime/model
 
@@ -2514,7 +2517,30 @@ async function loadEarlierMessages() {
   }
 }
 
-async function renderMessage(role, content, files = [], timing = null) {
+/**
+ * Build timing/token footer text for assistant messages (Issue #128).
+ */
+function buildTimingText(elapsedSec, weeMeta) {
+  const base = elapsedSec != null ? `Generated in ${elapsedSec.toFixed(1)}s` : null;
+  if (!weeMeta) return base ? `⏱️ ${base}` : '';
+  const runtime = weeMeta.runtime || '';
+  const tokens = weeMeta.tokens;
+  const costLabel = weeMeta.cost_label || '';
+  if (runtime === 'copilot-sdk' || costLabel === 'copilot') {
+    return base ? `⏱️ ${base} · copilot request` : 'copilot request';
+  }
+  if (tokens != null) {
+    const tokenStr = tokens.toLocaleString();
+    let costStr = '';
+    if (costLabel === 'local') costStr = ' · local';
+    else if (costLabel === 'free') costStr = ' · free';
+    else if (costLabel && costLabel.startsWith('$')) costStr = ` · ${costLabel}`;
+    return base ? `⏱️ ${base} · ${tokenStr} tokens${costStr}` : `${tokenStr} tokens${costStr}`;
+  }
+  return base ? `⏱️ ${base}` : '';
+}
+
+async function renderMessage(role, content, files = [], timing = null, weeMeta = null) {
   hide($('empty-state'));
 
   const container = $('messages');
@@ -2569,12 +2595,15 @@ async function renderMessage(role, content, files = [], timing = null) {
   // Make file paths clickable in all messages
   if (typeof linkifyFilePaths === 'function') linkifyFilePaths(bubble);
 
-  // Add timing indicator for assistant messages
-  if (role === 'assistant' && timing) {
-    const timingDiv = document.createElement('div');
-    timingDiv.className = 'message-timing';
-    timingDiv.textContent = `⏱️ Generated in ${timing.toFixed(1)}s`;
-    bubble.appendChild(timingDiv);
+  // Add timing/token info (Issue #128)
+  if (role === 'assistant' && (timing || weeMeta)) {
+    const _rmTimingText = buildTimingText(timing, weeMeta);
+    if (_rmTimingText) {
+      const timingDiv = document.createElement('div');
+      timingDiv.className = 'message-timing';
+      timingDiv.textContent = _rmTimingText;
+      bubble.appendChild(timingDiv);
+    }
   }
 
   // Add TTS play button for assistant messages

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -4,6 +4,9 @@
 Standalone CLI for use in background tasks. Streams response tokens to stdout.
 Supports Ollama, OpenRouter, LM Studio, and any OpenAI-compatible API.
 
+Issue #128: Adds token usage tracking, OpenRouter cost estimation,
+__WEE_META__ output line, and JSONL logging to ~/.copilot/logs/token_usage.jsonl.
+
 Usage:
     python3 wee_runtime.py --model MODEL --api-base URL [--api-key KEY] "PROMPT"
 """
@@ -13,14 +16,18 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 
 
 # Provider presets: prefix → (api_base, default_api_key)
 PROVIDER_PRESETS = {
-    "ollama": ("http://192.168.1.101:11436/v1", "ollama"),
+    "ollama": ("http://192.168.1.101:11434/v1", "ollama"),
     "openrouter": ("https://openrouter.ai/api/v1", None),
     "lmstudio": ("http://localhost:1234/v1", "lm-studio"),
 }
+
+# Log file for token usage
+LOG_FILE = Path.home() / ".copilot" / "logs" / "token_usage.jsonl"
 
 
 def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = None):
@@ -36,7 +43,6 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
     resolved_base = api_base
     resolved_key = api_key
 
-    # Check for provider prefix
     for prefix, (preset_base, preset_key) in PROVIDER_PRESETS.items():
         if model.lower().startswith(f"{prefix}/"):
             resolved_model = model[len(prefix) + 1:]
@@ -46,18 +52,15 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
                 resolved_key = preset_key
             break
 
-    # Defaults
     if not resolved_base:
         resolved_base = os.environ.get(
-            "WEE_API_BASE", "http://192.168.1.101:11436/v1"
+            "WEE_API_BASE", "http://192.168.1.101:11434/v1"
         )
     if not resolved_key:
-        # Try environment variables
         resolved_key = os.environ.get("WEE_API_KEY") or os.environ.get(
             "OPENROUTER_API_KEY"
         )
         if not resolved_key:
-            # Try keyring for OpenRouter
             if "openrouter" in (resolved_base or "").lower():
                 try:
                     import keyring
@@ -65,9 +68,121 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
                 except Exception:
                     pass
             if not resolved_key:
-                resolved_key = "ollama"  # Safe default for local endpoints
+                resolved_key = "ollama"
 
     return resolved_model, resolved_base, resolved_key
+
+
+def fetch_openrouter_pricing() -> dict:
+    """Fetch and cache OpenRouter model pricing (1h TTL).
+
+    Returns dict of {model_id: {prompt: float, completion: float}} per-token prices.
+    """
+    import urllib.request
+
+    cache_path = Path("/tmp/openrouter_pricing.json")
+    now = time.time()
+
+    if cache_path.exists() and (now - cache_path.stat().st_mtime) < 3600:
+        try:
+            with open(cache_path) as f:
+                return json.load(f)
+        except Exception:
+            pass
+
+    try:
+        with urllib.request.urlopen(
+            "https://openrouter.ai/api/v1/models", timeout=10
+        ) as resp:
+            data = json.loads(resp.read().decode())
+
+        pricing = {}
+        for model_info in data.get("data", []):
+            mid = model_info.get("id", "")
+            p = model_info.get("pricing", {})
+            try:
+                pricing[mid] = {
+                    "prompt": float(p.get("prompt", 0) or 0),
+                    "completion": float(p.get("completion", 0) or 0),
+                }
+            except (ValueError, TypeError):
+                pass
+
+        with open(cache_path, "w") as f:
+            json.dump(pricing, f)
+        return pricing
+    except Exception as e:
+        print(f"[wee_runtime] Could not fetch OpenRouter pricing: {e}", file=sys.stderr)
+        return {}
+
+
+def calculate_cost(model: str, prompt_tokens: int, completion_tokens: int, pricing: dict):
+    """Calculate USD cost and a display label for the given model and token counts.
+
+    Returns (cost_usd: float, label: str) where label is one of:
+        'local'    — Ollama or local endpoint
+        'free'     — OpenRouter free model
+        '$0.0001'  — paid model with calculated cost
+    """
+    model_lower = model.lower()
+
+    # Local/Ollama = free
+    if model_lower.startswith("ollama/") or "192.168" in model_lower:
+        return 0.0, "local"
+
+    # Strip provider prefix for pricing lookup
+    bare_model = model
+    for prefix in ("openrouter/", "lmstudio/", "wee/"):
+        if model_lower.startswith(prefix):
+            bare_model = model[len(prefix):]
+            break
+
+    if bare_model not in pricing:
+        return 0.0, "free"
+
+    p = pricing[bare_model]
+    cost = (prompt_tokens * p["prompt"]) + (completion_tokens * p["completion"])
+
+    if cost == 0.0:
+        return 0.0, "free"
+    if cost < 0.00001:
+        label = f"${cost:.8f}".rstrip("0")
+    elif cost < 0.001:
+        label = f"${cost:.6f}".rstrip("0")
+    else:
+        label = f"${cost:.4f}".rstrip("0").rstrip(".")
+    return cost, label
+
+
+def log_token_usage(
+    session_id: str,
+    model: str,
+    provider: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    total_tokens: int,
+    cost_usd: float,
+    duration_ms: int,
+):
+    """Append a usage entry to ~/.copilot/logs/token_usage.jsonl."""
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "timestamp": time.time(),
+            "session_id": session_id,
+            "model": model,
+            "runtime": "wee",
+            "provider": provider,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "cost_usd": cost_usd,
+            "duration_ms": duration_ms,
+        }
+        with open(LOG_FILE, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except Exception as e:
+        print(f"[wee_runtime] Failed to log usage: {e}", file=sys.stderr)
 
 
 def main():
@@ -80,6 +195,7 @@ def main():
     parser.add_argument("--system-prompt", default="", help="System prompt")
     parser.add_argument("--timeout", type=int, default=300, help="Request timeout in seconds")
     parser.add_argument("--temperature", type=float, default=None, help="Sampling temperature")
+    parser.add_argument("--session-id", default="", help="Session ID for usage logging")
     parser.add_argument("prompt", help="User prompt")
     args = parser.parse_args()
 
@@ -108,9 +224,13 @@ def main():
         "model": model,
         "messages": messages,
         "stream": True,
+        "stream_options": {"include_usage": True},
     }
     if args.temperature is not None:
         create_kwargs["temperature"] = args.temperature
+
+    start_time = time.time()
+    last_usage = None
 
     try:
         stream = client.chat.completions.create(**create_kwargs)
@@ -120,10 +240,50 @@ def main():
                 token = chunk.choices[0].delta.content
                 sys.stdout.write(token)
                 sys.stdout.flush()
+            # Capture usage from final chunk
+            if hasattr(chunk, "usage") and chunk.usage is not None:
+                last_usage = chunk.usage
 
-        # Final newline
         sys.stdout.write("\n")
         sys.stdout.flush()
+
+        # Compute token usage and cost (Issue #128)
+        duration_ms = int((time.time() - start_time) * 1000)
+
+        if last_usage is not None:
+            prompt_tokens = getattr(last_usage, "prompt_tokens", 0) or 0
+            completion_tokens = getattr(last_usage, "completion_tokens", 0) or 0
+            total_tokens = getattr(last_usage, "total_tokens", prompt_tokens + completion_tokens)
+
+            provider = "ollama" if "192.168" in api_base else ("openrouter" if "openrouter" in api_base else "wee")
+            pricing = fetch_openrouter_pricing() if provider == "openrouter" else {}
+            cost_usd, cost_label = calculate_cost(args.model, prompt_tokens, completion_tokens, pricing)
+
+            meta = {
+                "tokens": total_tokens,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "cost_usd": cost_usd,
+                "cost_label": cost_label,
+                "model": args.model,
+                "runtime": "wee",
+            }
+
+            # Output metadata line for backend to parse
+            print(f"__WEE_META__ {json.dumps(meta)}", flush=True)
+
+            # Log to JSONL
+            log_token_usage(
+                session_id=args.session_id or "cli",
+                model=args.model,
+                provider=provider,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+                cost_usd=cost_usd,
+                duration_ms=duration_ms,
+            )
+
     except KeyboardInterrupt:
         sys.exit(130)
     except Exception as e:


### PR DESCRIPTION
Implements token usage tracking for wee runtime with cost estimation and WebUI footer display.

## Changes
- **wee_runtime.py**: stream_options usage capture, OpenRouter pricing (1h cache), `calculate_cost()`, `log_token_usage()`, `__WEE_META__` output
- **agent_manager.py**: cost helper methods, `run_wee_native`/`run_claude_sdk` capture usage + store wee_meta, SSE done_payload includes wee_meta, new `GET /api/v1/usage` endpoint (period=today|7d|30d)
- **webui/dist/app.js**: `buildTimingText()` helper, footer shows: `Generated in 3.4s · 229 tokens · $0.0001` / `free` / `local`
- 28 new tests, 1170 total pass, 0 regressions

Closes #128