### PR TITLE
fix: BackgroundTaskManager._trim_tool_call crash + gpt-5.4-mini in CODEX_MODELS

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -798,6 +798,18 @@ class BackgroundTaskManager:
                     break
             self._save_unlocked(tasks)
 
+    def _trim_tool_call(self, tool_call: dict) -> dict:
+        """Truncate large string fields in a tool call to MAX_TOOL_FIELD_CHARS."""
+        max_chars = self.MAX_TOOL_FIELD_CHARS
+        trimmed = {}
+        for k, v in tool_call.items():
+            if isinstance(v, str) and len(v) > max_chars:
+                extra = len(v) - max_chars
+                trimmed[k] = v[:max_chars] + f"...[truncated {extra} chars]"
+            else:
+                trimmed[k] = v
+        return trimmed
+
     def append_tool_call(self, task_id: str, tool_call: dict):
         """Append a new tool call event to the task."""
         with self._lock:
@@ -1912,6 +1924,7 @@ class SessionManager:
     CODEX_MODELS = {
         "OpenAI Models": [
             ("gpt-5.4", "GPT-5.4", ["gpt-5.4", "gpt-5.4-pro"]),
+            ("gpt-5.4-mini", "GPT-5.4 mini", ["gpt-5.4-mini"]),
             ("gpt-5.3-codex", "GPT-5.3 Codex", ["gpt-5.3", "codex-latest"]),
             ("gpt-5.2-codex", "GPT-5.2 Codex", ["gpt-5.2-codex"]),
             ("gpt-5.2", "GPT-5.2", ["gpt-5.2"]),

--- a/tests/test_issue200_agents_runtimes_auth.py
+++ b/tests/test_issue200_agents_runtimes_auth.py
@@ -1,4 +1,5 @@
-"""Regression tests for GitHub Issue #200 - auth gate on /api/v1/agents and /api/v1/runtimes.
+"""Regression tests for GitHub Issue #200 - auth gate on /api/v1/agents
+and /api/v1/runtimes.
 
 wee-qa blocker: GET /api/v1/agents and GET /api/v1/runtimes returned HTTP 200 to
 unauthenticated callers. Both endpoints must now require a valid Bearer token,
@@ -55,7 +56,8 @@ class TestIssue200AgentsRuntimesAuth(unittest.TestCase):
         self.assertIn(
             resp.status_code,
             (401, 403),
-            f"Expected 401/403 for unauthenticated /api/v1/agents, got {resp.status_code}",
+            f"Expected 401/403 for unauthenticated /api/v1/agents, "
+            f"got {resp.status_code}",
         )
 
     def test_agents_authenticated_ok(self):
@@ -89,7 +91,8 @@ class TestIssue200AgentsRuntimesAuth(unittest.TestCase):
         self.assertIn(
             resp.status_code,
             (401, 403),
-            f"Expected 401/403 for unauthenticated /api/v1/runtimes, got {resp.status_code}",
+            f"Expected 401/403 for unauthenticated /api/v1/runtimes, "
+            f"got {resp.status_code}",
         )
 
     def test_runtimes_authenticated_ok(self):

--- a/tests/test_issue200_agents_runtimes_auth.py
+++ b/tests/test_issue200_agents_runtimes_auth.py
@@ -1,0 +1,120 @@
+"""Regression tests for GitHub Issue #200 - auth gate on /api/v1/agents and /api/v1/runtimes.
+
+wee-qa blocker: GET /api/v1/agents and GET /api/v1/runtimes returned HTTP 200 to
+unauthenticated callers. Both endpoints must now require a valid Bearer token,
+matching the behaviour of /api/v1/models.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ["API_SHARED_KEY"] = "test_key_123"
+os.environ["APP_ENV"] = "DEV"
+os.environ["API_PORT"] = "8099"
+
+
+class TestIssue200AgentsRuntimesAuth(unittest.TestCase):
+    """GET /api/v1/agents and /api/v1/runtimes must require authentication."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        cls._telegram_patch = patch.object(
+            agent_manager,
+            "_resolve_telegram_identity",
+            side_effect=lambda identity: identity,
+        )
+        cls._telegram_patch.start()
+        cls._send_pairing_patch = patch.object(
+            agent_manager,
+            "_send_pairing_code",
+            return_value=True,
+        )
+        cls._send_pairing_patch.start()
+        cls.app = agent_manager.create_api_app()
+        cls.client = TestClient(cls.app)
+        cls.auth_header = {"Authorization": "Bearer shared_test_key_123"}
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._telegram_patch.stop()
+        cls._send_pairing_patch.stop()
+
+    # ---------- /api/v1/agents ----------
+
+    def test_agents_unauthenticated_rejected(self):
+        """GET /api/v1/agents without auth must return HTTP 401."""
+        resp = self.client.get("/api/v1/agents")
+        self.assertIn(
+            resp.status_code,
+            (401, 403),
+            f"Expected 401/403 for unauthenticated /api/v1/agents, got {resp.status_code}",
+        )
+
+    def test_agents_authenticated_ok(self):
+        """GET /api/v1/agents with a valid Bearer token must return HTTP 200."""
+        resp = self.client.get("/api/v1/agents", headers=self.auth_header)
+        self.assertEqual(
+            resp.status_code,
+            200,
+            f"Authenticated /api/v1/agents should return 200, got {resp.status_code}",
+        )
+        body = resp.json()
+        self.assertIn("agents", body, "Response must contain 'agents' key")
+
+    def test_agents_wrong_token_rejected(self):
+        """GET /api/v1/agents with a wrong token must return HTTP 401/403."""
+        resp = self.client.get(
+            "/api/v1/agents",
+            headers={"Authorization": "Bearer wrong_token"},
+        )
+        self.assertIn(
+            resp.status_code,
+            (401, 403),
+            f"Wrong token should be rejected, got {resp.status_code}",
+        )
+
+    # ---------- /api/v1/runtimes ----------
+
+    def test_runtimes_unauthenticated_rejected(self):
+        """GET /api/v1/runtimes without auth must return HTTP 401."""
+        resp = self.client.get("/api/v1/runtimes")
+        self.assertIn(
+            resp.status_code,
+            (401, 403),
+            f"Expected 401/403 for unauthenticated /api/v1/runtimes, got {resp.status_code}",
+        )
+
+    def test_runtimes_authenticated_ok(self):
+        """GET /api/v1/runtimes with a valid Bearer token must return HTTP 200."""
+        resp = self.client.get("/api/v1/runtimes", headers=self.auth_header)
+        self.assertEqual(
+            resp.status_code,
+            200,
+            f"Authenticated /api/v1/runtimes should return 200, got {resp.status_code}",
+        )
+        body = resp.json()
+        self.assertIn("runtimes", body, "Response must contain 'runtimes' key")
+
+    def test_runtimes_wrong_token_rejected(self):
+        """GET /api/v1/runtimes with a wrong token must return HTTP 401/403."""
+        resp = self.client.get(
+            "/api/v1/runtimes",
+            headers={"Authorization": "Bearer wrong_token"},
+        )
+        self.assertIn(
+            resp.status_code,
+            (401, 403),
+            f"Wrong token should be rejected, got {resp.status_code}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue200_tool_call_crash.py
+++ b/tests/test_issue200_tool_call_crash.py
@@ -4,15 +4,12 @@
 - gpt-5.4-mini missing from CODEX_MODELS static configuration
 """
 
-import sys
 import os
-import importlib
+import sys
+import types
 import unittest
 
 sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
-
-# Patch out heavy imports before loading agent_manager
-import types
 
 # Minimal stubs so agent_manager imports cleanly
 for mod_name in ["anthropic", "google.generativeai", "google", "openai"]:
@@ -75,15 +72,16 @@ class TestTrimToolCall(unittest.TestCase):
         self.assertIsNone(result["meta"])
 
     def test_append_tool_call_does_not_crash(self):
-        """append_tool_call must not crash (regression: AttributeError on _trim_tool_call)."""
-        import tempfile
+        """append_tool_call must not crash.
+
+        Regression: AttributeError on _trim_tool_call.
+        """
         import json
+        import tempfile
 
         mgr = self._make_manager()
         # Provide a temporary task store
-        with tempfile.NamedTemporaryFile(
-            suffix=".json", mode="w", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
             json.dump(
                 [{"task_id": "bg_test001", "tool_calls": [], "output_lines": []}],
                 f,
@@ -95,7 +93,9 @@ class TestTrimToolCall(unittest.TestCase):
 
         try:
             # This must not raise AttributeError
-            mgr.append_tool_call("bg_test001", {"id": "tc_a", "name": "shell", "input": "ls"})
+            mgr.append_tool_call(
+                "bg_test001", {"id": "tc_a", "name": "shell", "input": "ls"}
+            )
             task = mgr.get_task("bg_test001")
             self.assertEqual(len(task["tool_calls"]), 1)
             self.assertEqual(task["tool_calls"][0]["name"], "shell")
@@ -103,19 +103,22 @@ class TestTrimToolCall(unittest.TestCase):
             os.unlink(tmp_path)
 
     def test_update_tool_call_does_not_crash(self):
-        """update_tool_call must not crash (regression: AttributeError on _trim_tool_call)."""
-        import tempfile
+        """update_tool_call must not crash.
+
+        Regression: AttributeError on _trim_tool_call.
+        """
         import json
+        import tempfile
 
         mgr = self._make_manager()
-        with tempfile.NamedTemporaryFile(
-            suffix=".json", mode="w", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
             json.dump(
                 [
                     {
                         "task_id": "bg_test002",
-                        "tool_calls": [{"id": "tc_b", "name": "shell", "status": "running"}],
+                        "tool_calls": [
+                            {"id": "tc_b", "name": "shell", "status": "running"}
+                        ],
                         "output_lines": [],
                     }
                 ],

--- a/tests/test_issue200_tool_call_crash.py
+++ b/tests/test_issue200_tool_call_crash.py
@@ -1,0 +1,179 @@
+"""Regression tests for GitHub Issue #200.
+
+- BackgroundTaskManager._trim_tool_call missing caused task crash on tool-call logging
+- gpt-5.4-mini missing from CODEX_MODELS static configuration
+"""
+
+import sys
+import os
+import importlib
+import unittest
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
+
+# Patch out heavy imports before loading agent_manager
+import types
+
+# Minimal stubs so agent_manager imports cleanly
+for mod_name in ["anthropic", "google.generativeai", "google", "openai"]:
+    parts = mod_name.split(".")
+    parent = None
+    for i, part in enumerate(parts):
+        full = ".".join(parts[: i + 1])
+        if full not in sys.modules:
+            m = types.ModuleType(full)
+            if parent is not None:
+                setattr(parent, part, m)
+            sys.modules[full] = m
+        parent = sys.modules[full]
+
+
+class TestTrimToolCall(unittest.TestCase):
+    """_trim_tool_call must exist and truncate oversized string fields."""
+
+    def _make_manager(self):
+        # Import lazily inside test so the stub environment is in place
+        from agent_manager import BackgroundTaskManager  # noqa: PLC0415
+
+        return BackgroundTaskManager()
+
+    def test_trim_tool_call_method_exists(self):
+        """BackgroundTaskManager must have a _trim_tool_call method."""
+        from agent_manager import BackgroundTaskManager  # noqa: PLC0415
+
+        self.assertTrue(
+            hasattr(BackgroundTaskManager, "_trim_tool_call"),
+            "_trim_tool_call method is missing from BackgroundTaskManager",
+        )
+
+    def test_trim_tool_call_truncates_long_strings(self):
+        """Long string values must be truncated to MAX_TOOL_FIELD_CHARS."""
+        mgr = self._make_manager()
+        long_value = "x" * (mgr.MAX_TOOL_FIELD_CHARS + 500)
+        tool_call = {"id": "tc1", "name": "shell", "input": long_value}
+        result = mgr._trim_tool_call(tool_call)
+        self.assertLessEqual(
+            len(result["input"]),
+            mgr.MAX_TOOL_FIELD_CHARS + 50,  # allow for truncation suffix
+        )
+        self.assertIn("truncated", result["input"])
+
+    def test_trim_tool_call_preserves_short_strings(self):
+        """Short string values must pass through unchanged."""
+        mgr = self._make_manager()
+        tool_call = {"id": "tc2", "name": "shell", "input": "echo hello"}
+        result = mgr._trim_tool_call(tool_call)
+        self.assertEqual(result["input"], "echo hello")
+
+    def test_trim_tool_call_preserves_non_string_values(self):
+        """Non-string values (int, bool, None) must pass through unchanged."""
+        mgr = self._make_manager()
+        tool_call = {"id": "tc3", "count": 42, "active": True, "meta": None}
+        result = mgr._trim_tool_call(tool_call)
+        self.assertEqual(result["count"], 42)
+        self.assertEqual(result["active"], True)
+        self.assertIsNone(result["meta"])
+
+    def test_append_tool_call_does_not_crash(self):
+        """append_tool_call must not crash (regression: AttributeError on _trim_tool_call)."""
+        import tempfile
+        import json
+
+        mgr = self._make_manager()
+        # Provide a temporary task store
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False
+        ) as f:
+            json.dump(
+                [{"task_id": "bg_test001", "tool_calls": [], "output_lines": []}],
+                f,
+            )
+            tmp_path = f.name
+
+        mgr._path = tmp_path
+        mgr._tasks_cache = None  # force load from disk
+
+        try:
+            # This must not raise AttributeError
+            mgr.append_tool_call("bg_test001", {"id": "tc_a", "name": "shell", "input": "ls"})
+            task = mgr.get_task("bg_test001")
+            self.assertEqual(len(task["tool_calls"]), 1)
+            self.assertEqual(task["tool_calls"][0]["name"], "shell")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_update_tool_call_does_not_crash(self):
+        """update_tool_call must not crash (regression: AttributeError on _trim_tool_call)."""
+        import tempfile
+        import json
+
+        mgr = self._make_manager()
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False
+        ) as f:
+            json.dump(
+                [
+                    {
+                        "task_id": "bg_test002",
+                        "tool_calls": [{"id": "tc_b", "name": "shell", "status": "running"}],
+                        "output_lines": [],
+                    }
+                ],
+                f,
+            )
+            tmp_path = f.name
+
+        mgr._path = tmp_path
+        mgr._tasks_cache = None
+
+        try:
+            mgr.update_tool_call("bg_test002", "tc_b", status="done", output="ok")
+            task = mgr.get_task("bg_test002")
+            self.assertEqual(task["tool_calls"][0]["status"], "done")
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestCodexModelsGpt54Mini(unittest.TestCase):
+    """gpt-5.4-mini must be present in the static CODEX_MODELS list."""
+
+    def test_gpt_54_mini_in_codex_models(self):
+        """CODEX_MODELS must include gpt-5.4-mini."""
+        from agent_manager import SessionManager  # noqa: PLC0415
+
+        all_ids = []
+        for _category, entries in SessionManager.CODEX_MODELS.items():
+            for entry in entries:
+                model_id = entry[0]
+                all_ids.append(model_id)
+
+        self.assertIn(
+            "gpt-5.4-mini",
+            all_ids,
+            "gpt-5.4-mini is missing from SessionManager.CODEX_MODELS",
+        )
+
+    def test_gpt_54_mini_in_fetch_codex_models(self):
+        """fetch_codex_models() must include gpt-5.4-mini (no env override)."""
+        from agent_manager import SessionManager  # noqa: PLC0415
+
+        orig = os.environ.pop("CODEX_MODELS_JSON", None)
+        try:
+            mgr = SessionManager.__new__(SessionManager)
+            result = mgr.fetch_codex_models()
+            all_ids = []
+            for _cat, models in result.items():
+                for m in models:
+                    all_ids.append(m["id"] if isinstance(m, dict) else m)
+            self.assertIn(
+                "gpt-5.4-mini",
+                all_ids,
+                "gpt-5.4-mini missing from fetch_codex_models() output",
+            )
+        finally:
+            if orig is not None:
+                os.environ["CODEX_MODELS_JSON"] = orig
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_issue200_tool_call_crash.py
+++ b/tests/test_issue200_tool_call_crash.py
@@ -180,3 +180,38 @@ class TestCodexModelsGpt54Mini(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestCodexModelsEndpoint(unittest.TestCase):
+    """gpt-5.4-mini must appear in /api/v1/models endpoint for codex runtime."""
+
+    def test_models_endpoint_codex_includes_gpt_54_mini(self):
+        """Endpoint logic must return gpt-5.4-mini; _group NameError must not occur."""
+        from agent_manager import SessionManager  # noqa: PLC0415
+
+        mgr = SessionManager.__new__(SessionManager)
+        mgr._env_codex_models = None
+        raw = mgr.fetch_codex_models()
+
+        # Reproduce the /api/v1/models endpoint loop (post e3d0009 cherry-pick)
+        models = []
+        for group_name, model_ids in raw.items():
+            for model_id in model_ids:
+                if isinstance(model_id, tuple):
+                    model_id = model_id[0]
+                models.append({"id": model_id, "label": model_id, "group": group_name})
+
+        all_ids = [m["id"] for m in models]
+        self.assertIn(
+            "gpt-5.4-mini",
+            all_ids,
+            "gpt-5.4-mini missing from codex models endpoint simulation",
+        )
+        for m in models:
+            self.assertIsInstance(
+                m["group"], str, f"group must be a string, got: {m['group']!r}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Fixes two bugs from issue #200:

### Bug 1: BackgroundTaskManager missing `_trim_tool_call`
`append_tool_call` and `update_tool_call` called `self._trim_tool_call()` which didn't exist, crashing any background task that logged a tool call with `AttributeError: 'BackgroundTaskManager' object has no attribute '_trim_tool_call'`.

**Fix:** Added the missing `_trim_tool_call()` method that truncates oversized string fields to `MAX_TOOL_FIELD_CHARS` characters.

### Bug 2: `gpt-5.4-mini` missing from `CODEX_MODELS`
`gpt-5.4-mini` was absent from the static `CODEX_MODELS` list in `SessionManager`, preventing it from appearing in the Codex runtime model picker.

**Fix:** Added `gpt-5.4-mini` entry to `SessionManager.CODEX_MODELS`.

## Tests
8 regression tests added in `tests/test_issue200_tool_call_crash.py`:
- `_trim_tool_call` method existence
- Truncation of oversized strings  
- Preservation of short strings and non-string values
- `append_tool_call` no longer crashes (direct regression test for bug 1)
- `update_tool_call` no longer crashes (direct regression test for bug 1)
- `gpt-5.4-mini` present in `CODEX_MODELS` (direct regression test for bug 2)
- `gpt-5.4-mini` present in `fetch_codex_models()` output

Closes #200