### PR TITLE
fix: persist copilot session_id after proactive/reactive recovery

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -7068,6 +7068,11 @@ User Request:
                     "or make network requests to external services. Analysis and reporting only."
                 )
             cmd[2] = context_prompt
+            # Mark proactive recovery so we fetch and persist the new session_id
+            # after execution completes
+            _proactive_recovery_triggered = True
+        else:
+            _proactive_recovery_triggered = False
 
         if resume and session_id:
             cmd.extend(["--resume", session_id])
@@ -7166,8 +7171,21 @@ User Request:
                 _recovery_preamble,
                 n8n_session_id,
             )
-            return self.strip_metadata(_recovery_output, "copilot")
+            _recovery_result = self.strip_metadata(_recovery_output, "copilot")
+            
+            # Persist the new session_id from reactive recovery (issue #190)
+            _new_session_id = self.get_most_recent_session_id("copilot", agent)
+            if _new_session_id:
+                self.update_session_field(n8n_session_id, "session_id", _new_session_id)
+            
+            return _recovery_result
 
+        # If proactive recovery was triggered, persist the new session_id (issue #190)
+        if _proactive_recovery_triggered:
+            _new_session_id = self.get_most_recent_session_id("copilot", agent)
+            if _new_session_id:
+                self.update_session_field(n8n_session_id, "session_id", _new_session_id)
+        
         return result
 
     def run_copilot_sdk(

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1601,6 +1601,7 @@ class SessionManager:
                 ["sonnet-thinking"],
             ),
             ("claude-sonnet-4.6", "Claude Sonnet 4.6", ["sonnet-4.6"]),
+            ("claude-opus-4.7", "Claude Opus 4.7", ["opus-4.7"]),
             ("claude-opus-4.5", "Claude Opus 4.5", ["opus-4.5"]),
             ("claude-opus-4.6", "Claude Opus 4.6", ["opus-4.6", "opus"]),
             ("claude-haiku-4.5", "Claude Haiku 4.5", ["haiku-4.5", "haiku"]),
@@ -1846,6 +1847,12 @@ class SessionManager:
 
         # Last subprocess exit code per n8n_session_id (for debugging/monitoring)
         self._last_exit_codes: Dict[str, int] = {}
+
+        # Copilot session start times for proactive token refresh (issue #190).
+        # Maps n8n_session_id -> float (epoch seconds when session was started).
+        # Copilot session tokens expire ~30 min after creation; we restart at 25 min.
+        self._copilot_session_start: Dict[str, float] = {}
+        _COPILOT_SESSION_MAX_AGE_SEC = 25 * 60  # restart at 25 min, before 30-min TTL
 
         # Per-session live status for mobile channel progress updates (F004).
         # Maps n8n_session_id -> {"text": str, "updated_at": float}
@@ -3372,7 +3379,11 @@ You can mention an agent in your prompt and it will auto-delegate:
     def _copilot_static_fallback(self) -> dict:
         # Static model list used when copilot CLI is unavailable
         return {
+            "Auto": [
+                "auto",
+            ],
             "Claude Models": [
+                "claude-opus-4.7",
                 "claude-sonnet-4.6",
                 "claude-opus-4.6",
                 "claude-haiku-4.5",
@@ -3430,7 +3441,7 @@ You can mention an agent in your prompt and it will auto-delegate:
                     for m in models
                     if any(
                         kw in m.lower()
-                        for kw in ["gpt", "claude", "gemini", "o1", "o3", "o4"]
+                        for kw in ["gpt", "claude", "gemini", "o1", "o3", "o4", "auto"]
                     )
                 ]
 
@@ -3438,6 +3449,8 @@ You can mention an agent in your prompt and it will auto-delegate:
             if not models:
                 # Look for known models as a sanity check/fallback
                 fallback_models = [
+                    "auto",
+                    "claude-opus-4.7",
                     "claude-sonnet-4.6",
                     "claude-sonnet-4.5",
                     "claude-haiku-4.5",
@@ -3473,7 +3486,11 @@ You can mention an agent in your prompt and it will auto-delegate:
                 # copilot CLI no longer lists models in --help (choices removed in newer versions).
                 # Return the static fallback list so /model list and /model set still work.
                 return {
+                    "Auto": [
+                        "auto",
+                    ],
                     "Claude Models": [
+                        "claude-opus-4.7",
                         "claude-sonnet-4.6",
                         "claude-opus-4.6",
                         "claude-haiku-4.5",
@@ -7008,10 +7025,56 @@ User Request:
             cmd.insert(4, "--allow-all-paths")
             cmd.append("--yolo")
 
+        # Proactive session age check (issue #190): Copilot session tokens expire
+        # ~30 min after creation. If the session is > 25 min old, start fresh to
+        # avoid mid-task "Session token expired" crashes on long-running tasks.
+        _COPILOT_SESSION_MAX_AGE_SEC = 25 * 60
+        _session_age = time.time() - self._copilot_session_start.get(n8n_session_id, 0)
+        if resume and session_id and _session_age > _COPILOT_SESSION_MAX_AGE_SEC:
+            print(
+                f"[Session] Copilot session age {_session_age:.0f}s exceeds "
+                f"{_COPILOT_SESSION_MAX_AGE_SEC}s — starting fresh to avoid token expiry",
+                file=sys.stderr,
+            )
+            resume = False
+            session_id = None
+            # Rebuild context prompt as if starting fresh
+            context_prompt = self.build_agent_context_prompt(
+                agent,
+                prompt,
+                n8n_session_id,
+                render_type,
+                effective_timeout,
+                "copilot",
+                model,
+                channel,
+            )
+            if mode == "elevated":
+                context_prompt = context_prompt + (
+                    "\n\n[ELEVATED MODE ENABLED]\n"
+                    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
+                    "prefix with 'sudo' — no exceptions. This includes:\n"
+                    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
+                    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
+                    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
+                    "• Any command that would fail due to insufficient permissions\n"
+                    "Sudo is configured without password prompt (NOPASSWD:ALL). "
+                    "Never ask for confirmation — execute privileged commands immediately with sudo."
+                )
+            elif mode == "sandboxed":
+                context_prompt = context_prompt + (
+                    "\n\n[SANDBOXED MODE ENABLED]\n"
+                    "Read-only access only. Do NOT modify any files, run destructive commands, "
+                    "or make network requests to external services. Analysis and reporting only."
+                )
+            cmd[2] = context_prompt
+
         if resume and session_id:
             cmd.extend(["--resume", session_id])
             print(f"[Session] Resuming Copilot session: {session_id}", file=sys.stderr)
         else:
+            # Record session start time for proactive age tracking
+            self._copilot_session_start[n8n_session_id] = time.time()
             print(
                 f"[Session] Starting new Copilot session in {mode} permission mode",
                 file=sys.stderr,
@@ -7020,7 +7083,92 @@ User Request:
         output = self._execute_subprocess_with_tracking(
             cmd, agent_dir, effective_timeout, "copilot", agent, prompt, n8n_session_id
         )
-        return self.strip_metadata(output, "copilot")
+        result = self.strip_metadata(output, "copilot")
+
+        # Reactive recovery (issue #190): if the session token expired mid-task,
+        # restart with a fresh session and inject accumulated context so the agent
+        # can continue rather than crashing the background task.
+        _TOKEN_EXPIRED_MARKER = "Session token expired"
+        if _TOKEN_EXPIRED_MARKER in result:
+            print(
+                "[Session] Copilot session token expired — auto-restarting with fresh session",
+                file=sys.stderr,
+            )
+            # Extract work done before expiry to feed as context to the new session
+            _expiry_idx = result.index(_TOKEN_EXPIRED_MARKER)
+            _prior_work = result[:_expiry_idx].strip()
+
+            _recovery_preamble = (
+                "[SESSION RECOVERY] Your previous Copilot session token expired mid-task. "
+                "Below is the context of the original task and any work completed before the "
+                "session was interrupted. Please continue and complete all remaining work.\n\n"
+                f"ORIGINAL TASK:\n{prompt}\n\n"
+            )
+            if _prior_work:
+                _recovery_preamble += (
+                    f"PROGRESS MADE BEFORE SESSION EXPIRED (first 4000 chars):\n"
+                    f"{_prior_work[:4000]}\n\n"
+                )
+            _recovery_preamble += "Please continue from where the task was interrupted."
+
+            _recovery_context = self.build_agent_context_prompt(
+                agent,
+                _recovery_preamble,
+                n8n_session_id,
+                render_type,
+                effective_timeout,
+                "copilot",
+                model,
+                channel,
+            )
+            if mode == "elevated":
+                _recovery_context += (
+                    "\n\n[ELEVATED MODE ENABLED]\n"
+                    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
+                    "prefix with 'sudo' — no exceptions. This includes:\n"
+                    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
+                    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
+                    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
+                    "• Any command that would fail due to insufficient permissions\n"
+                    "Sudo is configured without password prompt (NOPASSWD:ALL). "
+                    "Never ask for confirmation — execute privileged commands immediately with sudo."
+                )
+            elif mode == "sandboxed":
+                _recovery_context += (
+                    "\n\n[SANDBOXED MODE ENABLED]\n"
+                    "Read-only access only. Do NOT modify any files, run destructive commands, "
+                    "or make network requests to external services. Analysis and reporting only."
+                )
+
+            _recovery_cmd = [
+                self.copilot_bin,
+                "-p",
+                _recovery_context,
+                "--allow-all-tools",
+                "--no-color",
+                "--model",
+                model,
+                "--additional-mcp-config",
+                f"@{mcp_config_path}",
+            ]
+            if mode == "elevated":
+                _recovery_cmd.insert(4, "--allow-all-paths")
+                _recovery_cmd.append("--yolo")
+
+            # Record new session start for age tracking
+            self._copilot_session_start[n8n_session_id] = time.time()
+            _recovery_output = self._execute_subprocess_with_tracking(
+                _recovery_cmd,
+                agent_dir,
+                effective_timeout,
+                "copilot",
+                agent,
+                _recovery_preamble,
+                n8n_session_id,
+            )
+            return self.strip_metadata(_recovery_output, "copilot")
+
+        return result
 
     def run_copilot_sdk(
         self,
@@ -10556,7 +10704,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         session_mgr._get_model_description(model_id, runtime)
                         or model_id
                     )
-                    models.append({"id": model_id, "label": label, "group": _group})
+                    models.append({"id": model_id, "label": label, "group": group_name})
             return {"runtime": runtime, "models": models}
         except Exception as e:
             return {"runtime": runtime, "models": [], "error": str(e)}

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1852,7 +1852,6 @@ class SessionManager:
         # Maps n8n_session_id -> float (epoch seconds when session was started).
         # Copilot session tokens expire ~30 min after creation; we restart at 25 min.
         self._copilot_session_start: Dict[str, float] = {}
-        _COPILOT_SESSION_MAX_AGE_SEC = 25 * 60  # restart at 25 min, before 30-min TTL
 
         # Per-session live status for mobile channel progress updates (F004).
         # Maps n8n_session_id -> {"text": str, "updated_at": float}

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -100,6 +100,18 @@ _CURL_USER_RE = re.compile(
     r"""(-u\s+)(\S+)""",
 )
 
+_ELEVATED_MODE_INSTRUCTIONS = (
+    "\n\n[ELEVATED MODE ENABLED]\n"
+    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
+    "prefix with 'sudo' — no exceptions. This includes:\n"
+    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
+    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
+    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
+    "• Any command that would fail due to insufficient permissions\n"
+    "Sudo is configured without password prompt (NOPASSWD:ALL). "
+    "Never ask for confirmation — execute privileged commands immediately with sudo."
+)
+
 
 def _sanitize_command_for_display(text: str) -> str:
     """Redact sensitive headers and credentials from command strings for UI display.
@@ -6984,18 +6996,7 @@ User Request:
 
         # Add elevated mode instructions for unrestricted privileged access
         if mode == "elevated":
-            elevated_instruction = (
-                "\n\n[ELEVATED MODE ENABLED]\n"
-                "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
-                "prefix with 'sudo' \u2014 no exceptions. This includes:\n"
-                "\u2022 Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
-                "\u2022 Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
-                "\u2022 System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
-                "\u2022 Any command that would fail due to insufficient permissions\n"
-                "Sudo is configured without password prompt (NOPASSWD:ALL). "
-                "Never ask for confirmation \u2014 execute privileged commands immediately with sudo."
-            )
-            context_prompt = context_prompt + elevated_instruction
+            context_prompt = context_prompt + _ELEVATED_MODE_INSTRUCTIONS
         elif mode == "sandboxed":
             sandboxed_instruction = (
                 "\n\n[SANDBOXED MODE ENABLED]\n"
@@ -7049,17 +7050,7 @@ User Request:
                 channel,
             )
             if mode == "elevated":
-                context_prompt = context_prompt + (
-                    "\n\n[ELEVATED MODE ENABLED]\n"
-                    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
-                    "prefix with 'sudo' — no exceptions. This includes:\n"
-                    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
-                    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
-                    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
-                    "• Any command that would fail due to insufficient permissions\n"
-                    "Sudo is configured without password prompt (NOPASSWD:ALL). "
-                    "Never ask for confirmation — execute privileged commands immediately with sudo."
-                )
+                context_prompt = context_prompt + _ELEVATED_MODE_INSTRUCTIONS
             elif mode == "sandboxed":
                 context_prompt = context_prompt + (
                     "\n\n[SANDBOXED MODE ENABLED]\n"
@@ -7126,17 +7117,7 @@ User Request:
                 channel,
             )
             if mode == "elevated":
-                _recovery_context += (
-                    "\n\n[ELEVATED MODE ENABLED]\n"
-                    "Full permissions granted. ALL commands requiring elevated privileges MUST automatically "
-                    "prefix with 'sudo' — no exceptions. This includes:\n"
-                    "• Service management: sudo systemctl restart/start/stop/reload/enable/disable <service>\n"
-                    "• Network commands: sudo ping, sudo ssh, sudo iptables, sudo ip, etc.\n"
-                    "• System administration: sudo journalctl, sudo systemd-*, sudo chmod/chown on system paths\n"
-                    "• Any command that would fail due to insufficient permissions\n"
-                    "Sudo is configured without password prompt (NOPASSWD:ALL). "
-                    "Never ask for confirmation — execute privileged commands immediately with sudo."
-                )
+                _recovery_context += _ELEVATED_MODE_INSTRUCTIONS
             elif mode == "sandboxed":
                 _recovery_context += (
                     "\n\n[SANDBOXED MODE ENABLED]\n"
@@ -7171,12 +7152,22 @@ User Request:
                 n8n_session_id,
             )
             _recovery_result = self.strip_metadata(_recovery_output, "copilot")
-            
+
+            # Double-expiry guard: if the recovery session also expired, log a warning.
+            # The result is still returned as-is — the caller sees partial output rather
+            # than a silent truncation.
+            if _TOKEN_EXPIRED_MARKER in _recovery_result:
+                print(
+                    "[Session] WARNING: Copilot recovery session also expired — "
+                    "double-expiry detected; returning partial output",
+                    file=sys.stderr,
+                )
+
             # Persist the new session_id from reactive recovery (issue #190)
             _new_session_id = self.get_most_recent_session_id("copilot", agent)
             if _new_session_id:
                 self.update_session_field(n8n_session_id, "session_id", _new_session_id)
-            
+
             return _recovery_result
 
         # If proactive recovery was triggered, persist the new session_id (issue #190)

--- a/tests/test_issue190_copilot_session_expiry.py
+++ b/tests/test_issue190_copilot_session_expiry.py
@@ -327,3 +327,57 @@ class TestIssue190SourceInspection(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestIssue190DoubleExpiry(unittest.TestCase):
+    """B07: If the recovery session also expires, a warning is logged and output returned."""
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+        self.mgr.get_most_recent_session_id = MagicMock(return_value=None)
+        self.mgr.update_session_field = MagicMock()
+
+    def test_issue190_double_expiry_recovery_also_expires(self):
+        """B07: double-expiry logs a warning and returns the partial recovery output."""
+        first_expiry_output = (
+            "Partial work.\n"
+            "Session token expired. Please resend your message. (Request ID: aaa)\n"
+        )
+        second_expiry_output = (
+            "Started recovery.\n"
+            "Session token expired. Please resend your message. (Request ID: bbb)\n"
+        )
+
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return first_expiry_output
+            return second_expiry_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        import io
+
+        stderr_capture = io.StringIO()
+        with patch("sys.stderr", stderr_capture):
+            result = self.mgr.run_copilot(
+                prompt="long task that double-expires",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-double-expiry",
+            )
+
+        self.assertEqual(call_count[0], 2, "B07: exactly 2 subprocesses launched")
+        self.assertEqual(
+            result, second_expiry_output, "B07: partial recovery output returned"
+        )
+        warning_output = stderr_capture.getvalue()
+        self.assertIn(
+            "double-expiry",
+            warning_output,
+            "B07: double-expiry warning must be logged to stderr",
+        )

--- a/tests/test_issue190_copilot_session_expiry.py
+++ b/tests/test_issue190_copilot_session_expiry.py
@@ -333,3 +333,83 @@ class TestIssue190SourceInspection(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestIssue190SessionPersistence(unittest.TestCase):
+    """Regression test: session_id must persist after proactive/reactive recovery.
+    
+    When Copilot session recovery is triggered internally (proactive age-based or
+    reactive token-expiry), the new session_id must be persisted back to session_data.
+    
+    Fix: run_copilot() now calls get_most_recent_session_id() and update_session_field()
+    after both recovery paths to ensure the new session persists across turns.
+    """
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+        self.mgr.get_most_recent_session_id = MagicMock(return_value="new-session-xyz")
+        self.mgr.update_session_field = MagicMock()
+
+    def test_issue_190_persistence_proactive_recovery(self):
+        """Proactive recovery (age-based) should persist new session_id."""
+        n8n_session_id = "n8n-persist-proactive"
+        self.mgr._copilot_session_start[n8n_session_id] = time.time() - (26 * 60)
+        
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            return "Task completed with fresh session."
+        
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+        
+        with patch("sys.stderr"):
+            result = self.mgr.run_copilot(
+                prompt="long running task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="old-session-abc",
+                resume=True,
+                n8n_session_id=n8n_session_id,
+            )
+        
+        # Verify get_most_recent_session_id was called
+        self.mgr.get_most_recent_session_id.assert_called_with("copilot", "wee-dev")
+        
+        # Verify new session_id was persisted to session_data
+        self.mgr.update_session_field.assert_called_with(
+            n8n_session_id, "session_id", "new-session-xyz"
+        )
+
+    def test_issue_190_persistence_reactive_recovery(self):
+        """Reactive recovery (token expiry) should persist new session_id."""
+        session_expiry_output = (
+            "Some work done...\n"
+            "Session token expired. Please resend your message.\n"
+        )
+        
+        call_count = [0]
+        
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            return session_expiry_output if call_count[0] == 1 else "Task recovered."
+        
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+        n8n_session_id = "n8n-persist-reactive"
+        
+        with patch("sys.stderr"):
+            result = self.mgr.run_copilot(
+                prompt="task causing expiry",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="active-session-123",
+                resume=True,
+                n8n_session_id=n8n_session_id,
+            )
+        
+        # Verify get_most_recent_session_id was called after reactive recovery
+        self.mgr.get_most_recent_session_id.assert_called_with("copilot", "wee-dev")
+        
+        # Verify the new session_id was persisted
+        self.mgr.update_session_field.assert_called_with(
+            n8n_session_id, "session_id", "new-session-xyz"
+        )
+        
+        self.assertIn("recovered", result)

--- a/tests/test_issue190_copilot_session_expiry.py
+++ b/tests/test_issue190_copilot_session_expiry.py
@@ -1,0 +1,335 @@
+"""
+Regression tests for Issue #190 — Copilot session token expiry on long-running tasks.
+
+Tests:
+  B01 - Reactive: 'Session token expired' in output triggers auto-retry with fresh session
+  B02 - Reactive: prior work context injected into recovery prompt
+  B03 - Reactive: recovery prompt builds a fresh session (no --resume flag)
+  B04 - Proactive: session age > 25 min causes fresh session start (ignores --resume)
+  B05 - Proactive: session age <= 25 min keeps --resume flag
+  B06 - Happy path: no token error → normal output returned unchanged
+"""
+import os
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_190")
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from agent_manager import SessionManager
+
+
+def _make_mgr():
+    """Minimal SessionManager instance for issue #190 testing."""
+    mgr = SessionManager.__new__(SessionManager)
+    mgr.session_map = {}
+    mgr._session_map_lock = threading.Lock()
+    mgr.command_timeout = 120
+    mgr._stream_queues = {}
+    mgr._stream_buffers = {}
+    mgr._last_exit_codes = {}
+    mgr._copilot_session_start = {}
+    mgr._live_status = {}
+    mgr._live_status_lock = threading.Lock()
+    mgr.copilot_bin = "/usr/local/bin/copilot"
+    mgr.AGENTS = {
+        "wee-dev": {"path": "/opt/n8n-copilot-shim-dev", "description": "dev agent"},
+        "orchestrator": {"path": "/opt", "description": "orchestrator"},
+    }
+    mgr.get_or_create_session_data = MagicMock(
+        return_value={"channel": "telegram", "permissions": {"mode": "restricted"}}
+    )
+    mgr.build_agent_context_prompt = MagicMock(return_value="<ctx>mock context</ctx>")
+    mgr._parse_mode_command = MagicMock(side_effect=lambda p: (p, "restricted"))
+    mgr._resolve_permission_mode = MagicMock(return_value="restricted")
+    mgr.strip_metadata = MagicMock(side_effect=lambda output, _rt: output)
+    mgr.clear_live_status = MagicMock()
+    mgr.set_live_status = MagicMock()
+    return mgr
+
+
+class TestIssue190ReactiveRecovery(unittest.TestCase):
+    """B01–B03: Reactive detection of 'Session token expired' and auto-retry."""
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+
+    def test_issue_190_b01_expired_output_triggers_retry(self):
+        """B01: When output contains 'Session token expired', a second subprocess is launched."""
+        call_count = [0]
+        session_expiry_output = (
+            "Some partial work completed...\n"
+            "Session token expired. Please resend your message. "
+            "(Request ID: 8888:112498:1207E6B:16D0D95:69E58E62)\n"
+        )
+        recovery_output = "Task completed successfully after session recovery."
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return session_expiry_output
+            return recovery_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_copilot(
+                prompt="do a long task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="copilot-session-abc",
+                resume=True,
+                n8n_session_id="n8n-session-xyz",
+            )
+
+        self.assertEqual(call_count[0], 2, "B01: must launch exactly 2 subprocesses (original + retry)")
+        self.assertEqual(result, recovery_output, "B01: final result must be from retry subprocess")
+
+    def test_issue_190_b02_prior_work_injected_into_recovery(self):
+        """B02: Context from work done before expiry is injected into the recovery prompt."""
+        captured_recovery_prompt = []
+        session_expiry_output = (
+            "Installed dependencies.\nRan tests.\n"
+            "Session token expired. Please resend your message. (Request ID: 9999:abc)\n"
+        )
+
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                # Capture the prompt arg sent to the recovery session
+                captured_recovery_prompt.append(prompt)
+            return "done" if call_count[0] == 2 else session_expiry_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="implement feature X",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-b02",
+            )
+
+        self.assertTrue(captured_recovery_prompt, "B02: recovery subprocess must be launched")
+        recovery_prompt_text = captured_recovery_prompt[0]
+        # Recovery prompt must reference prior work
+        self.assertIn("Installed dependencies", recovery_prompt_text, "B02: prior work must appear in recovery prompt")
+        self.assertIn("Ran tests", recovery_prompt_text, "B02: prior work must appear in recovery prompt")
+        # Recovery prompt must include original task
+        self.assertIn("implement feature X", recovery_prompt_text, "B02: original task must appear in recovery prompt")
+
+    def test_issue_190_b03_recovery_uses_fresh_session_no_resume(self):
+        """B03: Recovery subprocess must NOT use --resume (fresh session only)."""
+        captured_cmds = []
+
+        session_expiry_output = "partial work\nSession token expired. Please resend your message.\n"
+
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            captured_cmds.append(list(cmd))
+            return "recovered" if call_count[0] == 2 else session_expiry_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="long task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="old-copilot-session",
+                resume=True,
+                n8n_session_id="n8n-b03",
+            )
+
+        self.assertEqual(len(captured_cmds), 2, "B03: exactly 2 subprocess launches expected")
+        recovery_cmd = captured_cmds[1]
+        self.assertNotIn("--resume", recovery_cmd, "B03: recovery cmd must NOT use --resume")
+
+    def test_issue_190_b06_happy_path_no_retry(self):
+        """B06: Normal output (no expiry marker) must be returned as-is without retry."""
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            return "Task completed successfully."
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            result = self.mgr.run_copilot(
+                prompt="simple task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-b06",
+            )
+
+        self.assertEqual(call_count[0], 1, "B06: only one subprocess for normal output")
+        self.assertEqual(result, "Task completed successfully.")
+
+
+class TestIssue190ProactiveRestart(unittest.TestCase):
+    """B04–B05: Proactive session age check prevents token expiry before it occurs."""
+
+    def setUp(self):
+        self.mgr = _make_mgr()
+
+    def test_issue_190_b04_old_session_starts_fresh(self):
+        """B04: Session age > 25 min forces fresh start even when resume=True and session_id set."""
+        # Mark session as 26 minutes old
+        self.mgr._copilot_session_start["n8n-b04"] = time.time() - (26 * 60)
+
+        captured_cmds = []
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            captured_cmds.append(list(cmd))
+            return "completed"
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="continue work",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="stale-copilot-session",
+                resume=True,
+                n8n_session_id="n8n-b04",
+            )
+
+        self.assertEqual(len(captured_cmds), 1, "B04: exactly one subprocess")
+        cmd = captured_cmds[0]
+        self.assertNotIn("--resume", cmd, "B04: stale session must NOT use --resume")
+        self.assertNotIn("stale-copilot-session", cmd, "B04: stale session ID must not appear in cmd")
+
+    def test_issue_190_b05_young_session_keeps_resume(self):
+        """B05: Session age <= 25 min keeps --resume as expected."""
+        # Mark session as 5 minutes old (well within TTL)
+        self.mgr._copilot_session_start["n8n-b05"] = time.time() - (5 * 60)
+
+        captured_cmds = []
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            captured_cmds.append(list(cmd))
+            return "completed"
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="continue work",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id="valid-copilot-session",
+                resume=True,
+                n8n_session_id="n8n-b05",
+            )
+
+        self.assertEqual(len(captured_cmds), 1)
+        cmd = captured_cmds[0]
+        self.assertIn("--resume", cmd, "B05: young session must still use --resume")
+        self.assertIn("valid-copilot-session", cmd, "B05: session ID must be passed to --resume")
+
+    def test_issue_190_session_start_recorded_on_new_session(self):
+        """Session start time is recorded when launching a new (non-resume) session."""
+        before = time.time()
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            return "done"
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="new task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-new",
+            )
+
+        after = time.time()
+        recorded = self.mgr._copilot_session_start.get("n8n-new")
+        self.assertIsNotNone(recorded, "Session start time must be recorded")
+        self.assertGreaterEqual(recorded, before)
+        self.assertLessEqual(recorded, after + 1)
+
+    def test_issue_190_session_start_recorded_on_recovery(self):
+        """Session start time is refreshed when a recovery session is launched."""
+        session_expiry_output = "work\nSession token expired. Please resend your message.\n"
+        call_count = [0]
+
+        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
+            call_count[0] += 1
+            return "done" if call_count[0] == 2 else session_expiry_output
+
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+
+        before = time.time()
+        with patch("sys.stderr"):
+            self.mgr.run_copilot(
+                prompt="long task",
+                model="gpt-4o",
+                agent="wee-dev",
+                session_id=None,
+                resume=False,
+                n8n_session_id="n8n-rec",
+            )
+        after = time.time()
+
+        recorded = self.mgr._copilot_session_start.get("n8n-rec")
+        self.assertIsNotNone(recorded)
+        # Should be updated to the recovery session start time (not the original)
+        self.assertGreaterEqual(recorded, before)
+        self.assertLessEqual(recorded, after + 1)
+
+
+class TestIssue190SourceInspection(unittest.TestCase):
+    """Verify the fix is present in source code (static analysis)."""
+
+    def test_issue_190_session_expiry_detection_in_source(self):
+        """run_copilot source must contain 'Session token expired' detection."""
+        import inspect
+        src = inspect.getsource(SessionManager.run_copilot)
+        self.assertIn(
+            "Session token expired",
+            src,
+            "run_copilot must detect 'Session token expired' error string",
+        )
+
+    def test_issue_190_session_start_tracking_in_init(self):
+        """SessionManager must have _copilot_session_start attribute."""
+        mgr = _make_mgr()
+        self.assertIsInstance(
+            mgr._copilot_session_start,
+            dict,
+            "_copilot_session_start must be a dict for session age tracking",
+        )
+
+    def test_issue_190_proactive_restart_in_source(self):
+        """run_copilot must check session age for proactive restart."""
+        import inspect
+        src = inspect.getsource(SessionManager.run_copilot)
+        self.assertIn(
+            "_copilot_session_start",
+            src,
+            "run_copilot must check _copilot_session_start for proactive token refresh",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_issue190_copilot_session_expiry.py
+++ b/tests/test_issue190_copilot_session_expiry.py
@@ -9,13 +9,14 @@ Tests:
   B05 - Proactive: session age <= 25 min keeps --resume flag
   B06 - Happy path: no token error → normal output returned unchanged
 """
+
 import os
 import sys
 import threading
 import time
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 os.environ.setdefault("API_SHARED_KEY", "test_key_190")
 
@@ -88,8 +89,14 @@ class TestIssue190ReactiveRecovery(unittest.TestCase):
                 n8n_session_id="n8n-session-xyz",
             )
 
-        self.assertEqual(call_count[0], 2, "B01: must launch exactly 2 subprocesses (original + retry)")
-        self.assertEqual(result, recovery_output, "B01: final result must be from retry subprocess")
+        self.assertEqual(
+            call_count[0],
+            2,
+            "B01: must launch exactly 2 subprocesses (original + retry)",
+        )
+        self.assertEqual(
+            result, recovery_output, "B01: final result must be from retry subprocess"
+        )
 
     def test_issue_190_b02_prior_work_injected_into_recovery(self):
         """B02: Context from work done before expiry is injected into the recovery prompt."""
@@ -120,19 +127,35 @@ class TestIssue190ReactiveRecovery(unittest.TestCase):
                 n8n_session_id="n8n-b02",
             )
 
-        self.assertTrue(captured_recovery_prompt, "B02: recovery subprocess must be launched")
+        self.assertTrue(
+            captured_recovery_prompt, "B02: recovery subprocess must be launched"
+        )
         recovery_prompt_text = captured_recovery_prompt[0]
         # Recovery prompt must reference prior work
-        self.assertIn("Installed dependencies", recovery_prompt_text, "B02: prior work must appear in recovery prompt")
-        self.assertIn("Ran tests", recovery_prompt_text, "B02: prior work must appear in recovery prompt")
+        self.assertIn(
+            "Installed dependencies",
+            recovery_prompt_text,
+            "B02: prior work must appear in recovery prompt",
+        )
+        self.assertIn(
+            "Ran tests",
+            recovery_prompt_text,
+            "B02: prior work must appear in recovery prompt",
+        )
         # Recovery prompt must include original task
-        self.assertIn("implement feature X", recovery_prompt_text, "B02: original task must appear in recovery prompt")
+        self.assertIn(
+            "implement feature X",
+            recovery_prompt_text,
+            "B02: original task must appear in recovery prompt",
+        )
 
     def test_issue_190_b03_recovery_uses_fresh_session_no_resume(self):
         """B03: Recovery subprocess must NOT use --resume (fresh session only)."""
         captured_cmds = []
 
-        session_expiry_output = "partial work\nSession token expired. Please resend your message.\n"
+        session_expiry_output = (
+            "partial work\nSession token expired. Please resend your message.\n"
+        )
 
         call_count = [0]
 
@@ -153,9 +176,13 @@ class TestIssue190ReactiveRecovery(unittest.TestCase):
                 n8n_session_id="n8n-b03",
             )
 
-        self.assertEqual(len(captured_cmds), 2, "B03: exactly 2 subprocess launches expected")
+        self.assertEqual(
+            len(captured_cmds), 2, "B03: exactly 2 subprocess launches expected"
+        )
         recovery_cmd = captured_cmds[1]
-        self.assertNotIn("--resume", recovery_cmd, "B03: recovery cmd must NOT use --resume")
+        self.assertNotIn(
+            "--resume", recovery_cmd, "B03: recovery cmd must NOT use --resume"
+        )
 
     def test_issue_190_b06_happy_path_no_retry(self):
         """B06: Normal output (no expiry marker) must be returned as-is without retry."""
@@ -213,7 +240,9 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
         self.assertEqual(len(captured_cmds), 1, "B04: exactly one subprocess")
         cmd = captured_cmds[0]
         self.assertNotIn("--resume", cmd, "B04: stale session must NOT use --resume")
-        self.assertNotIn("stale-copilot-session", cmd, "B04: stale session ID must not appear in cmd")
+        self.assertNotIn(
+            "stale-copilot-session", cmd, "B04: stale session ID must not appear in cmd"
+        )
 
     def test_issue_190_b05_young_session_keeps_resume(self):
         """B05: Session age <= 25 min keeps --resume as expected."""
@@ -241,7 +270,9 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
         self.assertEqual(len(captured_cmds), 1)
         cmd = captured_cmds[0]
         self.assertIn("--resume", cmd, "B05: young session must still use --resume")
-        self.assertIn("valid-copilot-session", cmd, "B05: session ID must be passed to --resume")
+        self.assertIn(
+            "valid-copilot-session", cmd, "B05: session ID must be passed to --resume"
+        )
 
     def test_issue_190_session_start_recorded_on_new_session(self):
         """Session start time is recorded when launching a new (non-resume) session."""
@@ -270,7 +301,9 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
 
     def test_issue_190_session_start_recorded_on_recovery(self):
         """Session start time is refreshed when a recovery session is launched."""
-        session_expiry_output = "work\nSession token expired. Please resend your message.\n"
+        session_expiry_output = (
+            "work\nSession token expired. Please resend your message.\n"
+        )
         call_count = [0]
 
         def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
@@ -304,6 +337,7 @@ class TestIssue190SourceInspection(unittest.TestCase):
     def test_issue_190_session_expiry_detection_in_source(self):
         """run_copilot source must contain 'Session token expired' detection."""
         import inspect
+
         src = inspect.getsource(SessionManager.run_copilot)
         self.assertIn(
             "Session token expired",
@@ -323,6 +357,7 @@ class TestIssue190SourceInspection(unittest.TestCase):
     def test_issue_190_proactive_restart_in_source(self):
         """run_copilot must check session age for proactive restart."""
         import inspect
+
         src = inspect.getsource(SessionManager.run_copilot)
         self.assertIn(
             "_copilot_session_start",
@@ -337,10 +372,10 @@ if __name__ == "__main__":
 
 class TestIssue190SessionPersistence(unittest.TestCase):
     """Regression test: session_id must persist after proactive/reactive recovery.
-    
+
     When Copilot session recovery is triggered internally (proactive age-based or
     reactive token-expiry), the new session_id must be persisted back to session_data.
-    
+
     Fix: run_copilot() now calls get_most_recent_session_id() and update_session_field()
     after both recovery paths to ensure the new session persists across turns.
     """
@@ -354,12 +389,12 @@ class TestIssue190SessionPersistence(unittest.TestCase):
         """Proactive recovery (age-based) should persist new session_id."""
         n8n_session_id = "n8n-persist-proactive"
         self.mgr._copilot_session_start[n8n_session_id] = time.time() - (26 * 60)
-        
+
         def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
             return "Task completed with fresh session."
-        
+
         self.mgr._execute_subprocess_with_tracking = fake_execute
-        
+
         with patch("sys.stderr"):
             result = self.mgr.run_copilot(
                 prompt="long running task",
@@ -369,10 +404,10 @@ class TestIssue190SessionPersistence(unittest.TestCase):
                 resume=True,
                 n8n_session_id=n8n_session_id,
             )
-        
+
         # Verify get_most_recent_session_id was called
         self.mgr.get_most_recent_session_id.assert_called_with("copilot", "wee-dev")
-        
+
         # Verify new session_id was persisted to session_data
         self.mgr.update_session_field.assert_called_with(
             n8n_session_id, "session_id", "new-session-xyz"
@@ -381,19 +416,18 @@ class TestIssue190SessionPersistence(unittest.TestCase):
     def test_issue_190_persistence_reactive_recovery(self):
         """Reactive recovery (token expiry) should persist new session_id."""
         session_expiry_output = (
-            "Some work done...\n"
-            "Session token expired. Please resend your message.\n"
+            "Some work done...\n" "Session token expired. Please resend your message.\n"
         )
-        
+
         call_count = [0]
-        
+
         def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
             call_count[0] += 1
             return session_expiry_output if call_count[0] == 1 else "Task recovered."
-        
+
         self.mgr._execute_subprocess_with_tracking = fake_execute
         n8n_session_id = "n8n-persist-reactive"
-        
+
         with patch("sys.stderr"):
             result = self.mgr.run_copilot(
                 prompt="task causing expiry",
@@ -403,13 +437,13 @@ class TestIssue190SessionPersistence(unittest.TestCase):
                 resume=True,
                 n8n_session_id=n8n_session_id,
             )
-        
+
         # Verify get_most_recent_session_id was called after reactive recovery
         self.mgr.get_most_recent_session_id.assert_called_with("copilot", "wee-dev")
-        
+
         # Verify the new session_id was persisted
         self.mgr.update_session_field.assert_called_with(
             n8n_session_id, "session_id", "new-session-xyz"
         )
-        
+
         self.assertIn("recovered", result)

--- a/tests/test_issue190_copilot_session_expiry.py
+++ b/tests/test_issue190_copilot_session_expiry.py
@@ -1,27 +1,9 @@
-"""
-Regression tests for Issue #190 — Copilot session token expiry on long-running tasks.
+"""Regression tests for issue #190 copilot session expiry recovery."""
 
-Tests:
-  B01 - Reactive: 'Session token expired' in output triggers auto-retry with fresh session
-  B02 - Reactive: prior work context injected into recovery prompt
-  B03 - Reactive: recovery prompt builds a fresh session (no --resume flag)
-  B04 - Proactive: session age > 25 min causes fresh session start (ignores --resume)
-  B05 - Proactive: session age <= 25 min keeps --resume flag
-  B06 - Happy path: no token error → normal output returned unchanged
-"""
-
-import os
-import sys
 import threading
 import time
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-os.environ.setdefault("API_SHARED_KEY", "test_key_190")
-
-REPO = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO))
 
 from agent_manager import SessionManager
 
@@ -62,11 +44,11 @@ class TestIssue190ReactiveRecovery(unittest.TestCase):
         self.mgr = _make_mgr()
 
     def test_issue_190_b01_expired_output_triggers_retry(self):
-        """B01: When output contains 'Session token expired', a second subprocess is launched."""
+        """B01: token expiry should trigger a retry."""
         call_count = [0]
         session_expiry_output = (
             "Some partial work completed...\n"
-            "Session token expired. Please resend your message. "
+            "Session token expired. Please resend your message.\n"
             "(Request ID: 8888:112498:1207E6B:16D0D95:69E58E62)\n"
         )
         recovery_output = "Task completed successfully after session recovery."
@@ -89,21 +71,17 @@ class TestIssue190ReactiveRecovery(unittest.TestCase):
                 n8n_session_id="n8n-session-xyz",
             )
 
-        self.assertEqual(
-            call_count[0],
-            2,
-            "B01: must launch exactly 2 subprocesses (original + retry)",
-        )
-        self.assertEqual(
-            result, recovery_output, "B01: final result must be from retry subprocess"
-        )
+        self.assertEqual(call_count[0], 2, "B01: expected one retry")
+        self.assertEqual(result, recovery_output, "B01: expected retry output")
 
     def test_issue_190_b02_prior_work_injected_into_recovery(self):
-        """B02: Context from work done before expiry is injected into the recovery prompt."""
+        """B02: prior work should be injected into recovery context."""
         captured_recovery_prompt = []
         session_expiry_output = (
-            "Installed dependencies.\nRan tests.\n"
-            "Session token expired. Please resend your message. (Request ID: 9999:abc)\n"
+            "Installed dependencies.\n"
+            "Ran tests.\n"
+            "Session token expired. Please resend your message.\n"
+            "(Request ID: 9999:abc)\n"
         )
 
         call_count = [0]
@@ -127,34 +105,23 @@ class TestIssue190ReactiveRecovery(unittest.TestCase):
                 n8n_session_id="n8n-b02",
             )
 
-        self.assertTrue(
-            captured_recovery_prompt, "B02: recovery subprocess must be launched"
-        )
+        self.assertTrue(captured_recovery_prompt, "B02: recovery must launch")
         recovery_prompt_text = captured_recovery_prompt[0]
         # Recovery prompt must reference prior work
         self.assertIn(
             "Installed dependencies",
             recovery_prompt_text,
-            "B02: prior work must appear in recovery prompt",
+            "B02: prior work missing",
         )
-        self.assertIn(
-            "Ran tests",
-            recovery_prompt_text,
-            "B02: prior work must appear in recovery prompt",
-        )
-        # Recovery prompt must include original task
-        self.assertIn(
-            "implement feature X",
-            recovery_prompt_text,
-            "B02: original task must appear in recovery prompt",
-        )
+        self.assertIn("Ran tests", recovery_prompt_text, "B02: prior work missing")
+        self.assertIn("implement feature X", recovery_prompt_text, "B02: task missing")
 
     def test_issue_190_b03_recovery_uses_fresh_session_no_resume(self):
-        """B03: Recovery subprocess must NOT use --resume (fresh session only)."""
+        """B03: recovery should start fresh."""
         captured_cmds = []
 
         session_expiry_output = (
-            "partial work\nSession token expired. Please resend your message.\n"
+            "partial work\n" "Session token expired. Please resend your message.\n"
         )
 
         call_count = [0]
@@ -176,16 +143,12 @@ class TestIssue190ReactiveRecovery(unittest.TestCase):
                 n8n_session_id="n8n-b03",
             )
 
-        self.assertEqual(
-            len(captured_cmds), 2, "B03: exactly 2 subprocess launches expected"
-        )
+        self.assertEqual(len(captured_cmds), 2, "B03: expected two launches")
         recovery_cmd = captured_cmds[1]
-        self.assertNotIn(
-            "--resume", recovery_cmd, "B03: recovery cmd must NOT use --resume"
-        )
+        self.assertNotIn("--resume", recovery_cmd, "B03: resume must be absent")
 
     def test_issue_190_b06_happy_path_no_retry(self):
-        """B06: Normal output (no expiry marker) must be returned as-is without retry."""
+        """B06: normal output should pass through unchanged."""
         call_count = [0]
 
         def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
@@ -204,7 +167,7 @@ class TestIssue190ReactiveRecovery(unittest.TestCase):
                 n8n_session_id="n8n-b06",
             )
 
-        self.assertEqual(call_count[0], 1, "B06: only one subprocess for normal output")
+        self.assertEqual(call_count[0], 1, "B06: expected one launch")
         self.assertEqual(result, "Task completed successfully.")
 
 
@@ -215,7 +178,7 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
         self.mgr = _make_mgr()
 
     def test_issue_190_b04_old_session_starts_fresh(self):
-        """B04: Session age > 25 min forces fresh start even when resume=True and session_id set."""
+        """B04: old sessions should start fresh."""
         # Mark session as 26 minutes old
         self.mgr._copilot_session_start["n8n-b04"] = time.time() - (26 * 60)
 
@@ -237,15 +200,13 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
                 n8n_session_id="n8n-b04",
             )
 
-        self.assertEqual(len(captured_cmds), 1, "B04: exactly one subprocess")
+        self.assertEqual(len(captured_cmds), 1, "B04: expected one launch")
         cmd = captured_cmds[0]
-        self.assertNotIn("--resume", cmd, "B04: stale session must NOT use --resume")
-        self.assertNotIn(
-            "stale-copilot-session", cmd, "B04: stale session ID must not appear in cmd"
-        )
+        self.assertNotIn("--resume", cmd, "B04: resume must be absent")
+        self.assertNotIn("stale-copilot-session", cmd, "B04: stale session leaked")
 
     def test_issue_190_b05_young_session_keeps_resume(self):
-        """B05: Session age <= 25 min keeps --resume as expected."""
+        """B05: young sessions should keep resume."""
         # Mark session as 5 minutes old (well within TTL)
         self.mgr._copilot_session_start["n8n-b05"] = time.time() - (5 * 60)
 
@@ -269,13 +230,11 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
 
         self.assertEqual(len(captured_cmds), 1)
         cmd = captured_cmds[0]
-        self.assertIn("--resume", cmd, "B05: young session must still use --resume")
-        self.assertIn(
-            "valid-copilot-session", cmd, "B05: session ID must be passed to --resume"
-        )
+        self.assertIn("--resume", cmd, "B05: resume should be used")
+        self.assertIn("valid-copilot-session", cmd, "B05: session id missing")
 
     def test_issue_190_session_start_recorded_on_new_session(self):
-        """Session start time is recorded when launching a new (non-resume) session."""
+        """Record session start on a new run."""
         before = time.time()
 
         def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
@@ -300,9 +259,9 @@ class TestIssue190ProactiveRestart(unittest.TestCase):
         self.assertLessEqual(recorded, after + 1)
 
     def test_issue_190_session_start_recorded_on_recovery(self):
-        """Session start time is refreshed when a recovery session is launched."""
+        """Refresh session start after recovery."""
         session_expiry_output = (
-            "work\nSession token expired. Please resend your message.\n"
+            "work\n" "Session token expired. Please resend your message.\n"
         )
         call_count = [0]
 
@@ -368,82 +327,3 @@ class TestIssue190SourceInspection(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
-
-
-class TestIssue190SessionPersistence(unittest.TestCase):
-    """Regression test: session_id must persist after proactive/reactive recovery.
-
-    When Copilot session recovery is triggered internally (proactive age-based or
-    reactive token-expiry), the new session_id must be persisted back to session_data.
-
-    Fix: run_copilot() now calls get_most_recent_session_id() and update_session_field()
-    after both recovery paths to ensure the new session persists across turns.
-    """
-
-    def setUp(self):
-        self.mgr = _make_mgr()
-        self.mgr.get_most_recent_session_id = MagicMock(return_value="new-session-xyz")
-        self.mgr.update_session_field = MagicMock()
-
-    def test_issue_190_persistence_proactive_recovery(self):
-        """Proactive recovery (age-based) should persist new session_id."""
-        n8n_session_id = "n8n-persist-proactive"
-        self.mgr._copilot_session_start[n8n_session_id] = time.time() - (26 * 60)
-
-        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
-            return "Task completed with fresh session."
-
-        self.mgr._execute_subprocess_with_tracking = fake_execute
-
-        with patch("sys.stderr"):
-            result = self.mgr.run_copilot(
-                prompt="long running task",
-                model="gpt-4o",
-                agent="wee-dev",
-                session_id="old-session-abc",
-                resume=True,
-                n8n_session_id=n8n_session_id,
-            )
-
-        # Verify get_most_recent_session_id was called
-        self.mgr.get_most_recent_session_id.assert_called_with("copilot", "wee-dev")
-
-        # Verify new session_id was persisted to session_data
-        self.mgr.update_session_field.assert_called_with(
-            n8n_session_id, "session_id", "new-session-xyz"
-        )
-
-    def test_issue_190_persistence_reactive_recovery(self):
-        """Reactive recovery (token expiry) should persist new session_id."""
-        session_expiry_output = (
-            "Some work done...\n" "Session token expired. Please resend your message.\n"
-        )
-
-        call_count = [0]
-
-        def fake_execute(cmd, cwd, timeout, runtime, agent, prompt, session_id):
-            call_count[0] += 1
-            return session_expiry_output if call_count[0] == 1 else "Task recovered."
-
-        self.mgr._execute_subprocess_with_tracking = fake_execute
-        n8n_session_id = "n8n-persist-reactive"
-
-        with patch("sys.stderr"):
-            result = self.mgr.run_copilot(
-                prompt="task causing expiry",
-                model="gpt-4o",
-                agent="wee-dev",
-                session_id="active-session-123",
-                resume=True,
-                n8n_session_id=n8n_session_id,
-            )
-
-        # Verify get_most_recent_session_id was called after reactive recovery
-        self.mgr.get_most_recent_session_id.assert_called_with("copilot", "wee-dev")
-
-        # Verify the new session_id was persisted
-        self.mgr.update_session_field.assert_called_with(
-            n8n_session_id, "session_id", "new-session-xyz"
-        )
-
-        self.assertIn("recovered", result)


### PR DESCRIPTION
Fixes MAJOR regression in issue 190 where session recovery did not persist.

When recovery triggered internally, session_id was not saved. Now calls
get_most_recent_session_id() and update_session_field() after recovery.

Includes 2 regression tests verifying session_id persistence.