### PR TITLE
fix: apply glass-input glass-select classes to fallback Runtime/Model dropdowns

### DIFF
--- a/tests/test_issue188_fallback_dropdown_styling.py
+++ b/tests/test_issue188_fallback_dropdown_styling.py
@@ -1,0 +1,78 @@
+"""Regression tests for Issue #188: Fallback Runtime/Model dropdowns must use
+the same glass-input glass-select styling as the primary Runtime/Model selects."""
+
+import os
+import re
+import unittest
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_JS_PATH = os.path.join(BASE_DIR, "webui", "dist", "app.js")
+
+
+class TestFallbackDropdownStyling(unittest.TestCase):
+    """Verify fallback Runtime/Model selects carry the glassmorphism CSS classes."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(APP_JS_PATH) as f:
+            cls.app_js = f.read()
+
+    def _get_fallback_select_html(self, element_id):
+        """Extract the opening <select ...> tag for a given element id."""
+        pattern = rf'<select[^>]+id="{re.escape(element_id)}"[^>]*>'
+        match = re.search(pattern, self.app_js)
+        self.assertIsNotNone(match, f"Could not find <select id=\"{element_id}\"> in app.js")
+        return match.group(0)
+
+    def test_fallback_runtime_has_glass_input_class(self):
+        """sched-fallback-runtime select must have glass-input CSS class."""
+        tag = self._get_fallback_select_html("sched-fallback-runtime")
+        self.assertIn("glass-input", tag,
+                      "sched-fallback-runtime <select> is missing 'glass-input' class")
+
+    def test_fallback_runtime_has_glass_select_class(self):
+        """sched-fallback-runtime select must have glass-select CSS class."""
+        tag = self._get_fallback_select_html("sched-fallback-runtime")
+        self.assertIn("glass-select", tag,
+                      "sched-fallback-runtime <select> is missing 'glass-select' class")
+
+    def test_fallback_model_has_glass_input_class(self):
+        """sched-fallback-model select must have glass-input CSS class."""
+        tag = self._get_fallback_select_html("sched-fallback-model")
+        self.assertIn("glass-input", tag,
+                      "sched-fallback-model <select> is missing 'glass-input' class")
+
+    def test_fallback_model_has_glass_select_class(self):
+        """sched-fallback-model select must have glass-select CSS class."""
+        tag = self._get_fallback_select_html("sched-fallback-model")
+        self.assertIn("glass-select", tag,
+                      "sched-fallback-model <select> is missing 'glass-select' class")
+
+    def test_primary_runtime_still_has_glass_classes(self):
+        """Primary runtime select must still carry glass-input glass-select (no regression)."""
+        # Primary runtime uses name="runtime" with data-current attribute
+        pattern = r'<select class="glass-input glass-select" name="runtime"'
+        self.assertRegex(self.app_js, pattern,
+                         "Primary runtime <select> lost its glass-input glass-select classes")
+
+    def test_primary_model_still_has_glass_classes(self):
+        """Primary model select must still carry glass-input glass-select (no regression)."""
+        pattern = r'<select class="glass-input glass-select" name="model"'
+        self.assertRegex(self.app_js, pattern,
+                         "Primary model <select> lost its glass-input glass-select classes")
+
+    def test_fallback_runtime_class_order_matches_primary(self):
+        """Fallback runtime class attribute should match primary pattern exactly."""
+        fb_tag = self._get_fallback_select_html("sched-fallback-runtime")
+        self.assertIn('class="glass-input glass-select"', fb_tag,
+                      "sched-fallback-runtime class order should be 'glass-input glass-select'")
+
+    def test_fallback_model_class_order_matches_primary(self):
+        """Fallback model class attribute should match primary pattern exactly."""
+        fb_tag = self._get_fallback_select_html("sched-fallback-model")
+        self.assertIn('class="glass-input glass-select"', fb_tag,
+                      "sched-fallback-model class order should be 'glass-input glass-select'")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue188_fallback_dropdown_styling.py
+++ b/tests/test_issue188_fallback_dropdown_styling.py
@@ -1,5 +1,6 @@
 """Regression tests for Issue #188: Fallback Runtime/Model dropdowns must use
-the same glass-input glass-select styling as the primary Runtime/Model selects."""
+the same glass-input glass-select styling as the primary Runtime/Model
+selects."""
 
 import os
 import re
@@ -21,57 +22,85 @@ class TestFallbackDropdownStyling(unittest.TestCase):
         """Extract the opening <select ...> tag for a given element id."""
         pattern = rf'<select[^>]+id="{re.escape(element_id)}"[^>]*>'
         match = re.search(pattern, self.app_js)
-        self.assertIsNotNone(match, f"Could not find <select id=\"{element_id}\"> in app.js")
+        self.assertIsNotNone(
+            match, f'Could not find <select id="{element_id}"> in app.js'
+        )
         return match.group(0)
 
     def test_fallback_runtime_has_glass_input_class(self):
         """sched-fallback-runtime select must have glass-input CSS class."""
         tag = self._get_fallback_select_html("sched-fallback-runtime")
-        self.assertIn("glass-input", tag,
-                      "sched-fallback-runtime <select> is missing 'glass-input' class")
+        self.assertIn(
+            "glass-input",
+            tag,
+            "sched-fallback-runtime <select> missing 'glass-input' class",
+        )
 
     def test_fallback_runtime_has_glass_select_class(self):
         """sched-fallback-runtime select must have glass-select CSS class."""
         tag = self._get_fallback_select_html("sched-fallback-runtime")
-        self.assertIn("glass-select", tag,
-                      "sched-fallback-runtime <select> is missing 'glass-select' class")
+        self.assertIn(
+            "glass-select",
+            tag,
+            "sched-fallback-runtime <select> missing 'glass-select' class",
+        )
 
     def test_fallback_model_has_glass_input_class(self):
         """sched-fallback-model select must have glass-input CSS class."""
         tag = self._get_fallback_select_html("sched-fallback-model")
-        self.assertIn("glass-input", tag,
-                      "sched-fallback-model <select> is missing 'glass-input' class")
+        self.assertIn(
+            "glass-input",
+            tag,
+            "sched-fallback-model <select> missing 'glass-input' class",
+        )
 
     def test_fallback_model_has_glass_select_class(self):
         """sched-fallback-model select must have glass-select CSS class."""
         tag = self._get_fallback_select_html("sched-fallback-model")
-        self.assertIn("glass-select", tag,
-                      "sched-fallback-model <select> is missing 'glass-select' class")
+        self.assertIn(
+            "glass-select",
+            tag,
+            "sched-fallback-model <select> missing 'glass-select' class",
+        )
 
     def test_primary_runtime_still_has_glass_classes(self):
-        """Primary runtime select must still carry glass-input glass-select (no regression)."""
+        """Primary runtime select must still carry glass-input glass-select
+        (no regression)."""
         # Primary runtime uses name="runtime" with data-current attribute
         pattern = r'<select class="glass-input glass-select" name="runtime"'
-        self.assertRegex(self.app_js, pattern,
-                         "Primary runtime <select> lost its glass-input glass-select classes")
+        self.assertRegex(
+            self.app_js,
+            pattern,
+            "Primary runtime <select> lost its glass-input glass-select",
+        )
 
     def test_primary_model_still_has_glass_classes(self):
-        """Primary model select must still carry glass-input glass-select (no regression)."""
+        """Primary model select must still carry glass-input glass-select
+        (no regression)."""
         pattern = r'<select class="glass-input glass-select" name="model"'
-        self.assertRegex(self.app_js, pattern,
-                         "Primary model <select> lost its glass-input glass-select classes")
+        self.assertRegex(
+            self.app_js,
+            pattern,
+            "Primary model <select> lost its glass-input glass-select",
+        )
 
     def test_fallback_runtime_class_order_matches_primary(self):
-        """Fallback runtime class attribute should match primary pattern exactly."""
+        """Fallback runtime class attribute should match primary pattern."""
         fb_tag = self._get_fallback_select_html("sched-fallback-runtime")
-        self.assertIn('class="glass-input glass-select"', fb_tag,
-                      "sched-fallback-runtime class order should be 'glass-input glass-select'")
+        self.assertIn(
+            'class="glass-input glass-select"',
+            fb_tag,
+            "sched-fallback-runtime class order incorrect",
+        )
 
     def test_fallback_model_class_order_matches_primary(self):
-        """Fallback model class attribute should match primary pattern exactly."""
+        """Fallback model class attribute should match primary pattern."""
         fb_tag = self._get_fallback_select_html("sched-fallback-model")
-        self.assertIn('class="glass-input glass-select"', fb_tag,
-                      "sched-fallback-model class order should be 'glass-input glass-select'")
+        self.assertIn(
+            'class="glass-input glass-select"',
+            fb_tag,
+            "sched-fallback-model class order incorrect",
+        )
 
 
 if __name__ == "__main__":

--- a/webui/dist/app.js
+++ b/webui/dist/app.js
@@ -3256,14 +3256,14 @@ function buildJobForm(job) {
         <div style="margin-top:8px">
           <div class="form-group">
             <label>Fallback Runtime</label>
-            <select id="sched-fallback-runtime" name="fallback_runtime">
+            <select class="glass-input glass-select" id="sched-fallback-runtime" name="fallback_runtime">
               <option value="">None (no fallback)</option>
             </select>
             <small>Used if primary runtime fails (rate limit, auth error, timeout)</small>
           </div>
           <div class="form-group">
             <label>Fallback Model</label>
-            <select id="sched-fallback-model" name="fallback_model">
+            <select class="glass-input glass-select" id="sched-fallback-model" name="fallback_model">
               <option value="">None (no fallback)</option>
             </select>
             <small>Used with fallback runtime</small>

--- a/webui/dist/index.html
+++ b/webui/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" type="image/png" sizes="192x192" href="/static/icon-192.png" />
   <link rel="apple-touch-icon" href="/static/apple-touch-icon.png" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github-dark.min.css" />
-  <link rel="stylesheet" href="app.css?v=202604180001" />
-  <link rel="stylesheet" href="themes.css?v=202604180001" />
+  <link rel="stylesheet" href="app.css?v=202604210051" />
+  <link rel="stylesheet" href="themes.css?v=202604210051" />
 </head>
 <body>
   <!-- Auth overlay -->
@@ -703,7 +703,7 @@
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/highlight.min.js"></script>
-  <script src="app.js?v=202604180001" type="module"></script>
+  <script src="app.js?v=202604210051" type="module"></script>
 
     <!-- Skills slide-over panel (right side, below canvas) -->
     <aside id="skills-panel" class="skills-panel skills-hidden">


### PR DESCRIPTION
Fallback Runtime and Fallback Model selects were plain native HTML, missing glass-input/glass-select classes. Fix adds matching classes to both. Regression test included. Closes #188

🤖 Generated with Claude Code