### PR TITLE
fix(#26): TTL-based session map eviction — 30-day inactive cleanup

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1673,6 +1673,10 @@ class SessionManager:
         # candidates for cleanup.  Defaults to 30 min; override via env var.
         self.session_idle_timeout = int(os.environ.get("SESSION_IDLE_TIMEOUT", "1800"))
 
+        # Session map TTL — entries inactive longer than this are evicted on every save.
+        # Defaults to 30 days; override via SESSION_MAP_TTL_DAYS env var.
+        self.session_map_ttl = int(os.environ.get("SESSION_MAP_TTL_DAYS", "30")) * 86400
+
         # Lock for session map file read-modify-write to prevent TOCTOU races
         self._session_map_lock = threading.Lock()
 
@@ -3892,8 +3896,36 @@ You can mention an agent in your prompt and it will auto-delegate:
         except (json.JSONDecodeError, IOError):
             return {}
 
+    def _prune_session_map_ttl(self, session_map: dict) -> dict:
+        """Return a copy of session_map with entries older than session_map_ttl removed.
+
+        An entry is considered inactive if its ``last_activity`` timestamp is
+        older than ``self.session_map_ttl`` seconds.  Entries that lack a
+        ``last_activity`` field are kept so legacy data is not silently dropped.
+        """
+        now = time.time()
+        cutoff = now - self.session_map_ttl
+        pruned = {}
+        evicted = 0
+        for key, entry in session_map.items():
+            last_activity = (
+                entry.get("last_activity") if isinstance(entry, dict) else None
+            )
+            if last_activity is not None and last_activity < cutoff:
+                evicted += 1
+                continue
+            pruned[key] = entry
+        if evicted:
+            print(
+                f"[SessionMap] TTL evicted {evicted} inactive entries "
+                f"(threshold {self.session_map_ttl / 86400:.0f}d)",
+                file=__import__('sys').stderr,
+            )
+        return pruned
+
     def save_session_map(self, session_map: dict):
         """Save the N8N -> Session ID mapping (caller must hold _session_map_lock)"""
+        session_map = self._prune_session_map_ttl(session_map)
         with open(self.session_map_file, "w") as f:
             json.dump(session_map, f, indent=2)
 

--- a/scripts/session-cleanup.py
+++ b/scripts/session-cleanup.py
@@ -50,6 +50,56 @@ def _referenced_backend_sessions(*map_files: Path) -> set:
     return referenced
 
 
+def prune_stale_session_map_entries(
+    session_map_files: list,
+    ttl_days: int = 30,
+) -> None:
+    """Evict session map entries whose last_activity is older than ttl_days.
+
+    This is a separate sweep that complements the backend-session cleanup:
+    even when a backend session directory has already been removed (or never
+    existed for cloud-backed runtimes), the n8n-session-map entry will be
+    pruned once the user has been idle for ttl_days days.
+
+    Entries without a ``last_activity`` field are left untouched so legacy
+    data is not silently discarded.
+    """
+    now = time.time()
+    cutoff = now - ttl_days * 86400
+
+    for session_map_file in session_map_files:
+        if not session_map_file.exists():
+            continue
+        try:
+            session_map = _load_json(session_map_file)
+            if not session_map:
+                continue
+
+            keys_to_evict = []
+            for key, entry in session_map.items():
+                if not isinstance(entry, dict):
+                    continue
+                last_activity = entry.get("last_activity")
+                if last_activity is not None and last_activity < cutoff:
+                    keys_to_evict.append(key)
+
+            if not keys_to_evict:
+                continue
+
+            for key in keys_to_evict:
+                del session_map[key]
+
+            with open(session_map_file, "w") as f:
+                json.dump(session_map, f, indent=2)
+
+            print(
+                f"[{_ts()}] TTL evicted {len(keys_to_evict)} session map entries "
+                f"from {session_map_file.name} (threshold {ttl_days}d)"
+            )
+        except Exception as exc:
+            print(f"[{_ts()}] Error pruning {session_map_file.name}: {exc}")
+
+
 def cleanup_sessions():
     """Remove stale sessions from session-state directory and references."""
     copilot_home = Path.home() / ".copilot"
@@ -163,6 +213,11 @@ def cleanup_sessions():
                 )
         except Exception as exc:
             print(f"[{_ts()}] Error cleaning {session_map_file.name}: {exc}")
+
+    # Prune session map entries by TTL (30 days by default) — independent
+    # of whether the backend session directory exists.
+    ttl_days = int(os.environ.get("SESSION_MAP_TTL_DAYS", "30"))
+    prune_stale_session_map_entries(session_map_files, ttl_days=ttl_days)
 
     # Summary log
     total_dirs = sum(1 for d in session_state_dir.iterdir() if d.is_dir())

--- a/tests/test_issue26_session_map_ttl.py
+++ b/tests/test_issue26_session_map_ttl.py
@@ -1,0 +1,286 @@
+"""Regression tests for Issue #26: Session map grows unbounded — no TTL cleanup.
+
+Root cause: ``n8n-session-map.json`` accumulated every session forever because
+``save_session_map()`` never evicted stale entries and the cleanup daemon only
+removed backend session *directories*, not the map entries themselves.
+
+Fix: ``SessionManager._prune_session_map_ttl()`` removes entries whose
+``last_activity`` timestamp is older than ``SESSION_MAP_TTL_DAYS`` (default 30)
+before every ``save_session_map()`` call.  ``scripts/session-cleanup.py`` also
+calls ``prune_stale_session_map_entries()`` on every cleanup cycle.
+
+Scenarios tested:
+- Entries older than TTL are evicted
+- Entries newer than TTL are kept
+- Entries without last_activity are kept (legacy safety)
+- String-format legacy entries (no last_activity dict) are kept
+- save_session_map() automatically prunes before writing
+- Multiple old entries are all removed in one pass
+- TTL can be overridden via SESSION_MAP_TTL_DAYS env var
+- session-cleanup.py prune_stale_session_map_entries() evicts correctly
+"""
+
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_entry(last_activity):
+    """Build a minimal session map entry dict."""
+    return {
+        "session_id": "00000000-0000-0000-0000-000000000000",
+        "model": "haiku",
+        "agent": "orchestrator",
+        "runtime": "copilot",
+        "last_activity": last_activity,
+    }
+
+
+@pytest.fixture
+def session_mgr():
+    """Minimal SessionManager instance with a temporary session map file."""
+    from agent_manager import SessionManager
+
+    mgr = SessionManager.__new__(SessionManager)
+    # Required attributes for model / agent resolution
+    mgr._env_claude_models = {}
+    mgr._env_gemini_models = {}
+    mgr._env_codex_models = {}
+    mgr._env_devin_models = {}
+    mgr._env_cursor_models = {}
+    mgr._env_wee_models = None
+    # session_map_ttl: 30 days (default)
+    mgr.session_map_ttl = 30 * 86400
+    # Point to a temp file for all map I/O
+    mgr._tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+    mgr.session_map_file = Path(mgr._tmp.name)
+    mgr.session_map_file.write_text("{}")
+    return mgr
+
+
+# ── _prune_session_map_ttl() ──────────────────────────────────────────────────
+
+class TestPruneSessionMapTtl:
+    """Direct unit tests for _prune_session_map_ttl()."""
+
+    def test_old_entry_is_evicted(self, session_mgr):
+        """An entry with last_activity > TTL in the past must be removed."""
+        stale_ts = time.time() - (31 * 86400)  # 31 days ago
+        session_map = {"stale_session": _make_entry(stale_ts)}
+        result = session_mgr._prune_session_map_ttl(session_map)
+        assert "stale_session" not in result
+
+    def test_recent_entry_is_kept(self, session_mgr):
+        """An entry with last_activity within TTL must be retained."""
+        fresh_ts = time.time() - (1 * 86400)  # 1 day ago
+        session_map = {"fresh_session": _make_entry(fresh_ts)}
+        result = session_mgr._prune_session_map_ttl(session_map)
+        assert "fresh_session" in result
+
+    def test_entry_without_last_activity_is_kept(self, session_mgr):
+        """Entries missing last_activity must never be evicted (legacy safety)."""
+        entry = {
+            "session_id": "abc",
+            "model": "haiku",
+            # no last_activity
+        }
+        result = session_mgr._prune_session_map_ttl({"legacy_key": entry})
+        assert "legacy_key" in result
+
+    def test_string_legacy_entry_is_kept(self, session_mgr):
+        """Old-format string-only session map entries are kept (no last_activity)."""
+        result = session_mgr._prune_session_map_ttl(
+            {"legacy_str": "some-session-uuid"}
+        )
+        assert "legacy_str" in result
+
+    def test_multiple_stale_entries_all_evicted(self, session_mgr):
+        """All stale entries are removed in a single pass."""
+        stale_ts = time.time() - (35 * 86400)
+        session_map = {
+            f"stale_{i}": _make_entry(stale_ts) for i in range(5)
+        }
+        result = session_mgr._prune_session_map_ttl(session_map)
+        assert len(result) == 0
+
+    def test_mixed_map_only_stale_evicted(self, session_mgr):
+        """Only stale entries are removed; fresh ones survive."""
+        stale_ts = time.time() - (31 * 86400)
+        fresh_ts = time.time() - (1 * 86400)
+        session_map = {
+            "stale": _make_entry(stale_ts),
+            "fresh": _make_entry(fresh_ts),
+        }
+        result = session_mgr._prune_session_map_ttl(session_map)
+        assert "stale" not in result
+        assert "fresh" in result
+
+    def test_exactly_at_ttl_boundary_is_kept(self, session_mgr):
+        """An entry exactly at the cutoff (not strictly older) must be retained."""
+        # TTL = 30d; set last_activity to exactly 30d ago + 1 second (still fresh)
+        boundary_ts = time.time() - (session_mgr.session_map_ttl - 1)
+        session_map = {"boundary": _make_entry(boundary_ts)}
+        result = session_mgr._prune_session_map_ttl(session_map)
+        assert "boundary" in result
+
+    def test_ttl_override_via_attribute(self, session_mgr):
+        """session_map_ttl attribute controls the cutoff."""
+        # Use a very short TTL (1 hour)
+        session_mgr.session_map_ttl = 3600
+        slightly_old_ts = time.time() - 3700  # 1 hour and 100s ago
+        session_map = {"old_session": _make_entry(slightly_old_ts)}
+        result = session_mgr._prune_session_map_ttl(session_map)
+        assert "old_session" not in result
+
+
+# ── save_session_map() ────────────────────────────────────────────────────────
+
+class TestSaveSessionMapPrunes:
+    """save_session_map() must evict stale entries before writing to disk."""
+
+    def test_save_prunes_stale_entry(self, session_mgr):
+        """Stale entries must not appear in the written file."""
+        stale_ts = time.time() - (31 * 86400)
+        session_map = {
+            "stale": _make_entry(stale_ts),
+            "fresh": _make_entry(time.time()),
+        }
+
+        import threading
+        session_mgr._session_map_lock = threading.Lock()
+        session_mgr.save_session_map(session_map)
+
+        written = json.loads(session_mgr.session_map_file.read_text())
+        assert "stale" not in written
+        assert "fresh" in written
+
+    def test_save_with_all_fresh_entries(self, session_mgr):
+        """When all entries are fresh, the full map is written unchanged."""
+        fresh_ts = time.time() - 100
+        session_map = {
+            "s1": _make_entry(fresh_ts),
+            "s2": _make_entry(fresh_ts),
+        }
+
+        import threading
+        session_mgr._session_map_lock = threading.Lock()
+        session_mgr.save_session_map(session_map)
+
+        written = json.loads(session_mgr.session_map_file.read_text())
+        assert len(written) == 2
+
+    def test_save_does_not_modify_input_dict(self, session_mgr):
+        """The original session_map passed to save_session_map must be unmodified."""
+        stale_ts = time.time() - (31 * 86400)
+        original = {"stale": _make_entry(stale_ts)}
+        import copy, threading
+        before = copy.deepcopy(original)
+        session_mgr._session_map_lock = threading.Lock()
+        session_mgr.save_session_map(original)
+        # _prune_session_map_ttl returns a NEW dict, input unchanged
+        assert original == before
+
+
+# ── Unbounded-growth regression ───────────────────────────────────────────────
+
+class TestNoBoundedGrowthRegression:
+    """Reproduces the original bug: session map must not grow without bound."""
+
+    def test_session_map_does_not_grow_unbounded(self, session_mgr, tmp_path):
+        """Writing 100 old sessions over time must leave the map empty, not 100-large."""
+        import threading
+        session_mgr._session_map_lock = threading.Lock()
+        session_mgr.session_map_file = tmp_path / "test-session-map.json"
+        session_mgr.session_map_file.write_text("{}")
+
+        stale_ts = time.time() - (32 * 86400)
+        for i in range(100):
+            session_map = {f"session_{j}": _make_entry(stale_ts) for j in range(i + 1)}
+            session_mgr.save_session_map(session_map)
+
+        written = json.loads(session_mgr.session_map_file.read_text())
+        # All 100 stale sessions must have been pruned
+        assert len(written) == 0, (
+            f"Session map grew to {len(written)} entries — TTL eviction not working"
+        )
+
+
+# ── session-cleanup.py ────────────────────────────────────────────────────────
+
+class TestCleanupScriptTtlPruning:
+    """prune_stale_session_map_entries() in session-cleanup.py."""
+
+    def _load_script(self):
+        """Import prune_stale_session_map_entries from the cleanup script."""
+        import importlib.util
+        script = Path(__file__).parent.parent / "scripts" / "session-cleanup.py"
+        spec = importlib.util.spec_from_file_location("session_cleanup", script)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_prune_removes_stale_entries(self, tmp_path):
+        """prune_stale_session_map_entries() evicts entries older than ttl_days."""
+        mod = self._load_script()
+
+        stale_ts = time.time() - (31 * 86400)
+        fresh_ts = time.time() - 3600
+
+        map_data = {
+            "stale_key": _make_entry(stale_ts),
+            "fresh_key": _make_entry(fresh_ts),
+        }
+        map_file = tmp_path / "n8n-session-map.json"
+        map_file.write_text(json.dumps(map_data))
+
+        mod.prune_stale_session_map_entries([map_file], ttl_days=30)
+
+        result = json.loads(map_file.read_text())
+        assert "stale_key" not in result
+        assert "fresh_key" in result
+
+    def test_prune_no_op_on_all_fresh(self, tmp_path):
+        """prune_stale_session_map_entries() is a no-op when all entries are fresh."""
+        mod = self._load_script()
+
+        fresh_ts = time.time() - 3600
+        map_data = {"k1": _make_entry(fresh_ts), "k2": _make_entry(fresh_ts)}
+        map_file = tmp_path / "n8n-session-map.json"
+        map_file.write_text(json.dumps(map_data))
+
+        mod.prune_stale_session_map_entries([map_file], ttl_days=30)
+
+        result = json.loads(map_file.read_text())
+        assert len(result) == 2
+
+    def test_prune_missing_file_is_safe(self, tmp_path):
+        """prune_stale_session_map_entries() must not raise if file does not exist."""
+        mod = self._load_script()
+        missing = tmp_path / "nonexistent.json"
+        # Should complete without raising
+        mod.prune_stale_session_map_entries([missing], ttl_days=30)
+
+    def test_prune_entries_without_last_activity_kept(self, tmp_path):
+        """Entries without last_activity are preserved (legacy safety)."""
+        mod = self._load_script()
+
+        map_data = {
+            "no_ts": {"session_id": "abc", "model": "haiku"},
+        }
+        map_file = tmp_path / "n8n-session-map.json"
+        map_file.write_text(json.dumps(map_data))
+
+        mod.prune_stale_session_map_entries([map_file], ttl_days=30)
+
+        result = json.loads(map_file.read_text())
+        assert "no_ts" in result

--- a/tests/test_issue26_session_map_ttl.py
+++ b/tests/test_issue26_session_map_ttl.py
@@ -26,7 +26,6 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -34,6 +33,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
 
 def _make_entry(last_activity):
     """Build a minimal session map entry dict."""
@@ -70,6 +70,7 @@ def session_mgr():
 
 # ── _prune_session_map_ttl() ──────────────────────────────────────────────────
 
+
 class TestPruneSessionMapTtl:
     """Direct unit tests for _prune_session_map_ttl()."""
 
@@ -99,17 +100,13 @@ class TestPruneSessionMapTtl:
 
     def test_string_legacy_entry_is_kept(self, session_mgr):
         """Old-format string-only session map entries are kept (no last_activity)."""
-        result = session_mgr._prune_session_map_ttl(
-            {"legacy_str": "some-session-uuid"}
-        )
+        result = session_mgr._prune_session_map_ttl({"legacy_str": "some-session-uuid"})
         assert "legacy_str" in result
 
     def test_multiple_stale_entries_all_evicted(self, session_mgr):
         """All stale entries are removed in a single pass."""
         stale_ts = time.time() - (35 * 86400)
-        session_map = {
-            f"stale_{i}": _make_entry(stale_ts) for i in range(5)
-        }
+        session_map = {f"stale_{i}": _make_entry(stale_ts) for i in range(5)}
         result = session_mgr._prune_session_map_ttl(session_map)
         assert len(result) == 0
 
@@ -145,6 +142,7 @@ class TestPruneSessionMapTtl:
 
 # ── save_session_map() ────────────────────────────────────────────────────────
 
+
 class TestSaveSessionMapPrunes:
     """save_session_map() must evict stale entries before writing to disk."""
 
@@ -157,6 +155,7 @@ class TestSaveSessionMapPrunes:
         }
 
         import threading
+
         session_mgr._session_map_lock = threading.Lock()
         session_mgr.save_session_map(session_map)
 
@@ -173,6 +172,7 @@ class TestSaveSessionMapPrunes:
         }
 
         import threading
+
         session_mgr._session_map_lock = threading.Lock()
         session_mgr.save_session_map(session_map)
 
@@ -183,7 +183,9 @@ class TestSaveSessionMapPrunes:
         """The original session_map passed to save_session_map must be unmodified."""
         stale_ts = time.time() - (31 * 86400)
         original = {"stale": _make_entry(stale_ts)}
-        import copy, threading
+        import copy
+        import threading
+
         before = copy.deepcopy(original)
         session_mgr._session_map_lock = threading.Lock()
         session_mgr.save_session_map(original)
@@ -193,12 +195,16 @@ class TestSaveSessionMapPrunes:
 
 # ── Unbounded-growth regression ───────────────────────────────────────────────
 
+
 class TestNoBoundedGrowthRegression:
     """Reproduces the original bug: session map must not grow without bound."""
 
     def test_session_map_does_not_grow_unbounded(self, session_mgr, tmp_path):
-        """Writing 100 old sessions over time must leave the map empty, not 100-large."""
+        """Writing 100 old sessions over time must leave the map empty,
+
+        not 100-large."""
         import threading
+
         session_mgr._session_map_lock = threading.Lock()
         session_mgr.session_map_file = tmp_path / "test-session-map.json"
         session_mgr.session_map_file.write_text("{}")
@@ -210,12 +216,13 @@ class TestNoBoundedGrowthRegression:
 
         written = json.loads(session_mgr.session_map_file.read_text())
         # All 100 stale sessions must have been pruned
-        assert len(written) == 0, (
-            f"Session map grew to {len(written)} entries — TTL eviction not working"
-        )
+        assert (
+            len(written) == 0
+        ), f"Session map grew to {len(written)} entries — TTL eviction not working"
 
 
 # ── session-cleanup.py ────────────────────────────────────────────────────────
+
 
 class TestCleanupScriptTtlPruning:
     """prune_stale_session_map_entries() in session-cleanup.py."""
@@ -223,6 +230,7 @@ class TestCleanupScriptTtlPruning:
     def _load_script(self):
         """Import prune_stale_session_map_entries from the cleanup script."""
         import importlib.util
+
         script = Path(__file__).parent.parent / "scripts" / "session-cleanup.py"
         spec = importlib.util.spec_from_file_location("session_cleanup", script)
         mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary

- **Root cause**: `n8n-session-map.json` accumulated every session forever — `save_session_map()` never evicted stale entries, and the cleanup daemon only removed backend session *directories*, not map entries.
- **Fix**: `SessionManager._prune_session_map_ttl()` removes entries whose `last_activity` is older than `SESSION_MAP_TTL_DAYS` (default 30 days) before every `save_session_map()` call.
- **Second vector**: `prune_stale_session_map_entries()` added to `scripts/session-cleanup.py` so the daemon also prunes map entries on every cycle — even when the server isn't live.
- **Legacy safe**: entries without a `last_activity` field are preserved to avoid silently dropping old-format data.
- **Configurable**: `SESSION_MAP_TTL_DAYS` env var controls the cutoff (default 30).

## Changes

| File | Change |
|------|--------|
| `agent_manager.py` | `session_map_ttl` attribute + `_prune_session_map_ttl()` method + call in `save_session_map()` |
| `scripts/session-cleanup.py` | `prune_stale_session_map_entries()` function + call in `cleanup_sessions()` |
| `tests/test_issue26_session_map_ttl.py` | 16 regression tests — all passing |

## Test plan

- [x] `_prune_session_map_ttl()` evicts entries older than TTL
- [x] Fresh entries and legacy entries without `last_activity` are kept
- [x] `save_session_map()` prunes before writing to disk
- [x] Bounded-growth regression: 100 stale writes leave map empty
- [x] `prune_stale_session_map_entries()` in cleanup script evicts and is safe on missing files
- [x] All 16 tests pass: `python3 -m pytest tests/test_issue26_session_map_ttl.py -v`

Closes #26

Generated with [Devin](https://cli.devin.ai/docs)