### PR TITLE
fix: close file handle leak in send_document retry path

### DIFF
--- a/telegram_connector.py
+++ b/telegram_connector.py
@@ -946,13 +946,14 @@ class TelegramConnector:
                     # Retry without HTML parse_mode if caption failed
                     if caption:
                         data.pop("parse_mode", None)
+                        f.seek(0)
                         resp = requests.post(
                             f"{self.api_url}/sendDocument",
                             data=data,
                             files={
                                 "document": (
                                     filename or Path(file_path).name,
-                                    open(file_path, "rb"),
+                                    f,
                                     mime_type,
                                 )
                             },

--- a/tests/test_issue_27_file_handle_leak.py
+++ b/tests/test_issue_27_file_handle_leak.py
@@ -1,0 +1,117 @@
+"""
+Regression test for issue #27: File handle leaks in connector file sends.
+
+The bug: telegram_connector.send_document() opened a new file handle inline
+(`open(file_path, "rb")`) in the retry path without closing it.
+
+The fix: reuse the already-open file handle `f` via `f.seek(0)`.
+"""
+import io
+import tempfile
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
+
+
+class TestIssue27FileHandleLeak(unittest.TestCase):
+    """Verify no new file handles are opened in the send_document retry path."""
+
+    def setUp(self):
+        # Create a small temp file to send
+        self.tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
+        self.tmp.write(b"hello world")
+        self.tmp.close()
+        self.file_path = self.tmp.name
+
+    def tearDown(self):
+        os.unlink(self.file_path)
+
+    def _make_connector(self):
+        from telegram_connector import TelegramConnector
+
+        connector = TelegramConnector.__new__(TelegramConnector)
+        connector.token = "fake_token"
+        connector.api_url = "https://api.telegram.org/botfake_token"
+        connector.send_message = MagicMock()
+        connector._is_safe_file_path = MagicMock(return_value=True)
+        connector.sanitize_telegram_html = MagicMock(side_effect=lambda x: x)
+        return connector
+
+    def test_retry_reuses_file_handle_not_opens_new_one(self):
+        """
+        Simulate a first request failure (e.g. HTML parse_mode rejected).
+        The retry must NOT call open() again — it must seek(0) on the existing handle.
+        """
+        connector = self._make_connector()
+
+        # Track every builtin open() call for our temp file
+        open_calls = []
+        _real_open = open
+
+        def tracking_open(path, *args, **kwargs):
+            fh = _real_open(path, *args, **kwargs)
+            if str(path) == self.file_path:
+                open_calls.append(path)
+            return fh
+
+        first_fail = MagicMock()
+        first_fail.status_code = 400
+        first_fail.text = "Bad Request: can't parse entities"
+
+        second_ok = MagicMock()
+        second_ok.status_code = 200
+        second_ok.json.return_value = {"ok": True, "result": {"message_id": 42}}
+
+        with patch("builtins.open", side_effect=tracking_open):
+            with patch("requests.post", side_effect=[first_fail, second_ok]):
+                result = connector.send_document(
+                    chat_id=12345,
+                    file_path=self.file_path,
+                    caption="<b>test</b>",
+                )
+
+        # The fix: only ONE open() call (for the initial `with open(...)`)
+        # A second call would indicate the leak is back.
+        self.assertEqual(
+            len(open_calls),
+            1,
+            f"Expected exactly 1 open() call for {self.file_path}, got {len(open_calls)}. "
+            "Retry path must reuse the existing file handle via seek(0), not open a new one.",
+        )
+        self.assertEqual(result, 42)
+
+    def test_no_retry_when_first_request_succeeds(self):
+        """When the first request succeeds, only one open() call should happen."""
+        connector = self._make_connector()
+
+        open_calls = []
+        _real_open = open
+
+        def tracking_open(path, *args, **kwargs):
+            fh = _real_open(path, *args, **kwargs)
+            if str(path) == self.file_path:
+                open_calls.append(path)
+            return fh
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json.return_value = {"ok": True, "result": {"message_id": 7}}
+
+        with patch("builtins.open", side_effect=tracking_open):
+            with patch("requests.post", return_value=ok_response):
+                result = connector.send_document(
+                    chat_id=12345,
+                    file_path=self.file_path,
+                    caption="plain text",
+                )
+
+        self.assertEqual(len(open_calls), 1)
+        self.assertEqual(result, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue_27_file_handle_leak.py
+++ b/tests/test_issue_27_file_handle_leak.py
@@ -2,26 +2,65 @@
 Regression test for issue #27: File handle leaks in connector file sends.
 
 The bug: telegram_connector.send_document() opened a new file handle inline
-(`open(file_path, "rb")`) in the retry path without closing it.
+in the retry path without closing it.
 
-The fix: reuse the already-open file handle `f` via `f.seek(0)`.
+The fix: reuse the already-open file handle via f.seek(0).
 """
 import io
 import tempfile
 import os
 import sys
+import builtins
 import unittest
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 
+_REAL_OPEN = builtins.open
+
+
+class _SeekSpy:
+    """File-like wrapper that records seek() calls.
+
+    Used to verify the retry path rewinds the stream via seek(0) rather than
+    opening a second file handle.  Supports the context-manager protocol so
+    it can be returned directly from a patched builtins.open.
+    """
+
+    def __init__(self, content: bytes):
+        self._buf = io.BytesIO(content)
+        self.seek_calls: list = []
+
+    def read(self, *args):
+        return self._buf.read(*args)
+
+    def seek(self, *args):
+        self.seek_calls.append(args)
+        return self._buf.seek(*args)
+
+    def tell(self):
+        return self._buf.tell()
+
+    def readable(self):
+        return True
+
+    def writable(self):
+        return False
+
+    def __iter__(self):
+        return self._buf.__iter__()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
 
 class TestIssue27FileHandleLeak(unittest.TestCase):
-    """Verify no new file handles are opened in the send_document retry path."""
+    """Verify the send_document retry path rewinds the existing stream."""
 
     def setUp(self):
-        # Create a small temp file to send
         self.tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
         self.tmp.write(b"hello world")
         self.tmp.close()
@@ -41,22 +80,32 @@ class TestIssue27FileHandleLeak(unittest.TestCase):
         connector.sanitize_telegram_html = MagicMock(side_effect=lambda x: x)
         return connector
 
-    def test_retry_reuses_file_handle_not_opens_new_one(self):
+    def _make_open_spy(self, spy: _SeekSpy):
+        """Return a patched open() that yields the spy for our test file
+        and delegates to the real open() for everything else."""
+        target = self.file_path
+        open_count = [0]
+
+        def patched_open(path, *args, **kwargs):
+            if str(path) == target:
+                open_count[0] += 1
+                return spy
+            return _REAL_OPEN(path, *args, **kwargs)
+
+        return patched_open, open_count
+
+    def test_retry_seeks_stream_to_zero_not_opens_new_handle(self):
         """
-        Simulate a first request failure (e.g. HTML parse_mode rejected).
-        The retry must NOT call open() again — it must seek(0) on the existing handle.
+        On first-request failure the retry MUST call f.seek(0) to rewind the
+        stream — it must NOT open a second file handle.
+
+        Catches both failure modes:
+          * seek(0) omitted  -> seek_calls is empty   -> assertion fails
+          * new open() used  -> open_count[0] == 2    -> assertion fails
         """
         connector = self._make_connector()
-
-        # Track every builtin open() call for our temp file
-        open_calls = []
-        _real_open = open
-
-        def tracking_open(path, *args, **kwargs):
-            fh = _real_open(path, *args, **kwargs)
-            if str(path) == self.file_path:
-                open_calls.append(path)
-            return fh
+        spy = _SeekSpy(b"hello world")
+        patched_open, open_count = self._make_open_spy(spy)
 
         first_fail = MagicMock()
         first_fail.status_code = 400
@@ -66,7 +115,7 @@ class TestIssue27FileHandleLeak(unittest.TestCase):
         second_ok.status_code = 200
         second_ok.json.return_value = {"ok": True, "result": {"message_id": 42}}
 
-        with patch("builtins.open", side_effect=tracking_open):
+        with patch("builtins.open", side_effect=patched_open):
             with patch("requests.post", side_effect=[first_fail, second_ok]):
                 result = connector.send_document(
                     chat_id=12345,
@@ -74,34 +123,35 @@ class TestIssue27FileHandleLeak(unittest.TestCase):
                     caption="<b>test</b>",
                 )
 
-        # The fix: only ONE open() call (for the initial `with open(...)`)
-        # A second call would indicate the leak is back.
+        # 1. Exactly one open() call — retry must NOT open a new file handle
         self.assertEqual(
-            len(open_calls),
+            open_count[0],
             1,
-            f"Expected exactly 1 open() call for {self.file_path}, got {len(open_calls)}. "
-            "Retry path must reuse the existing file handle via seek(0), not open a new one.",
+            f"Expected 1 open() for {self.file_path}, got {open_count[0]}. "
+            "Retry path must reuse the existing handle, not open a new one.",
         )
+
+        # 2. seek(0) was called — stream position was rewound before the retry
+        self.assertTrue(
+            any(args == (0,) for args in spy.seek_calls),
+            f"Expected seek(0) before the retry request, "
+            f"but seek was called with: {spy.seek_calls}. "
+            "Without seek(0) the retry sends an empty/partial body.",
+        )
+
         self.assertEqual(result, 42)
 
     def test_no_retry_when_first_request_succeeds(self):
-        """When the first request succeeds, only one open() call should happen."""
+        """Happy path: one open() call, seek() never called."""
         connector = self._make_connector()
-
-        open_calls = []
-        _real_open = open
-
-        def tracking_open(path, *args, **kwargs):
-            fh = _real_open(path, *args, **kwargs)
-            if str(path) == self.file_path:
-                open_calls.append(path)
-            return fh
+        spy = _SeekSpy(b"hello world")
+        patched_open, open_count = self._make_open_spy(spy)
 
         ok_response = MagicMock()
         ok_response.status_code = 200
         ok_response.json.return_value = {"ok": True, "result": {"message_id": 7}}
 
-        with patch("builtins.open", side_effect=tracking_open):
+        with patch("builtins.open", side_effect=patched_open):
             with patch("requests.post", return_value=ok_response):
                 result = connector.send_document(
                     chat_id=12345,
@@ -109,7 +159,12 @@ class TestIssue27FileHandleLeak(unittest.TestCase):
                     caption="plain text",
                 )
 
-        self.assertEqual(len(open_calls), 1)
+        self.assertEqual(open_count[0], 1, "Exactly one open() call on success.")
+        self.assertEqual(
+            spy.seek_calls,
+            [],
+            "seek() must not be called when no retry is needed.",
+        )
         self.assertEqual(result, 7)
 
 


### PR DESCRIPTION
## Summary

- In `telegram_connector.py`'s `send_document()`, the retry path re-opened `open(file_path, "rb")` inline (passed directly to `requests.post files=`), leaking the file descriptor if the request raised an exception.
- Fix: call `f.seek(0)` on the already-open handle from the outer `with` block and pass `f` to the retry request instead of opening a new handle.

## Regression Test

`tests/test_issue_27_file_handle_leak.py` — 2 tests:
- `test_retry_reuses_file_handle_not_opens_new_one`: simulates a first-request failure (HTML parse error) and asserts that `open()` is called exactly once (no leak on retry).
- `test_no_retry_when_first_request_succeeds`: asserts the happy path also only opens the file once.

Closes #27