### PR TITLE
fix(#125): iterative 429 retry + configurable free model fallback chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1034,3 +1034,42 @@ compatibility with the existing `copilot` CLI runtime.
 ## Previous Releases
 
 (Historical releases documented when applicable)
+## [Issue #88] Feature: Wee Native Runtime — OpenAI-compatible API backend
+**Status:** Implementation Complete — 19 new tests, 1087 total pass
+
+### Overview
+Added a new `wee` runtime that connects to any OpenAI-compatible API endpoint
+(Ollama, OpenRouter, LM Studio, etc.) without depending on external CLI tools
+like GitHub Copilot CLI, Claude Code, or OpenCode.
+
+### Supported Backends
+- **Ollama** (Kubuntu) at `http://192.168.1.101:11436/v1` — local, free
+- **OpenRouter** at `https://openrouter.ai/api/v1` — cloud fallback, 100+ models
+- **LM Studio** at `http://localhost:1234/v1` — local alternative
+
+### Model Format
+Uses `provider/model_name` prefix syntax for auto-resolving API base URL and key:
+- `ollama/gemma4:e4b` — Ollama on Kubuntu (default)
+- `openrouter/meta-llama/llama-4-scout` — OpenRouter cloud
+- `lmstudio/qwen2.5-7b` — LM Studio local
+
+### Implementation Details
+- **`run_wee_native()`** — In-process method using OpenAI Python SDK with streaming
+- **`wee_runtime.py`** — Standalone CLI script for background task subprocess execution
+- Real-time SSE streaming to WebUI via `StreamBuffer.push()`
+- Provider presets auto-resolve API base URLs and API keys
+- `done` sentinel pushed on all exit paths (success and error)
+- Graceful error handling with informative messages
+
+### Files Changed
+- `agent_manager.py` — 17 touch points: runtime registration, dispatch, streaming,
+  model defaults, strip_metadata, background tasks
+- `wee_runtime.py` — NEW standalone CLI for background task execution
+- `tests/test_wee_native_runtime.py` — 19 comprehensive tests
+
+### Configuration
+```json
+{"runtime": "wee", "model": "ollama/gemma4:e4b"}
+```
+Environment variables: `WEE_API_BASE`, `WEE_API_KEY`, `WEE_DEFAULT_MODEL`
+

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -7734,66 +7734,36 @@ User Request:
 
     # ── End Issue #128 helpers ─────────────────────────────────────────────────
 
-    def run_wee_native(
-        self,
-        prompt: str,
-        model: str,
-        agent: str,
-        session_id: Optional[str],
-        resume: bool,
-        n8n_session_id: str,
-        timeout: Optional[int] = None,
-        render_type: str = "text",
-    ) -> str:
-        """Execute via Wee Native runtime - OpenAI-compatible chat completions.
 
-        Connects to any OpenAI-compatible API endpoint (Ollama, OpenRouter,
-        LM Studio, etc.) using the openai Python package. No external CLI
-        binary required.
+    # ---- Issue #125 helpers ------------------------------------------------
 
-        Model format: [provider/]model_name
-        Examples:
-            ollama/gemma4:e4b         - Ollama on Kubuntu
-            openrouter/meta-llama/llama-4-scout - OpenRouter cloud
-            gemma4:e4b                - Default endpoint (Ollama)
-
-        Supports real-time streaming to WebUI SSE consumers.
-        """
+    def _wee_load_free_config(self) -> dict:
+        """Load wee_free_models.json config. Returns defaults if file missing."""
         import json as _json
-
+        config_path = Path(__file__).parent / "wee_free_models.json"
         try:
-            from openai import OpenAI
-        except ImportError:
-            return (
-                "Error: openai package not installed. "
-                "Run: pip install openai"
-            )
+            with open(config_path) as f:
+                return _json.load(f)
+        except (FileNotFoundError, _json.JSONDecodeError):
+            return {
+                "max_retries_per_model": 3,
+                "retry_backoff_seconds": [2, 5, 10],
+                "free_model_fallback_chain": [],
+            }
 
-        session_data = self.get_or_create_session_data(n8n_session_id)
-        agent_dir = self.AGENTS.get(agent, self.AGENTS["orchestrator"])["path"]
-        effective_timeout = timeout if timeout is not None else self.command_timeout
-        channel = session_data.get("channel", "webui")
+    def _wee_is_free_model(self, model: str) -> bool:
+        """Return True if model is an OpenRouter :free model."""
+        return ":free" in model.lower() and "openrouter" in model.lower()
 
-        # Build context prompt with agent identity
-        context_prompt = self.build_agent_context_prompt(
-            prompt, agent, channel, n8n_session_id
-        )
-
-        # -- Resolve model, endpoint, and API key --
-        api_base = session_data.get("api_base") or os.environ.get(
-            "WEE_API_BASE"
-        )
-        api_key = session_data.get("api_key") or os.environ.get(
-            "WEE_API_KEY"
-        )
-
-        # Provider presets
+    def _wee_resolve_endpoint(self, model, session_api_base, session_api_key):
+        """Resolve (api_base, api_key, resolved_model) for a wee model string."""
         _PRESETS = {
             "ollama": ("http://192.168.1.101:11434/v1", "ollama"),
             "openrouter": ("https://openrouter.ai/api/v1", None),
             "lmstudio": ("http://localhost:1234/v1", "lm-studio"),
         }
-
+        api_base = session_api_base or os.environ.get("WEE_API_BASE")
+        api_key = session_api_key or os.environ.get("WEE_API_KEY")
         resolved_model = model
         for prefix, (preset_base, preset_key) in _PRESETS.items():
             if model.lower().startswith(f"{prefix}/"):
@@ -7803,11 +7773,9 @@ User Request:
                 if not api_key and preset_key:
                     api_key = preset_key
                 break
-
         if not api_base:
-            api_base = "http://192.168.1.101:11436/v1"
+            api_base = "http://192.168.1.101:11434/v1"
         if not api_key:
-            # Try keyring for OpenRouter
             if "openrouter" in api_base.lower():
                 try:
                     import keyring
@@ -7816,102 +7784,253 @@ User Request:
                     pass
             if not api_key:
                 api_key = "ollama"
+        return api_base, api_key, resolved_model
 
-        print(
-            f"[Wee Native] model={resolved_model} api_base={api_base} "
-            f"session={n8n_session_id[:8]}...",
-            file=sys.stderr,
-        )
+    # ---- End Issue #125 helpers ---------------------------------------------
 
-        # -- Streaming infrastructure --
-        stream_buffer = getattr(self, "_stream_buffers", {}).get(n8n_session_id)
 
-        # -- Create OpenAI client and call API --
-        client = OpenAI(
-            base_url=api_base,
-            api_key=api_key,
-            timeout=effective_timeout,
-        )
+    # ---- Issue #125 helpers ------------------------------------------------
 
-        messages = []
-        # System prompt from agent context
-        if context_prompt:
-            messages.append({"role": "system", "content": context_prompt})
-        messages.append({"role": "user", "content": prompt})
+    def _wee_load_free_config(self) -> dict:
+        """Load wee_free_models.json config. Returns defaults if file missing."""
+        import json as _json
+        config_path = Path(__file__).parent / "wee_free_models.json"
+        try:
+            with open(config_path) as f:
+                return _json.load(f)
+        except (FileNotFoundError, _json.JSONDecodeError):
+            return {
+                "max_retries_per_model": 3,
+                "retry_backoff_seconds": [2, 5, 10],
+                "free_model_fallback_chain": [],
+            }
 
-        collected_output = []
+    def _wee_is_free_model(self, model: str) -> bool:
+        """Return True if model is an OpenRouter :free model."""
+        return ":free" in model.lower() and "openrouter" in model.lower()
+
+    def _wee_resolve_endpoint(self, model, session_api_base, session_api_key):
+        """Resolve (api_base, api_key, resolved_model) for a wee model string."""
+        _PRESETS = {
+            "ollama": ("http://192.168.1.101:11434/v1", "ollama"),
+            "openrouter": ("https://openrouter.ai/api/v1", None),
+            "lmstudio": ("http://localhost:1234/v1", "lm-studio"),
+        }
+        api_base = session_api_base or os.environ.get("WEE_API_BASE")
+        api_key = session_api_key or os.environ.get("WEE_API_KEY")
+        resolved_model = model
+        for prefix, (preset_base, preset_key) in _PRESETS.items():
+            if model.lower().startswith(f"{prefix}/"):
+                resolved_model = model[len(prefix) + 1:]
+                if not api_base:
+                    api_base = preset_base
+                if not api_key and preset_key:
+                    api_key = preset_key
+                break
+        if not api_base:
+            api_base = "http://192.168.1.101:11434/v1"
+        if not api_key:
+            if "openrouter" in api_base.lower():
+                try:
+                    import keyring
+                    api_key = keyring.get_password("openrouter", "api_key")
+                except Exception:
+                    pass
+            if not api_key:
+                api_key = "ollama"
+        return api_base, api_key, resolved_model
+
+    # ---- End Issue #125 helpers ---------------------------------------------
+
+    def run_wee_native(
+        self,
+        prompt: str,
+        model: str,
+        agent: str,
+        session_id,
+        resume: bool,
+        n8n_session_id: str,
+        timeout=None,
+        render_type: str = "text",
+    ) -> str:
+        """Execute via Wee Native runtime - OpenAI-compatible chat completions.
+
+        Issue #125: 429 retry with backoff + iterative model fallback chain.
+        Uses a for-loop over fallback models — no recursion (fixes B01).
+        Fallback switches are streamed to user for visibility (fixes B02).
+        time.sleep is safe: sync function runs in thread-pool worker (M01).
+        """
+        import json as _json
+        import time as _time
 
         try:
-            import time as _time
-            _wee_start = _time.time()
-            _last_usage = [None]
+            from openai import OpenAI
+        except ImportError:
+            return "Error: openai package not installed. Run: pip install openai"
 
-            stream = client.chat.completions.create(
-                model=resolved_model,
-                messages=messages,
-                stream=True,
-                stream_options={"include_usage": True},
+        session_data = self.get_or_create_session_data(n8n_session_id)
+        effective_timeout = timeout if timeout is not None else self.command_timeout
+        channel = session_data.get("channel", "webui")
+        context_prompt = self.build_agent_context_prompt(prompt, agent, channel, n8n_session_id)
+        _sess_api_base = session_data.get("api_base")
+        _sess_api_key = session_data.get("api_key")
+
+        # Issue #125: build iterative fallback chain (B01: no recursion)
+        _free_cfg = self._wee_load_free_config()
+        _max_retries = _free_cfg.get("max_retries_per_model", 3)
+        _backoff = _free_cfg.get("retry_backoff_seconds", [2, 5, 10])
+        _is_free = self._wee_is_free_model(model)
+        if _is_free:
+            _chain_raw = _free_cfg.get("free_model_fallback_chain", [])
+            _chain = [model] + [m for m in _chain_raw if m.lower() != model.lower()]
+        else:
+            _chain = [model]
+
+        stream_buffer = getattr(self, "_stream_buffers", {}).get(n8n_session_id)
+
+        for _chain_idx, _attempt_model in enumerate(_chain):
+            if _chain_idx > 0:
+                # B02: surface fallback model switch to user
+                _fb_short = _attempt_model.split("/")[-1]
+                _fb_msg = (
+                    "\n\u26a0\ufe0f Rate limited \u2014 switching to fallback model "
+                    + _fb_short
+                    + " ("
+                    + str(_chain_idx)
+                    + "/"
+                    + str(len(_chain) - 1)
+                    + ")...\n"
+                )
+                print("[Wee Native] " + _fb_msg.strip(), file=sys.stderr)
+                if stream_buffer:
+                    stream_buffer.push("chunk", {"text": _fb_msg})
+
+            api_base, api_key, resolved_model = self._wee_resolve_endpoint(
+                _attempt_model, _sess_api_base, _sess_api_key
             )
-
-            for chunk in stream:
-                if chunk.choices and chunk.choices[0].delta.content:
-                    token = chunk.choices[0].delta.content
-                    collected_output.append(token)
-                    if stream_buffer:
-                        stream_buffer.push("chunk", {"text": token})
-                if hasattr(chunk, "usage") and chunk.usage is not None:
-                    _last_usage[0] = chunk.usage
-
-            output = "".join(collected_output)
-
-            # Compute cost + attach wee_meta (Issue #128)
-            try:
-                _duration_ms = int((_time.time() - _wee_start) * 1000)
-                if _last_usage[0] is not None:
-                    _u = _last_usage[0]
-                    _prompt_tokens = getattr(_u, "prompt_tokens", 0) or 0
-                    _completion_tokens = getattr(_u, "completion_tokens", 0) or 0
-                    _total = getattr(_u, "total_tokens", _prompt_tokens + _completion_tokens)
-                    _provider = "ollama" if "192.168" in api_base else ("openrouter" if "openrouter" in api_base else "wee")
-                    _pricing = self._fetch_openrouter_pricing() if _provider == "openrouter" else {}
-                    _cost_usd, _cost_label = self._calculate_wee_cost(model, _prompt_tokens, _completion_tokens, _pricing)
-                    _wee_meta = {
-                        "tokens": _total,
-                        "prompt_tokens": _prompt_tokens,
-                        "completion_tokens": _completion_tokens,
-                        "cost_usd": _cost_usd,
-                        "cost_label": _cost_label,
-                        "model": model,
-                        "runtime": "wee",
-                    }
-                    self.update_session_field(n8n_session_id, "wee_meta", _wee_meta)
-                    self._log_token_usage(
-                        session_id=n8n_session_id, model=model, runtime="wee",
-                        provider=_provider, prompt_tokens=_prompt_tokens,
-                        completion_tokens=_completion_tokens, total_tokens=_total,
-                        cost_usd=_cost_usd, duration_ms=_duration_ms,
-                    )
-            except Exception as _meta_err:
-                print(f"[Wee Native] wee_meta error: {_meta_err}", file=sys.stderr)
-
-            if stream_buffer:
-                stream_buffer.push("done", output)
-
             print(
-                f"[Wee Native] Completed. Output length: {len(output)} chars",
+                "[Wee Native] model=" + resolved_model + " api_base=" + api_base
+                + " session=" + n8n_session_id[:8] + "..."
+                + " (chain " + str(_chain_idx + 1) + "/" + str(len(_chain)) + ")",
                 file=sys.stderr,
             )
-            return output
 
-        except Exception as e:
-            error_msg = f"Error: Wee native runtime failed: {e}"
-            print(f"[Wee Native] {error_msg}", file=sys.stderr)
+            import httpx as _httpx_wee
+            client = OpenAI(
+                base_url=api_base,
+                api_key=api_key,
+                timeout=_httpx_wee.Timeout(
+                    connect=15.0, read=float(effective_timeout), write=30.0, pool=15.0
+                ),
+                max_retries=0,
+            )
+            messages = []
+            if context_prompt:
+                messages.append({"role": "system", "content": context_prompt})
+            messages.append({"role": "user", "content": prompt})
 
-            # Push error as done sentinel
-            if stream_buffer:
-                stream_buffer.push("done", error_msg)
+            collected_output = []
+            _got_429 = False
+            _wee_start = _time.time()
+            _last_usage = [None]
+            _max_attempts = _max_retries if _is_free else 1
 
-            return error_msg
+            for _retry in range(_max_attempts):
+                try:
+                    stream = client.chat.completions.create(
+                        model=resolved_model,
+                        messages=messages,
+                        stream=True,
+                        stream_options={"include_usage": True},
+                    )
+                    for chunk in stream:
+                        if chunk.choices and chunk.choices[0].delta.content:
+                            token = chunk.choices[0].delta.content
+                            collected_output.append(token)
+                            if stream_buffer:
+                                stream_buffer.push("chunk", {"text": token})
+                        if hasattr(chunk, "usage") and chunk.usage is not None:
+                            _last_usage[0] = chunk.usage
+                    _got_429 = False
+                    break  # success
+
+                except Exception as _e:
+                    _e_str = str(_e)
+                    _is_rate_limit = "429" in _e_str or "rate limit" in _e_str.lower()
+                    if _is_rate_limit and _is_free:
+                        _got_429 = True
+                        if _retry < _max_attempts - 1:
+                            _wait = (
+                                _backoff[_retry] if _retry < len(_backoff)
+                                else (_backoff[-1] if _backoff else 5)
+                            )
+                            _retry_msg = (
+                                "\n\u26a0\ufe0f Rate limited, retrying in "
+                                + str(_wait)
+                                + "s ("
+                                + str(_retry + 1)
+                                + "/"
+                                + str(_max_attempts)
+                                + ")...\n"
+                            )
+                            print("[Wee Native] " + _retry_msg.strip(), file=sys.stderr)
+                            if stream_buffer:
+                                stream_buffer.push("chunk", {"text": _retry_msg})
+                            # M01: time.sleep is correct here — sync function in thread-pool worker
+                            _time.sleep(_wait)
+                    else:
+                        error_msg = "Error: Wee native runtime failed: " + str(_e)
+                        print("[Wee Native] " + error_msg, file=sys.stderr)
+                        if stream_buffer:
+                            stream_buffer.push("done", error_msg)
+                        return error_msg
+
+            if not _got_429:
+                output = "".join(collected_output)
+                try:
+                    _duration_ms = int((_time.time() - _wee_start) * 1000)
+                    if _last_usage[0] is not None:
+                        _u = _last_usage[0]
+                        _pt = getattr(_u, "prompt_tokens", 0) or 0
+                        _ct = getattr(_u, "completion_tokens", 0) or 0
+                        _total = getattr(_u, "total_tokens", _pt + _ct)
+                        _provider = (
+                            "ollama" if "192.168" in api_base else
+                            "openrouter" if "openrouter" in api_base else "wee"
+                        )
+                        _pricing = self._fetch_openrouter_pricing() if _provider == "openrouter" else {}
+                        _cost_usd, _cost_label = self._calculate_wee_cost(
+                            _attempt_model, _pt, _ct, _pricing
+                        )
+                        self.update_session_field(n8n_session_id, "wee_meta", {
+                            "tokens": _total, "prompt_tokens": _pt,
+                            "completion_tokens": _ct, "cost_usd": _cost_usd,
+                            "cost_label": _cost_label, "model": _attempt_model, "runtime": "wee",
+                        })
+                        self._log_token_usage(
+                            session_id=n8n_session_id, model=_attempt_model, runtime="wee",
+                            provider=_provider, prompt_tokens=_pt, completion_tokens=_ct,
+                            total_tokens=_total, cost_usd=_cost_usd, duration_ms=_duration_ms,
+                        )
+                except Exception as _meta_err:
+                    print("[Wee Native] wee_meta error: " + str(_meta_err), file=sys.stderr)
+
+                if stream_buffer:
+                    stream_buffer.push("done", output)
+                print("[Wee Native] Completed. Output length: " + str(len(output)) + " chars", file=sys.stderr)
+                return output
+            # _got_429=True — continue outer loop to next fallback model
+
+        # B01: all models exhausted — iterative approach, no stack overflow
+        exhausted_msg = (
+            "\n\u274c All free model fallbacks exhausted. "
+            "Please try again later or switch to a paid model.\n"
+        )
+        print("[Wee Native] " + exhausted_msg.strip(), file=sys.stderr)
+        if stream_buffer:
+            stream_buffer.push("done", exhausted_msg)
+        return exhausted_msg
+
 
     def _get_cursor_session_id(self, n8n_session_id: str) -> Optional[str]:
         """Return the stored cursor session flag for this n8n session, or None."""

--- a/tests/test_issue125_429_retry.py
+++ b/tests/test_issue125_429_retry.py
@@ -1,0 +1,309 @@
+"""
+Regression tests for Issue #125 — 429 retry + free model fallback chain.
+Tests: B01 (no recursion), B02 (user visibility), M01 (sync sleep), M03 (coverage).
+"""
+import os
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_123")
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from agent_manager import SessionManager
+
+
+def _make_mgr():
+    """Create a minimal SessionManager for Issue #125 testing."""
+    mgr = SessionManager.__new__(SessionManager)
+    mgr.session_map = {}
+    mgr._session_map_lock = threading.Lock()
+    mgr.command_timeout = 60
+    mgr._stream_buffers = {}
+    mgr.AGENTS = {"test": {"path": "/opt", "description": "test"}}
+    return mgr
+
+
+def _make_chunk(text):
+    chunk = MagicMock()
+    chunk.choices = [MagicMock()]
+    chunk.choices[0].delta.content = text
+    chunk.usage = None
+    return chunk
+
+
+def _make_done_chunk():
+    chunk = MagicMock()
+    chunk.choices = []
+    chunk.usage = MagicMock()
+    chunk.usage.prompt_tokens = 10
+    chunk.usage.completion_tokens = 20
+    chunk.usage.total_tokens = 30
+    return chunk
+
+
+class TestIssue125RetryFallbackChain(unittest.TestCase):
+    """Main regression tests for B01/B02/M01/M03."""
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+        self.mgr.get_or_create_session_data = MagicMock(return_value={
+            "channel": "test", "api_base": None, "api_key": None
+        })
+        self.mgr.build_agent_context_prompt = MagicMock(return_value="")
+        self.mgr.update_session_field = MagicMock()
+        self.mgr._fetch_openrouter_pricing = MagicMock(return_value={})
+        self.mgr._calculate_wee_cost = MagicMock(return_value=(0.0, "free"))
+        self.mgr._log_token_usage = MagicMock()
+
+    @patch("agent_manager.time.sleep")
+    @patch("openai.OpenAI")
+    def test_issue_125_retry_fallback_chain(self, mock_openai_cls, mock_sleep):
+        """Main regression: 429 retries exhaust on primary, then falls back to next model."""
+        free_cfg = {
+            "max_retries_per_model": 2,
+            "retry_backoff_seconds": [1, 2],
+            "free_model_fallback_chain": [
+                "openrouter/primary:free",
+                "openrouter/fallback:free",
+            ],
+        }
+        self.mgr._wee_load_free_config = MagicMock(return_value=free_cfg)
+
+        call_tracker = []
+        err_429 = Exception("429 rate limit exceeded")
+
+        def stream_side_effect(*a, **kw):
+            model_arg = kw.get("model", "unknown")
+            call_tracker.append(model_arg)
+            if "primary" in model_arg:
+                raise err_429
+            return iter([_make_chunk("fallback works"), _make_done_chunk()])
+
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create.side_effect = stream_side_effect
+        mock_openai_cls.return_value = mock_instance
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_wee_native(
+                prompt="test prompt",
+                model="openrouter/primary:free",
+                agent="test",
+                session_id="s1",
+                resume=False,
+                n8n_session_id="n2",
+            )
+
+        self.assertIn("fallback works", result)
+        # primary was tried max_retries times before switching
+        primary_calls = [c for c in call_tracker if "primary" in c]
+        self.assertEqual(len(primary_calls), 2, "Should retry primary 2x before fallback")
+
+    @patch("agent_manager.time.sleep")
+    @patch("openai.OpenAI")
+    def test_issue_125_all_fallbacks_exhausted_no_crash(self, mock_openai_cls, mock_sleep):
+        """B01: When all fallbacks are 429, return error message (no stack overflow)."""
+        free_cfg = {
+            "max_retries_per_model": 1,
+            "retry_backoff_seconds": [1],
+            "free_model_fallback_chain": ["openrouter/b:free"],
+        }
+        self.mgr._wee_load_free_config = MagicMock(return_value=free_cfg)
+
+        err_429 = Exception("429 rate limit")
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create.side_effect = err_429
+        mock_openai_cls.return_value = mock_instance
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_wee_native(
+                prompt="test",
+                model="openrouter/primary:free",
+                agent="test",
+                session_id="s1",
+                resume=False,
+                n8n_session_id="n3",
+            )
+
+        self.assertIn("exhausted", result.lower())
+
+    @patch("agent_manager.time.sleep")
+    @patch("openai.OpenAI")
+    def test_issue_125_fallback_notification_in_stream(self, mock_openai_cls, mock_sleep):
+        """B02: stream buffer should receive fallback notification message."""
+        free_cfg = {
+            "max_retries_per_model": 1,
+            "retry_backoff_seconds": [1],
+            "free_model_fallback_chain": [
+                "openrouter/primary:free",
+                "openrouter/backup:free",
+            ],
+        }
+        self.mgr._wee_load_free_config = MagicMock(return_value=free_cfg)
+
+        stream_buf = MagicMock()
+        self.mgr._stream_buffers = {"n4": stream_buf}
+
+        err_429 = Exception("429 rate limit")
+        attempt = [0]
+
+        def stream_side_effect(*a, **kw):
+            attempt[0] += 1
+            if attempt[0] == 1:
+                raise err_429
+            return iter([_make_chunk("backup ok"), _make_done_chunk()])
+
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create.side_effect = stream_side_effect
+        mock_openai_cls.return_value = mock_instance
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_wee_native(
+                prompt="test",
+                model="openrouter/primary:free",
+                agent="test",
+                session_id="s1",
+                resume=False,
+                n8n_session_id="n4",
+            )
+
+        push_calls = stream_buf.push.call_args_list
+        fallback_pushed = any(
+            any(kw in str(c).lower() for kw in ("fallback", "rate limited", "switching"))
+            for c in push_calls
+        )
+        self.assertTrue(fallback_pushed, "B02: fallback notification must be pushed to stream buffer")
+        self.assertIn("backup ok", result)
+
+    @patch("agent_manager.time.sleep")
+    @patch("openai.OpenAI")
+    def test_issue_125_non_free_model_no_fallback(self, mock_openai_cls, mock_sleep):
+        """Non-:free models must NOT use the fallback chain."""
+        free_cfg = {
+            "max_retries_per_model": 3,
+            "retry_backoff_seconds": [1, 2, 5],
+            "free_model_fallback_chain": ["openrouter/b:free", "openrouter/c:free"],
+        }
+        self.mgr._wee_load_free_config = MagicMock(return_value=free_cfg)
+
+        err_429 = Exception("429 rate limit")
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create.side_effect = err_429
+        mock_openai_cls.return_value = mock_instance
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_wee_native(
+                prompt="test",
+                model="ollama/llama3",
+                agent="test",
+                session_id="s1",
+                resume=False,
+                n8n_session_id="n5",
+            )
+
+        # Should get a non-429 error (non-free model, no fallback)
+        self.assertIn("Error", result)
+        # sleep should NOT be called (non-free models don't retry)
+        mock_sleep.assert_not_called()
+
+    @patch("agent_manager.time.sleep")
+    @patch("openai.OpenAI")
+    def test_issue_125_sleep_called_on_retry(self, mock_openai_cls, mock_sleep):
+        """M01: time.sleep (not asyncio.sleep) must be called between retries."""
+        free_cfg = {
+            "max_retries_per_model": 2,
+            "retry_backoff_seconds": [3, 7],
+            "free_model_fallback_chain": ["openrouter/primary:free"],
+        }
+        self.mgr._wee_load_free_config = MagicMock(return_value=free_cfg)
+
+        attempt = [0]
+        err_429 = Exception("429 rate limit")
+
+        def stream_side_effect(*a, **kw):
+            attempt[0] += 1
+            if attempt[0] < 2:
+                raise err_429
+            return iter([_make_chunk("ok"), _make_done_chunk()])
+
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create.side_effect = stream_side_effect
+        mock_openai_cls.return_value = mock_instance
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_wee_native(
+                prompt="test",
+                model="openrouter/primary:free",
+                agent="test",
+                session_id="s1",
+                resume=False,
+                n8n_session_id="n6",
+            )
+
+        self.assertIn("ok", result)
+        # sleep should have been called with the backoff value
+        mock_sleep.assert_called()
+        sleep_args = [c[0][0] for c in mock_sleep.call_args_list]
+        self.assertIn(3, sleep_args, "Should sleep 3s per backoff config")
+
+
+class TestIssue125HelperMethods(unittest.TestCase):
+    """Unit tests for _wee_load_free_config, _wee_is_free_model, _wee_resolve_endpoint."""
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+
+    def test_issue_125_config_file_exists(self):
+        """wee_free_models.json config file must exist in repo root."""
+        import json
+        config_path = REPO / "wee_free_models.json"
+        self.assertTrue(config_path.exists(), "wee_free_models.json must exist")
+        with open(config_path) as f:
+            cfg = json.load(f)
+        self.assertIn("free_model_fallback_chain", cfg)
+        self.assertIn("max_retries_per_model", cfg)
+        self.assertIn("retry_backoff_seconds", cfg)
+        self.assertIsInstance(cfg["free_model_fallback_chain"], list)
+
+    def test_issue_125_config_default_on_missing(self):
+        """_wee_load_free_config must return defaults if file missing."""
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            result = self.mgr._wee_load_free_config()
+        self.assertIn("free_model_fallback_chain", result)
+        self.assertIn("max_retries_per_model", result)
+
+    def test_issue_125_free_model_detection(self):
+        """_wee_is_free_model must correctly identify :free models."""
+        self.assertTrue(self.mgr._wee_is_free_model("openrouter/anthropic/claude-3-haiku:free"))
+        self.assertTrue(self.mgr._wee_is_free_model("openrouter/mistral/mistral-7b-instruct:free"))
+        self.assertFalse(self.mgr._wee_is_free_model("ollama/llama3.2"))
+        self.assertFalse(self.mgr._wee_is_free_model("anthropic/claude-3-haiku"))
+
+    def test_issue_125_resolve_endpoint_ollama(self):
+        """_wee_resolve_endpoint must resolve ollama/ prefix correctly."""
+        base, key, model = self.mgr._wee_resolve_endpoint("ollama/llama3.2", None, None)
+        self.assertIn("11434", base)
+        self.assertEqual(model, "llama3.2")
+
+    def test_issue_125_resolve_endpoint_openrouter(self):
+        """_wee_resolve_endpoint must resolve openrouter/ prefix correctly."""
+        base, key, model = self.mgr._wee_resolve_endpoint(
+            "openrouter/anthropic/claude:free", None, None
+        )
+        self.assertIn("openrouter.ai", base)
+        self.assertEqual(model, "anthropic/claude:free")
+
+    def test_issue_125_time_sleep_not_asyncio_sleep(self):
+        """M01: run_wee_native must use time.sleep, not asyncio.sleep."""
+        import inspect
+        src = inspect.getsource(SessionManager.run_wee_native)
+        self.assertIn("_time.sleep", src, "Must use time.sleep via _time alias")
+        self.assertNotIn("asyncio.sleep", src, "Must NOT use asyncio.sleep in sync function")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/wee_free_models.json
+++ b/wee_free_models.json
@@ -1,0 +1,17 @@
+{
+  "max_retries_per_model": 3,
+  "retry_backoff_seconds": [2, 5, 10],
+  "free_model_fallback_chain": [
+    "openrouter/meta-llama/llama-4-scout:free",
+    "openrouter/meta-llama/llama-4-maverick:free",
+    "openrouter/mistralai/mistral-7b-instruct:free",
+    "openrouter/google/gemma-3-27b-it:free",
+    "openrouter/microsoft/phi-4-reasoning:free",
+    "openrouter/deepseek/deepseek-r1:free",
+    "openrouter/qwen/qwen3-8b:free",
+    "openrouter/qwen/qwq-32b:free",
+    "openrouter/nvidia/llama-3.1-nemotron-ultra-253b:free",
+    "openrouter/google/gemma-3n-e4b-it:free",
+    "openrouter/google/gemma-3-12b-it:free"
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes Issue #125 — 429 retry with backoff + free model fallback chain for wee native runtime.

## QA Rejection Fixes

### B01 FIXED: Infinite recursion → iterative for-loop
- Replaced recursive `run_wee_native(model=next_model)` calls with `for _chain_idx, _attempt_model in enumerate(_chain)` loop
- All fallbacks exhausted → returns error message, no stack overflow

### B02 FIXED: Silent fallback → user notification
- Streams `⚠️ Rate limited — switching to fallback model X (N/total)...` at each switch
- Pushed to stream buffer for WebUI visibility

### M01 ADDRESSED: Sync sleep
- `time.sleep` is correct here: `run_wee_native` is a sync function called in a thread-pool worker via FastAPI's `run_in_executor`. Using `asyncio.sleep` would be wrong. Added comment explaining this.

### M02 ADDRESSED: Configurable fallback order
- New file: `wee_free_models.json` — configures fallback chain (11 models), max_retries, backoff

### M03 FIXED: Regression tests
- `tests/test_issue125_429_retry.py` — 11 tests covering all scenarios

## New Files
- `wee_free_models.json`: configurable fallback chain of 11 OpenRouter :free models, max_retries=3, backoff=[2,5,10]s
- `tests/test_issue125_429_retry.py`: 11 regression tests

## Test Results
- 11/11 issue/125 tests pass
- 1223 total tests pass, 0 regressions

Closes #125