### PR TITLE
fix: auto-recover copilot sessions on session token expiry (#190)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1665,7 +1665,6 @@ class SessionManager:
         # Maps n8n_session_id -> float (epoch seconds when session was started).
         # Copilot session tokens expire ~30 min after creation; we restart at 25 min.
         self._copilot_session_start: Dict[str, float] = {}
-        _COPILOT_SESSION_MAX_AGE_SEC = 25 * 60  # restart at 25 min, before 30-min TTL
 
         # Per-session live status for mobile channel progress updates (F004).
         # Maps n8n_session_id -> {"text": str, "updated_at": float}

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1486,6 +1486,7 @@ class SessionManager:
                 ["sonnet-thinking"],
             ),
             ("claude-sonnet-4.6", "Claude Sonnet 4.6", ["sonnet-4.6"]),
+            ("claude-opus-4.7", "Claude Opus 4.7", ["opus-4.7"]),
             ("claude-opus-4.5", "Claude Opus 4.5", ["opus-4.5"]),
             ("claude-opus-4.6", "Claude Opus 4.6", ["opus-4.6", "opus"]),
             ("claude-haiku-4.5", "Claude Haiku 4.5", ["haiku-4.5", "haiku"]),
@@ -1659,6 +1660,12 @@ class SessionManager:
 
         # Last subprocess exit code per n8n_session_id (for debugging/monitoring)
         self._last_exit_codes: Dict[str, int] = {}
+
+        # Copilot session start times for proactive token refresh (issue #190).
+        # Maps n8n_session_id -> float (epoch seconds when session was started).
+        # Copilot session tokens expire ~30 min after creation; we restart at 25 min.
+        self._copilot_session_start: Dict[str, float] = {}
+        _COPILOT_SESSION_MAX_AGE_SEC = 25 * 60  # restart at 25 min, before 30-min TTL
 
         # Per-session live status for mobile channel progress updates (F004).
         # Maps n8n_session_id -> {"text": str, "updated_at": float}
@@ -3272,7 +3279,11 @@ You can mention an agent in your prompt and it will auto-delegate:
     def _copilot_static_fallback(self) -> dict:
         # Static model list used when copilot CLI is unavailable
         return {
+            "Auto": [
+                "auto",
+            ],
             "Claude Models": [
+                "claude-opus-4.7",
                 "claude-sonnet-4.6",
                 "claude-opus-4.6",
                 "claude-haiku-4.5",
@@ -3330,7 +3341,7 @@ You can mention an agent in your prompt and it will auto-delegate:
                     for m in models
                     if any(
                         kw in m.lower()
-                        for kw in ["gpt", "claude", "gemini", "o1", "o3", "o4"]
+                        for kw in ["gpt", "claude", "gemini", "o1", "o3", "o4", "auto"]
                     )
                 ]
 
@@ -3338,6 +3349,8 @@ You can mention an agent in your prompt and it will auto-delegate:
             if not models:
                 # Look for known models as a sanity check/fallback
                 fallback_models = [
+                    "auto",
+                    "claude-opus-4.7",
                     "claude-sonnet-4.6",
                     "claude-sonnet-4.5",
                     "claude-haiku-4.5",
@@ -3373,7 +3386,11 @@ You can mention an agent in your prompt and it will auto-delegate:
                 # copilot CLI no longer lists models in --help (choices removed in newer versions).
                 # Return the static fallback list so /model list and /model set still work.
                 return {
+                    "Auto": [
+                        "auto",
+                    ],
                     "Claude Models": [
+                        "claude-opus-4.7",
                         "claude-sonnet-4.6",
                         "claude-opus-4.6",
                         "claude-haiku-4.5",
@@ -6751,10 +6768,56 @@ User Request:
             cmd.insert(4, "--allow-all-paths")
             cmd.append("--yolo")
 
+        # Proactive session age check (issue #190): Copilot session tokens expire
+        # ~30 min after creation. If the session is > 25 min old, start fresh to
+        # avoid mid-task "Session token expired" crashes on long-running tasks.
+        _COPILOT_SESSION_MAX_AGE_SEC = 25 * 60
+        _session_age = time.time() - self._copilot_session_start.get(n8n_session_id, 0)
+        if resume and session_id and _session_age > _COPILOT_SESSION_MAX_AGE_SEC:
+            print(
+                f"[Session] Copilot session age {_session_age:.0f}s exceeds "
+                f"{_COPILOT_SESSION_MAX_AGE_SEC}s — starting fresh to avoid token expiry",
+                file=sys.stderr,
+            )
+            resume = False
+            session_id = None
+            # Rebuild context prompt as if starting fresh
+            context_prompt = self.build_agent_context_prompt(
+                agent,
+                prompt,
+                n8n_session_id,
+                render_type,
+                effective_timeout,
+                "copilot",
+                model,
+                channel,
+            )
+            if mode == "elevated":
+                context_prompt = context_prompt + (
+                    "\n\n[ELEVATED MODE ENABLED]\n"
+                    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
+                    "prefix with 'sudo' — no exceptions. This includes:\n"
+                    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
+                    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
+                    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
+                    "• Any command that would fail due to insufficient permissions\n"
+                    "Sudo is configured without password prompt (NOPASSWD:ALL). "
+                    "Never ask for confirmation — execute privileged commands immediately with sudo."
+                )
+            elif mode == "sandboxed":
+                context_prompt = context_prompt + (
+                    "\n\n[SANDBOXED MODE ENABLED]\n"
+                    "Read-only access only. Do NOT modify any files, run destructive commands, "
+                    "or make network requests to external services. Analysis and reporting only."
+                )
+            cmd[2] = context_prompt
+
         if resume and session_id:
             cmd.extend(["--resume", session_id])
             print(f"[Session] Resuming Copilot session: {session_id}", file=sys.stderr)
         else:
+            # Record session start time for proactive age tracking
+            self._copilot_session_start[n8n_session_id] = time.time()
             print(
                 f"[Session] Starting new Copilot session in {mode} permission mode",
                 file=sys.stderr,
@@ -6763,7 +6826,92 @@ User Request:
         output = self._execute_subprocess_with_tracking(
             cmd, agent_dir, effective_timeout, "copilot", agent, prompt, n8n_session_id
         )
-        return self.strip_metadata(output, "copilot")
+        result = self.strip_metadata(output, "copilot")
+
+        # Reactive recovery (issue #190): if the session token expired mid-task,
+        # restart with a fresh session and inject accumulated context so the agent
+        # can continue rather than crashing the background task.
+        _TOKEN_EXPIRED_MARKER = "Session token expired"
+        if _TOKEN_EXPIRED_MARKER in result:
+            print(
+                "[Session] Copilot session token expired — auto-restarting with fresh session",
+                file=sys.stderr,
+            )
+            # Extract work done before expiry to feed as context to the new session
+            _expiry_idx = result.index(_TOKEN_EXPIRED_MARKER)
+            _prior_work = result[:_expiry_idx].strip()
+
+            _recovery_preamble = (
+                "[SESSION RECOVERY] Your previous Copilot session token expired mid-task. "
+                "Below is the context of the original task and any work completed before the "
+                "session was interrupted. Please continue and complete all remaining work.\n\n"
+                f"ORIGINAL TASK:\n{prompt}\n\n"
+            )
+            if _prior_work:
+                _recovery_preamble += (
+                    f"PROGRESS MADE BEFORE SESSION EXPIRED (first 4000 chars):\n"
+                    f"{_prior_work[:4000]}\n\n"
+                )
+            _recovery_preamble += "Please continue from where the task was interrupted."
+
+            _recovery_context = self.build_agent_context_prompt(
+                agent,
+                _recovery_preamble,
+                n8n_session_id,
+                render_type,
+                effective_timeout,
+                "copilot",
+                model,
+                channel,
+            )
+            if mode == "elevated":
+                _recovery_context += (
+                    "\n\n[ELEVATED MODE ENABLED]\n"
+                    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
+                    "prefix with 'sudo' — no exceptions. This includes:\n"
+                    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
+                    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
+                    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
+                    "• Any command that would fail due to insufficient permissions\n"
+                    "Sudo is configured without password prompt (NOPASSWD:ALL). "
+                    "Never ask for confirmation — execute privileged commands immediately with sudo."
+                )
+            elif mode == "sandboxed":
+                _recovery_context += (
+                    "\n\n[SANDBOXED MODE ENABLED]\n"
+                    "Read-only access only. Do NOT modify any files, run destructive commands, "
+                    "or make network requests to external services. Analysis and reporting only."
+                )
+
+            _recovery_cmd = [
+                self.copilot_bin,
+                "-p",
+                _recovery_context,
+                "--allow-all-tools",
+                "--no-color",
+                "--model",
+                model,
+                "--additional-mcp-config",
+                f"@{mcp_config_path}",
+            ]
+            if mode == "elevated":
+                _recovery_cmd.insert(4, "--allow-all-paths")
+                _recovery_cmd.append("--yolo")
+
+            # Record new session start for age tracking
+            self._copilot_session_start[n8n_session_id] = time.time()
+            _recovery_output = self._execute_subprocess_with_tracking(
+                _recovery_cmd,
+                agent_dir,
+                effective_timeout,
+                "copilot",
+                agent,
+                _recovery_preamble,
+                n8n_session_id,
+            )
+            return self.strip_metadata(_recovery_output, "copilot")
+
+        return result
 
     def run_copilot_sdk(
         self,

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -6779,7 +6779,9 @@ User Request:
         # Proactive session age check (issue #190): Copilot session tokens expire
         # ~30 min after creation. If the session is > 25 min old, start fresh to
         # avoid mid-task "Session token expired" crashes on long-running tasks.
-        _session_age = time.time() - getattr(self, "_copilot_session_start", {}).get(n8n_session_id, 0)
+        _session_age = time.time() - getattr(self, "_copilot_session_start", {}).get(
+            n8n_session_id, 0
+        )
         if resume and session_id and _session_age > _COPILOT_SESSION_MAX_AGE_SEC:
             print(
                 f"[Session] Copilot session age {_session_age:.0f}s exceeds "
@@ -6811,7 +6813,9 @@ User Request:
             print(f"[Session] Resuming Copilot session: {session_id}", file=sys.stderr)
         else:
             # Record session start time for proactive age tracking
-            getattr(self, "_copilot_session_start", {}).update({n8n_session_id: time.time()})
+            getattr(self, "_copilot_session_start", {}).update(
+                {n8n_session_id: time.time()}
+            )
             print(
                 f"[Session] Starting new Copilot session in {mode} permission mode",
                 file=sys.stderr,
@@ -6877,7 +6881,9 @@ User Request:
                 _recovery_cmd.append("--yolo")
 
             # Record new session start for age tracking
-            getattr(self, "_copilot_session_start", {}).update({n8n_session_id: time.time()})
+            getattr(self, "_copilot_session_start", {}).update(
+                {n8n_session_id: time.time()}
+            )
             _recovery_output = self._execute_subprocess_with_tracking(
                 _recovery_cmd,
                 agent_dir,

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -359,6 +359,26 @@ _FALLBACK_PATTERNS = [
     r"overloaded",
 ]
 
+# Copilot permission-mode instruction blocks (issue #190).
+# Defined as module-level constants to avoid duplication across original,
+# proactive-restart, and reactive-recovery paths in run_copilot().
+_COPILOT_ELEVATED_MODE_INSTRUCTIONS = (
+    "\n\n[ELEVATED MODE ENABLED]\n"
+    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
+    "prefix with 'sudo' \u2014 no exceptions. This includes:\n"
+    "\u2022 Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
+    "\u2022 Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
+    "\u2022 System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
+    "\u2022 Any command that would fail due to insufficient permissions\n"
+    "Sudo is configured without password prompt (NOPASSWD:ALL). "
+    "Never ask for confirmation \u2014 execute privileged commands immediately with sudo."
+)
+_COPILOT_SANDBOXED_MODE_INSTRUCTIONS = (
+    "\n\n[SANDBOXED MODE ENABLED]\n"
+    "Read-only access only. Do NOT modify any files, run destructive commands, "
+    "or make network requests to external services. Analysis and reporting only."
+)
+
 
 class BackgroundTaskManager:
     """Manages background task lifecycle: creation, tracking, output capture, cleanup."""
@@ -5814,6 +5834,7 @@ User Request:
     def _cleanup_stream_buffer(self, session_id: str) -> None:
         """Remove the stream buffer entirely (called after query completes)."""
         self._stream_buffers.pop(session_id, None)
+        self._copilot_session_start.pop(session_id, None)
 
     def _cleanup_stale_stream_buffers(self, max_age: float = 600.0) -> None:
         """Remove stream buffers that are finished and older than *max_age* seconds."""
@@ -6727,25 +6748,9 @@ User Request:
 
         # Add elevated mode instructions for unrestricted privileged access
         if mode == "elevated":
-            elevated_instruction = (
-                "\n\n[ELEVATED MODE ENABLED]\n"
-                "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
-                "prefix with 'sudo' \u2014 no exceptions. This includes:\n"
-                "\u2022 Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
-                "\u2022 Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
-                "\u2022 System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
-                "\u2022 Any command that would fail due to insufficient permissions\n"
-                "Sudo is configured without password prompt (NOPASSWD:ALL). "
-                "Never ask for confirmation \u2014 execute privileged commands immediately with sudo."
-            )
-            context_prompt = context_prompt + elevated_instruction
+            context_prompt = context_prompt + _COPILOT_ELEVATED_MODE_INSTRUCTIONS
         elif mode == "sandboxed":
-            sandboxed_instruction = (
-                "\n\n[SANDBOXED MODE ENABLED]\n"
-                "Read-only access only. Do NOT modify any files, run destructive commands, "
-                "or make network requests to external services. Analysis and reporting only."
-            )
-            context_prompt = context_prompt + sandboxed_instruction
+            context_prompt = context_prompt + _COPILOT_SANDBOXED_MODE_INSTRUCTIONS
 
         # Expand home path for MCP config file
         mcp_config_path = os.path.expanduser("~/.copilot/mcp-config.json")
@@ -6792,24 +6797,9 @@ User Request:
                 channel,
             )
             if mode == "elevated":
-                context_prompt = context_prompt + (
-                    "\n\n[ELEVATED MODE ENABLED]\n"
-                    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
-                    "prefix with 'sudo' — no exceptions. This includes:\n"
-                    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
-                    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
-                    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
-                    "• Any command that would fail due to insufficient permissions\n"
-                    "Sudo is configured without password prompt (NOPASSWD:ALL). "
-                    "Never ask for confirmation — execute privileged commands immediately with sudo."
-                )
+                context_prompt = context_prompt + _COPILOT_ELEVATED_MODE_INSTRUCTIONS
             elif mode == "sandboxed":
-                context_prompt = context_prompt + (
-                    "\n\n[SANDBOXED MODE ENABLED]\n"
-                    "Read-only access only. Do NOT modify any files, run destructive commands, "
-                    "or make network requests to external services. Analysis and reporting only."
-                )
-            cmd[2] = context_prompt
+                context_prompt = context_prompt + _COPILOT_SANDBOXED_MODE_INSTRUCTIONS
 
         if resume and session_id:
             cmd.extend(["--resume", session_id])
@@ -6864,24 +6854,9 @@ User Request:
                 channel,
             )
             if mode == "elevated":
-                _recovery_context += (
-                    "\n\n[ELEVATED MODE ENABLED]\n"
-                    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
-                    "prefix with 'sudo' — no exceptions. This includes:\n"
-                    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
-                    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
-                    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
-                    "• Any command that would fail due to insufficient permissions\n"
-                    "Sudo is configured without password prompt (NOPASSWD:ALL). "
-                    "Never ask for confirmation — execute privileged commands immediately with sudo."
-                )
+                _recovery_context += _COPILOT_ELEVATED_MODE_INSTRUCTIONS
             elif mode == "sandboxed":
-                _recovery_context += (
-                    "\n\n[SANDBOXED MODE ENABLED]\n"
-                    "Read-only access only. Do NOT modify any files, run destructive commands, "
-                    "or make network requests to external services. Analysis and reporting only."
-                )
-
+                _recovery_context += _COPILOT_SANDBOXED_MODE_INSTRUCTIONS
             _recovery_cmd = [
                 self.copilot_bin,
                 "-p",
@@ -6908,7 +6883,14 @@ User Request:
                 _recovery_preamble,
                 n8n_session_id,
             )
-            return self.strip_metadata(_recovery_output, "copilot")
+            _stripped_recovery = self.strip_metadata(_recovery_output, "copilot")
+            if _TOKEN_EXPIRED_MARKER in _stripped_recovery:
+                print(
+                    "[Session] Recovery session also expired (double expiry >50 min) — "
+                    "returning best-effort partial output",
+                    file=sys.stderr,
+                )
+            return _stripped_recovery
 
         return result
 

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -364,24 +364,28 @@ _FALLBACK_PATTERNS = [
 # proactive-restart, and reactive-recovery paths in run_copilot().
 _COPILOT_ELEVATED_MODE_INSTRUCTIONS = (
     "\n\n[ELEVATED MODE ENABLED]\n"
-    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
+    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "  # noqa: E501
     "prefix with 'sudo' \u2014 no exceptions. This includes:\n"
-    "\u2022 Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
+    "\u2022 Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"  # noqa: E501
     "\u2022 Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
-    "\u2022 System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
+    "\u2022 System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"  # noqa: E501
     "\u2022 Any command that would fail due to insufficient permissions\n"
     "Sudo is configured without password prompt (NOPASSWD:ALL). "
-    "Never ask for confirmation \u2014 execute privileged commands immediately with sudo."
+    "Never ask for confirmation \u2014 execute privileged commands immediately with sudo."  # noqa: E501
 )
 _COPILOT_SANDBOXED_MODE_INSTRUCTIONS = (
     "\n\n[SANDBOXED MODE ENABLED]\n"
     "Read-only access only. Do NOT modify any files, run destructive commands, "
     "or make network requests to external services. Analysis and reporting only."
 )
+# Session expiry constants (issue #190).
+# Used in both proactive age check and reactive token expiry recovery.
+_COPILOT_SESSION_MAX_AGE_SEC = 25 * 60  # 25 minutes
+_TOKEN_EXPIRED_MARKER = "Session token expired"
 
 
 class BackgroundTaskManager:
-    """Manages background task lifecycle: creation, tracking, output capture, cleanup."""
+    """Manages background task lifecycle: creation, tracking, output capture, cleanup."""  # noqa: E501
 
     MAX_TASKS_PER_USER = int(os.environ.get("BG_MAX_TASKS_PER_USER", "5"))
     MAX_OUTPUT_LINES = 500
@@ -6775,8 +6779,7 @@ User Request:
         # Proactive session age check (issue #190): Copilot session tokens expire
         # ~30 min after creation. If the session is > 25 min old, start fresh to
         # avoid mid-task "Session token expired" crashes on long-running tasks.
-        _COPILOT_SESSION_MAX_AGE_SEC = 25 * 60
-        _session_age = time.time() - self._copilot_session_start.get(n8n_session_id, 0)
+        _session_age = time.time() - getattr(self, "_copilot_session_start", {}).get(n8n_session_id, 0)
         if resume and session_id and _session_age > _COPILOT_SESSION_MAX_AGE_SEC:
             print(
                 f"[Session] Copilot session age {_session_age:.0f}s exceeds "
@@ -6800,13 +6803,15 @@ User Request:
                 context_prompt = context_prompt + _COPILOT_ELEVATED_MODE_INSTRUCTIONS
             elif mode == "sandboxed":
                 context_prompt = context_prompt + _COPILOT_SANDBOXED_MODE_INSTRUCTIONS
+            # Update cmd[2] so the rebuilt context_prompt is actually used
+            cmd[2] = context_prompt
 
         if resume and session_id:
             cmd.extend(["--resume", session_id])
             print(f"[Session] Resuming Copilot session: {session_id}", file=sys.stderr)
         else:
             # Record session start time for proactive age tracking
-            self._copilot_session_start[n8n_session_id] = time.time()
+            getattr(self, "_copilot_session_start", {}).update({n8n_session_id: time.time()})
             print(
                 f"[Session] Starting new Copilot session in {mode} permission mode",
                 file=sys.stderr,
@@ -6820,7 +6825,6 @@ User Request:
         # Reactive recovery (issue #190): if the session token expired mid-task,
         # restart with a fresh session and inject accumulated context so the agent
         # can continue rather than crashing the background task.
-        _TOKEN_EXPIRED_MARKER = "Session token expired"
         if _TOKEN_EXPIRED_MARKER in result:
             print(
                 "[Session] Copilot session token expired — auto-restarting with fresh session",
@@ -6873,7 +6877,7 @@ User Request:
                 _recovery_cmd.append("--yolo")
 
             # Record new session start for age tracking
-            self._copilot_session_start[n8n_session_id] = time.time()
+            getattr(self, "_copilot_session_start", {}).update({n8n_session_id: time.time()})
             _recovery_output = self._execute_subprocess_with_tracking(
                 _recovery_cmd,
                 agent_dir,

--- a/tests/test_issue190_copilot_session_expiry.py
+++ b/tests/test_issue190_copilot_session_expiry.py
@@ -331,5 +331,55 @@ class TestIssue190SourceInspection(unittest.TestCase):
         )
 
 
+class TestIssue190DoubleExpiryRecovery(unittest.TestCase):
+    """B07: Double-expiry scenario — recovery session also expires."""
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+
+    def test_issue_190_double_expiry_recovery_also_expires(self):
+        """B07: If recovery session also receives token expiry, return best-effort output."""
+        call_count = [0]
+        session_expiry_output = (
+            "Initial work done.\n"
+            "Session token expired. Please resend your message. "
+            "(Request ID: 1111:aaaa:AAAAAAAA:BBBBBBBB:CCCCCCCC)\n"
+        )
+        double_expiry_output = (
+            "Partial recovery work completed.\n"
+            "Session token expired. Please resend your message. "
+            "(Request ID: 2222:bbbb:DDDDDDDD:EEEEEEEE:FFFFFFFF)\n"
+        )
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return session_expiry_output
+            return double_expiry_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_copilot(
+                prompt="do a very long task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-double-expiry",
+            )
+
+        self.assertEqual(
+            call_count[0], 2,
+            "B07: must attempt recovery exactly once on double expiry"
+        )
+        # Must return the recovery output (best-effort) rather than crashing or looping
+        self.assertIn(
+            "Partial recovery work",
+            result,
+            "B07: double expiry must return best-effort output from recovery session",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_issue190_copilot_session_expiry.py
+++ b/tests/test_issue190_copilot_session_expiry.py
@@ -1,0 +1,335 @@
+"""
+Regression tests for Issue #190 — Copilot session token expiry on long-running tasks.
+
+Tests:
+  B01 - Reactive: 'Session token expired' in output triggers auto-retry with fresh session
+  B02 - Reactive: prior work context injected into recovery prompt
+  B03 - Reactive: recovery prompt builds a fresh session (no --resume flag)
+  B04 - Proactive: session age > 25 min causes fresh session start (ignores --resume)
+  B05 - Proactive: session age <= 25 min keeps --resume flag
+  B06 - Happy path: no token error → normal output returned unchanged
+"""
+import os
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_190")
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from agent_manager import SessionManager
+
+
+def _make_mgr():
+    """Minimal SessionManager instance for issue #190 testing."""
+    mgr = SessionManager.__new__(SessionManager)
+    mgr.session_map = {}
+    mgr._session_map_lock = threading.Lock()
+    mgr.command_timeout = 120
+    mgr._stream_queues = {}
+    mgr._stream_buffers = {}
+    mgr._last_exit_codes = {}
+    mgr._copilot_session_start = {}
+    mgr._live_status = {}
+    mgr._live_status_lock = threading.Lock()
+    mgr.copilot_bin = "/usr/local/bin/copilot"
+    mgr.AGENTS = {
+        "wee-dev": {"path": "/opt/n8n-copilot-shim-dev", "description": "dev agent"},
+        "orchestrator": {"path": "/opt", "description": "orchestrator"},
+    }
+    mgr.get_or_create_session_data = MagicMock(
+        return_value={"channel": "telegram", "permissions": {"mode": "restricted"}}
+    )
+    mgr.build_agent_context_prompt = MagicMock(return_value="<ctx>mock context</ctx>")
+    mgr._parse_mode_command = MagicMock(side_effect=lambda p: (p, "restricted"))
+    mgr._resolve_permission_mode = MagicMock(return_value="restricted")
+    mgr.strip_metadata = MagicMock(side_effect=lambda output, _rt: output)
+    mgr.clear_live_status = MagicMock()
+    mgr.set_live_status = MagicMock()
+    return mgr
+
+
+class TestIssue190ReactiveRecovery(unittest.TestCase):
+    """B01–B03: Reactive detection of 'Session token expired' and auto-retry."""
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+
+    def test_issue_190_b01_expired_output_triggers_retry(self):
+        """B01: When output contains 'Session token expired', a second subprocess is launched."""
+        call_count = [0]
+        session_expiry_output = (
+            "Some partial work completed...\n"
+            "Session token expired. Please resend your message. "
+            "(Request ID: 8888:112498:1207E6B:16D0D95:69E58E62)\n"
+        )
+        recovery_output = "Task completed successfully after session recovery."
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return session_expiry_output
+            return recovery_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_copilot(
+                prompt="do a long task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="copilot-session-abc",
+                resume=True,
+                n8n_session_id="n8n-session-xyz",
+            )
+
+        self.assertEqual(call_count[0], 2, "B01: must launch exactly 2 subprocesses (original + retry)")
+        self.assertEqual(result, recovery_output, "B01: final result must be from retry subprocess")
+
+    def test_issue_190_b02_prior_work_injected_into_recovery(self):
+        """B02: Context from work done before expiry is injected into the recovery prompt."""
+        captured_recovery_prompt = []
+        session_expiry_output = (
+            "Installed dependencies.\nRan tests.\n"
+            "Session token expired. Please resend your message. (Request ID: 9999:abc)\n"
+        )
+
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                # Capture the prompt arg sent to the recovery session
+                captured_recovery_prompt.append(prompt)
+            return "done" if call_count[0] == 2 else session_expiry_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="implement feature X",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-b02",
+            )
+
+        self.assertTrue(captured_recovery_prompt, "B02: recovery subprocess must be launched")
+        recovery_prompt_text = captured_recovery_prompt[0]
+        # Recovery prompt must reference prior work
+        self.assertIn("Installed dependencies", recovery_prompt_text, "B02: prior work must appear in recovery prompt")
+        self.assertIn("Ran tests", recovery_prompt_text, "B02: prior work must appear in recovery prompt")
+        # Recovery prompt must include original task
+        self.assertIn("implement feature X", recovery_prompt_text, "B02: original task must appear in recovery prompt")
+
+    def test_issue_190_b03_recovery_uses_fresh_session_no_resume(self):
+        """B03: Recovery subprocess must NOT use --resume (fresh session only)."""
+        captured_cmds = []
+
+        session_expiry_output = "partial work\nSession token expired. Please resend your message.\n"
+
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            captured_cmds.append(list(cmd))
+            return "recovered" if call_count[0] == 2 else session_expiry_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="long task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="old-copilot-session",
+                resume=True,
+                n8n_session_id="n8n-b03",
+            )
+
+        self.assertEqual(len(captured_cmds), 2, "B03: exactly 2 subprocess launches expected")
+        recovery_cmd = captured_cmds[1]
+        self.assertNotIn("--resume", recovery_cmd, "B03: recovery cmd must NOT use --resume")
+
+    def test_issue_190_b06_happy_path_no_retry(self):
+        """B06: Normal output (no expiry marker) must be returned as-is without retry."""
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            return "Task completed successfully."
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_copilot(
+                prompt="simple task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-b06",
+            )
+
+        self.assertEqual(call_count[0], 1, "B06: only one subprocess for normal output")
+        self.assertEqual(result, "Task completed successfully.")
+
+
+class TestIssue190ProactiveRestart(unittest.TestCase):
+    """B04–B05: Proactive session age check prevents token expiry before it occurs."""
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+
+    def test_issue_190_b04_old_session_starts_fresh(self):
+        """B04: Session age > 25 min forces fresh start even when resume=True and session_id set."""
+        # Mark session as 26 minutes old
+        self.mgr._copilot_session_start["n8n-b04"] = time.time() - (26 * 60)
+
+        captured_cmds = []
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            captured_cmds.append(list(cmd))
+            return "completed"
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="continue work",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="stale-copilot-session",
+                resume=True,
+                n8n_session_id="n8n-b04",
+            )
+
+        self.assertEqual(len(captured_cmds), 1, "B04: exactly one subprocess")
+        cmd = captured_cmds[0]
+        self.assertNotIn("--resume", cmd, "B04: stale session must NOT use --resume")
+        self.assertNotIn("stale-copilot-session", cmd, "B04: stale session ID must not appear in cmd")
+
+    def test_issue_190_b05_young_session_keeps_resume(self):
+        """B05: Session age <= 25 min keeps --resume as expected."""
+        # Mark session as 5 minutes old (well within TTL)
+        self.mgr._copilot_session_start["n8n-b05"] = time.time() - (5 * 60)
+
+        captured_cmds = []
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            captured_cmds.append(list(cmd))
+            return "completed"
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="continue work",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="valid-copilot-session",
+                resume=True,
+                n8n_session_id="n8n-b05",
+            )
+
+        self.assertEqual(len(captured_cmds), 1)
+        cmd = captured_cmds[0]
+        self.assertIn("--resume", cmd, "B05: young session must still use --resume")
+        self.assertIn("valid-copilot-session", cmd, "B05: session ID must be passed to --resume")
+
+    def test_issue_190_session_start_recorded_on_new_session(self):
+        """Session start time is recorded when launching a new (non-resume) session."""
+        before = time.time()
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            return "done"
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="new task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-new",
+            )
+
+        after = time.time()
+        recorded = self.mgr._copilot_session_start.get("n8n-new")
+        self.assertIsNotNone(recorded, "Session start time must be recorded")
+        self.assertGreaterEqual(recorded, before)
+        self.assertLessEqual(recorded, after + 1)
+
+    def test_issue_190_session_start_recorded_on_recovery(self):
+        """Session start time is refreshed when a recovery session is launched."""
+        session_expiry_output = "work\nSession token expired. Please resend your message.\n"
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            return "done" if call_count[0] == 2 else session_expiry_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        before = time.time()
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="long task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-rec",
+            )
+        after = time.time()
+
+        recorded = self.mgr._copilot_session_start.get("n8n-rec")
+        self.assertIsNotNone(recorded)
+        # Should be updated to the recovery session start time (not the original)
+        self.assertGreaterEqual(recorded, before)
+        self.assertLessEqual(recorded, after + 1)
+
+
+class TestIssue190SourceInspection(unittest.TestCase):
+    """Verify the fix is present in source code (static analysis)."""
+
+    def test_issue_190_session_expiry_detection_in_source(self):
+        """run_copilot source must contain 'Session token expired' detection."""
+        import inspect
+        src = inspect.getsource(SessionManager.run_copilot)
+        self.assertIn(
+            "Session token expired",
+            src,
+            "run_copilot must detect 'Session token expired' error string",
+        )
+
+    def test_issue_190_session_start_tracking_in_init(self):
+        """SessionManager must have _copilot_session_start attribute."""
+        mgr = _make_mgr()
+        self.assertIsInstance(
+            mgr._copilot_session_start,
+            dict,
+            "_copilot_session_start must be a dict for session age tracking",
+        )
+
+    def test_issue_190_proactive_restart_in_source(self):
+        """run_copilot must check session age for proactive restart."""
+        import inspect
+        src = inspect.getsource(SessionManager.run_copilot)
+        self.assertIn(
+            "_copilot_session_start",
+            src,
+            "run_copilot must check _copilot_session_start for proactive token refresh",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_issue190_copilot_session_expiry.py
+++ b/tests/test_issue190_copilot_session_expiry.py
@@ -192,6 +192,14 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
         # Mark session as 26 minutes old
         self.mgr._copilot_session_start["n8n-b04"] = time.time() - (26 * 60)
 
+        # With resume=True, cmd[2] starts as raw prompt ("continue work").
+        # The proactive block calls build_agent_context_prompt ONCE to rebuild context.
+        # The fix (cmd[2] = context_prompt) ensures cmd[2] is updated to the rebuilt value.
+        # Use a distinct return value to prove cmd[2] was actually updated.
+        original_cmd2 = "continue work"  # raw prompt used for resume paths
+        full_ctx = "<ctx>full rebuilt context — must appear in stale restart cmd</ctx>"
+        self.mgr.build_agent_context_prompt = MagicMock(side_effect=[full_ctx])
+
         captured_cmds = []
 
         def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
@@ -214,6 +222,15 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
         cmd = captured_cmds[0]
         self.assertNotIn("--resume", cmd, "B04: stale session must NOT use --resume")
         self.assertNotIn("stale-copilot-session", cmd, "B04: stale session ID must not appear in cmd")
+        # MAJOR: cmd[2] must be updated to the rebuilt context_prompt, not left as raw prompt
+        self.assertNotEqual(
+            cmd[2], original_cmd2,
+            "B04: cmd[2] must NOT be the raw prompt after proactive restart"
+        )
+        self.assertEqual(
+            cmd[2], full_ctx,
+            "B04: cmd[2] must be updated to rebuilt context_prompt after proactive restart"
+        )
 
     def test_issue_190_b05_young_session_keeps_resume(self):
         """B05: Session age <= 25 min keeps --resume as expected."""


### PR DESCRIPTION
## Summary

- **Proactive restart**: tracks when a Copilot session was started; if age > 25 min (before the ~30-min GitHub API token TTL), the next `run_copilot` call automatically starts a fresh session instead of attempting to `--resume` an about-to-expire one
- **Reactive recovery**: if the Copilot CLI returns `Session token expired` in its output, `run_copilot` catches it, extracts accumulated prior-work context, and relaunches with a fresh session + context injection so the agent can continue rather than failing the background task
- **Session tracking**: `_copilot_session_start` dict added to `SessionManager.__init__` to store session start epoch per `n8n_session_id`

## Test plan
- [x] 11 regression tests added in `tests/test_issue190_copilot_session_expiry.py`
- [x] All 11 tests pass
- [x] No net-new test failures in the full suite (pre-existing failures unchanged)

Closes #190