### PR TITLE
fix: timing-safe shared key comparison (issue #28)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9,6 +9,7 @@ import argparse
 import calendar
 import copy
 import hashlib
+import hmac
 import json
 import logging
 import os
@@ -241,7 +242,7 @@ class AuthManager:
         """Validate a Bearer token as a shared key. Expects 'shared_<key>'."""
         if not token.startswith("shared_"):
             return False
-        return token[7:] == self.shared_key
+        return hmac.compare_digest(token[7:], self.shared_key)
 
     def _load_sessions(self):
         """Load persisted sessions from file on startup."""

--- a/tests/test_issue_28_timing_safe_key.py
+++ b/tests/test_issue_28_timing_safe_key.py
@@ -1,0 +1,50 @@
+"""Regression test for issue #28: AuthManager.validate_shared_key() timing safety.
+
+Verifies that validate_shared_key() uses hmac.compare_digest() instead of ==,
+which prevents timing side-channel attacks on the Bearer token comparison.
+"""
+import hmac
+import inspect
+import sys
+import os
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
+
+from agent_manager import AuthManager
+
+
+def test_issue_28_validate_shared_key_uses_compare_digest():
+    """validate_shared_key must use hmac.compare_digest, not ==."""
+    source = inspect.getsource(AuthManager.validate_shared_key)
+    assert "hmac.compare_digest" in source, (
+        "validate_shared_key must use hmac.compare_digest() for timing-safe comparison"
+    )
+    assert "==" not in source, (
+        "validate_shared_key must NOT use == for key comparison (timing side-channel)"
+    )
+
+
+def test_issue_28_valid_key_accepted():
+    """Correct shared key must be accepted."""
+    mgr = AuthManager(shared_key="testsecret")
+    assert mgr.validate_shared_key("shared_testsecret") is True
+
+
+def test_issue_28_wrong_key_rejected():
+    """Wrong key must be rejected."""
+    mgr = AuthManager(shared_key="testsecret")
+    assert mgr.validate_shared_key("shared_wrongkey") is False
+
+
+def test_issue_28_missing_prefix_rejected():
+    """Token without 'shared_' prefix must be rejected."""
+    mgr = AuthManager(shared_key="testsecret")
+    assert mgr.validate_shared_key("testsecret") is False
+    assert mgr.validate_shared_key("bearer_testsecret") is False
+    assert mgr.validate_shared_key("") is False
+
+
+def test_issue_28_empty_key_safe():
+    """Empty token after prefix must be rejected even if shared_key is also empty string."""
+    mgr = AuthManager(shared_key="nonempty")
+    assert mgr.validate_shared_key("shared_") is False


### PR DESCRIPTION
## Summary

- Replaces `==` with `hmac.compare_digest()` in `AuthManager.validate_shared_key()`
- Adds `import hmac` (alongside existing `import hashlib`)
- Adds 5 regression tests in `tests/test_issue_28_timing_safe_key.py`

## Changes

**`agent_manager.py`** (2 lines changed):
- Line ~12: `import hmac` added
- `validate_shared_key()`: `token[7:] == self.shared_key` → `hmac.compare_digest(token[7:], self.shared_key)`

**`tests/test_issue_28_timing_safe_key.py`** (new file):
- Asserts source code uses `compare_digest` and not `==`
- Valid key accepted, wrong key rejected, missing prefix rejected, empty token safe

## Security

`hmac.compare_digest()` runs in constant time regardless of how many characters match, eliminating the timing side-channel that allowed an attacker to brute-force the shared key byte-by-byte.

Closes #28