### PR TITLE
feat: add fallback_runtime/fallback_model to agents.json dispatch_config

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -963,6 +963,131 @@ def check_runtime_available(runtime: str) -> bool:
     return False
 
 
+def check_runtime_blocked(runtime: str, state_file_path=None) -> bool:
+    """Check if a runtime is listed as blocked in RUNTIME_STATE.md.
+
+    Parses the Active Incidents table and checks if the runtime appears
+    with a future Blocked Until timestamp.  Returns True only when the
+    incident is still active (not yet expired).
+    """
+    if state_file_path is None:
+        state_file_path = "/opt/RUNTIME_STATE.md"
+
+    state_path = Path(state_file_path)
+    if not state_path.exists():
+        return False
+
+    try:
+        content = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    in_table = False
+    header_passed = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## Active Incidents"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if stripped.startswith("## ") and "Active Incidents" not in stripped:
+            break
+        if not stripped.startswith("|"):
+            continue
+        # Skip separator rows
+        is_sep = (
+            stripped.startswith("|---")
+            or stripped.startswith("| ---")
+            or set(stripped.replace("|", "").replace("-", "").replace(" ", "")) == set()
+        )
+        if is_sep:
+            continue
+        if "| ID " in stripped or "| ID|" in stripped:
+            header_passed = True
+            continue
+        if not header_passed:
+            header_passed = True
+            if "Blocked Until" in stripped:
+                continue
+
+        # Parse: | ID | Runtime/Service | Issue | Blocked Until | Written By | Fallback |
+        cols = [c.strip() for c in stripped.split("|")]
+        if len(cols) < 5:
+            continue
+
+        runtime_col = cols[2] if len(cols) > 2 else ""
+        blocked_until_col = cols[4] if len(cols) > 4 else ""
+        runtime_col_clean = runtime_col.strip("`").strip()
+
+        runtime_matches = (
+            runtime_col_clean == runtime
+            or runtime_col_clean.startswith(f"{runtime}/")
+            or runtime_col_clean.startswith(f"{runtime} ")
+        )
+        if not runtime_matches:
+            continue
+
+        blocked_until_clean = blocked_until_col.strip()
+        if not blocked_until_clean:
+            return True  # No expiry — treat as blocked
+
+        try:
+            import re as _re
+            from datetime import timezone as _tz, datetime as _dt
+
+            dt_str = _re.sub(r"\s+UTC$", "+00:00", blocked_until_clean).strip()
+            if "T" in dt_str or "+" in dt_str or dt_str.endswith("Z"):
+                blocked_dt = _dt.fromisoformat(dt_str.replace("Z", "+00:00"))
+            else:
+                blocked_dt = _dt.strptime(
+                    dt_str, "%Y-%m-%d %H:%M"
+                ).replace(tzinfo=_tz.utc)
+            return _dt.now(_tz.utc) < blocked_dt
+        except (ValueError, ImportError):
+            return True  # Unparseable date — treat as blocked
+
+    return False
+
+
+def resolve_dispatch_runtime_model(
+    agent: str,
+    requested_runtime: str,
+    requested_model: str,
+    agents_map: Dict,
+    state_file_path=None,
+) -> tuple:
+    """Resolve effective runtime/model, applying dispatch_config fallback.
+
+    Checks whether the primary runtime is blocked in RUNTIME_STATE.md or
+    unavailable on this host.  If so, and the agent's dispatch_config defines
+    fallback_runtime / fallback_model, the fallback values are returned.
+
+    Returns:
+        (effective_runtime, effective_model, used_fallback: bool, fallback_reason: str)
+    """
+    agent_config = agents_map.get(agent, {})
+    dispatch_cfg = agent_config.get("dispatch_config", {})
+    fallback_runtime = dispatch_cfg.get("fallback_runtime")
+    fallback_model = dispatch_cfg.get("fallback_model")
+
+    if not fallback_runtime and not fallback_model:
+        return requested_runtime, requested_model, False, ""
+
+    reason = ""
+    if check_runtime_blocked(requested_runtime, state_file_path):
+        reason = f"runtime '{requested_runtime}' blocked in RUNTIME_STATE.md"
+    elif not check_runtime_available(requested_runtime):
+        reason = f"runtime '{requested_runtime}' not available on this host"
+
+    if not reason:
+        return requested_runtime, requested_model, False, ""
+
+    effective_runtime = fallback_runtime or requested_runtime
+    effective_model = fallback_model or requested_model
+    return effective_runtime, effective_model, True, reason
+
+
 def get_available_runtimes() -> List[Dict[str, str]]:
     """Get list of available runtimes on this system.
 
@@ -12812,6 +12937,19 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         agent = body.agent or defaults.get("agent", get_default_agent())
         runtime = body.runtime or defaults.get("runtime", get_default_runtime())
         model = body.model or defaults.get("model", get_default_model())
+
+        # Apply dispatch_config fallback if primary runtime is blocked/unavailable
+        eff_rt, eff_model, used_fallback, fb_reason = resolve_dispatch_runtime_model(
+            agent, runtime, model, session_mgr.AGENTS
+        )
+        if used_fallback:
+            print(
+                f"[Dispatch] Fallback activated for agent='{agent}': {fb_reason}. "
+                f"Using runtime={eff_rt}, model={eff_model} "
+                f"(was {runtime}/{model})"
+            )
+            runtime = eff_rt
+            model = eff_model
 
         task_id = f"bg_{str(uuid4())[:8]}"
         session_id = str(uuid4())  # Must be valid UUID format for Copilot CLI

--- a/agents.json
+++ b/agents.json
@@ -90,7 +90,9 @@
         "vendor": "Anthropic Claude Sonnet 4.6",
         "permission_mode": "elevated",
         "yolo": true,
-        "timeout": 3600
+        "timeout": 3600,
+        "fallback_runtime": "copilot",
+        "fallback_model": "claude-sonnet-4.6"
       },
       "bots": {
         "telegram": {
@@ -130,7 +132,9 @@
         "vendor": "OpenAI (GPT-5.4-mini)",
         "permission_mode": "elevated",
         "yolo": true,
-        "timeout": 1800
+        "timeout": 1800,
+        "fallback_runtime": "copilot",
+        "fallback_model": "gpt-5.4"
       },
       "bots": {
         "telegram": {

--- a/tests/test_issue_197_dispatch_fallback.py
+++ b/tests/test_issue_197_dispatch_fallback.py
@@ -1,0 +1,237 @@
+"""Regression tests for Issue #197 — fallback_runtime / fallback_model dispatch.
+
+These tests verify that:
+- check_runtime_blocked() correctly parses RUNTIME_STATE.md
+- resolve_dispatch_runtime_model() applies fallbacks when primary is blocked/unavailable
+- No fallback is applied when primary is healthy
+"""
+
+import os
+import sys
+import types
+import unittest
+
+# ---------------------------------------------------------------------------
+# Bootstrap path so we can import from agent_manager without starting FastAPI
+# ---------------------------------------------------------------------------
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")  # noqa: E402
+
+from unittest.mock import MagicMock, patch
+
+import agent_manager
+
+
+class TestCheckRuntimeBlocked(unittest.TestCase):
+    """Unit tests for check_runtime_blocked()."""
+
+    def _write_state(self, tmpdir, content):
+        path = os.path.join(tmpdir, "RUNTIME_STATE.md")
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def test_no_file_returns_false(self):
+        result = agent_manager.check_runtime_blocked("copilot", "/nonexistent/path.md")
+        self.assertFalse(result)
+
+    def test_empty_incidents_returns_false(self):
+        content = (
+            "# Runtime State\n\n"
+            "## Active Incidents\n\n"
+            "| ID | Runtime/Service | Issue | Blocked Until | Written By | Fallback Action |\n"
+            "|----|-----------------|-------|---------------|------------|----------------|\n"
+        )
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_state(d, content)
+            self.assertFalse(agent_manager.check_runtime_blocked("copilot", path))
+
+    def test_blocked_runtime_detected(self):
+        content = (
+            "# Runtime State\n\n"
+            "## Active Incidents\n\n"
+            "| ID | Runtime/Service | Issue | Blocked Until | Written By | Fallback Action |\n"
+            "|----|-----------------|-------|---------------|------------|----------------|\n"
+            "| RS-001 | `copilot` | Rate limited | 2099-12-31 23:59 UTC | wee-dev | use claude-sdk |\n"  # noqa: E501
+        )
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_state(d, content)
+            self.assertTrue(agent_manager.check_runtime_blocked("copilot", path))
+
+    def test_expired_incident_returns_false(self):
+        content = (
+            "# Runtime State\n\n"
+            "## Active Incidents\n\n"
+            "| ID | Runtime/Service | Issue | Blocked Until | Written By | Fallback Action |\n"
+            "|----|-----------------|-------|---------------|------------|----------------|\n"
+            "| RS-002 | `copilot` | Old issue | 2000-01-01 00:00 UTC | wee-dev | use claude-sdk |\n"  # noqa: E501
+        )
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_state(d, content)
+            self.assertFalse(agent_manager.check_runtime_blocked("copilot", path))
+
+    def test_blank_blocked_until_treated_as_blocked(self):
+        content = (
+            "# Runtime State\n\n"
+            "## Active Incidents\n\n"
+            "| ID | Runtime/Service | Issue | Blocked Until | Written By | Fallback Action |\n"
+            "|----|-----------------|-------|---------------|------------|----------------|\n"
+            "| RS-003 | `claude-sdk` | Auth failure |  | wee-dev | use copilot |\n"
+        )
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_state(d, content)
+            self.assertTrue(agent_manager.check_runtime_blocked("claude-sdk", path))
+
+    def test_different_runtime_not_matched(self):
+        content = (
+            "# Runtime State\n\n"
+            "## Active Incidents\n\n"
+            "| ID | Runtime/Service | Issue | Blocked Until | Written By | Fallback Action |\n"
+            "|----|-----------------|-------|---------------|------------|----------------|\n"
+            "| RS-004 | `claude-sdk` | Auth failure | 2099-01-01 00:00 UTC | wee-dev | use copilot |\n"  # noqa: E501
+        )
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_state(d, content)
+            self.assertFalse(agent_manager.check_runtime_blocked("copilot", path))
+
+    def test_runtime_prefix_matching(self):
+        content = (
+            "# Runtime State\n\n"
+            "## Active Incidents\n\n"
+            "| ID | Runtime/Service | Issue | Blocked Until | Written By | Fallback Action |\n"
+            "|----|-----------------|-------|---------------|------------|----------------|\n"
+            "| RS-005 | `openrouter/:free` | Quota | 2099-01-01 00:00 UTC | wee-dev | use copilot |\n"  # noqa: E501
+        )
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_state(d, content)
+            # "openrouter" alone should match "openrouter/:free"
+            self.assertTrue(agent_manager.check_runtime_blocked("openrouter", path))
+
+    def test_backtick_stripped(self):
+        content = (
+            "# Runtime State\n\n"
+            "## Active Incidents\n\n"
+            "| ID | Runtime/Service | Issue | Blocked Until | Written By | Fallback Action |\n"
+            "|----|-----------------|-------|---------------|------------|----------------|\n"
+            "| RS-006 | copilot | Rate limit | 2099-01-01 00:00 UTC | wee-dev | - |\n"
+        )
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write_state(d, content)
+            self.assertTrue(agent_manager.check_runtime_blocked("copilot", path))
+
+
+class TestResolveDispatchRuntimeModel(unittest.TestCase):
+    """Unit tests for resolve_dispatch_runtime_model()."""
+
+    AGENTS_WITH_FALLBACK = {
+        "wee-dev": {
+            "dispatch_config": {
+                "runtime": "claude-sdk",
+                "model": "claude-sonnet-4.6",
+                "fallback_runtime": "copilot",
+                "fallback_model": "claude-haiku-4.5",
+            }
+        }
+    }
+
+    AGENTS_NO_FALLBACK = {
+        "orchestrator": {
+            "dispatch_config": {
+                "runtime": "copilot",
+                "model": "claude-sonnet-4.6",
+            }
+        }
+    }
+
+    def test_no_fallback_config_returns_original(self):
+        rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
+            "orchestrator", "copilot", "claude-sonnet-4.6", self.AGENTS_NO_FALLBACK
+        )
+        self.assertEqual(rt, "copilot")
+        self.assertFalse(used)
+
+    def test_primary_healthy_no_fallback(self):
+        with patch.object(agent_manager, "check_runtime_blocked", return_value=False), \
+             patch.object(agent_manager, "check_runtime_available", return_value=True):
+            rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
+                "wee-dev", "claude-sdk", "claude-sonnet-4.6", self.AGENTS_WITH_FALLBACK
+            )
+        self.assertEqual(rt, "claude-sdk")
+        self.assertFalse(used)
+
+    def test_blocked_runtime_triggers_fallback(self):
+        with patch.object(agent_manager, "check_runtime_blocked", return_value=True):
+            rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
+                "wee-dev", "claude-sdk", "claude-sonnet-4.6", self.AGENTS_WITH_FALLBACK
+            )
+        self.assertEqual(rt, "copilot")
+        self.assertEqual(model, "claude-haiku-4.5")
+        self.assertTrue(used)
+        self.assertIn("blocked in RUNTIME_STATE.md", reason)
+
+    def test_unavailable_runtime_triggers_fallback(self):
+        with patch.object(agent_manager, "check_runtime_blocked", return_value=False), \
+             patch.object(agent_manager, "check_runtime_available", return_value=False):
+            rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
+                "wee-dev", "claude-sdk", "claude-sonnet-4.6", self.AGENTS_WITH_FALLBACK
+            )
+        self.assertEqual(rt, "copilot")
+        self.assertTrue(used)
+        self.assertIn("not available on this host", reason)
+
+    def test_unknown_agent_returns_original(self):
+        with patch.object(agent_manager, "check_runtime_blocked", return_value=False), \
+             patch.object(agent_manager, "check_runtime_available", return_value=True):
+            rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
+                "nonexistent-agent", "copilot", "gpt-5-mini", {}
+            )
+        self.assertEqual(rt, "copilot")
+        self.assertFalse(used)
+
+    def test_fallback_runtime_only_preserves_original_model(self):
+        agents = {
+            "my-agent": {
+                "dispatch_config": {
+                    "runtime": "claude-sdk",
+                    "model": "sonnet",
+                    "fallback_runtime": "copilot",
+                    # No fallback_model — should preserve original
+                }
+            }
+        }
+        with patch.object(agent_manager, "check_runtime_blocked", return_value=True):
+            rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
+                "my-agent", "claude-sdk", "sonnet", agents
+            )
+        self.assertEqual(rt, "copilot")
+        self.assertEqual(model, "sonnet")  # original preserved
+        self.assertTrue(used)
+
+    def test_fallback_model_only_preserves_original_runtime(self):
+        agents = {
+            "my-agent": {
+                "dispatch_config": {
+                    "runtime": "claude-sdk",
+                    "model": "opus",
+                    "fallback_model": "haiku",
+                    # No fallback_runtime — should preserve original
+                }
+            }
+        }
+        with patch.object(agent_manager, "check_runtime_blocked", return_value=True):
+            rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
+                "my-agent", "claude-sdk", "opus", agents
+            )
+        self.assertEqual(rt, "claude-sdk")
+        self.assertEqual(model, "haiku")
+        self.assertTrue(used)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #197

## Changes
- `check_runtime_blocked()`: parses RUNTIME_STATE.md Active Incidents to detect blocked runtimes
- `resolve_dispatch_runtime_model()`: applies dispatch_config fallback when primary is blocked/unavailable
- `create_background_task` now calls resolve before creating tasks, logs fallback choice
- `agents.json`: wee-dev and wee-qa now have `fallback_runtime` and `fallback_model`

## Tests
15 regression tests in `tests/test_issue_197_dispatch_fallback.py` covering:
- RUNTIME_STATE.md parsing (blocked, expired, empty, missing file)
- Fallback activation on blocked and unavailable runtimes
- Fallback passthrough when primary is healthy