### PR TITLE
fix(#168): real primary/backup fallback via check_runtime_available

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -14362,7 +14362,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         file=sys.stderr,
                     )
                 else:
-                    # Primary configured but unavailable — validate backup before using it
+                    # Primary unavailable — validate backup before using it
                     if _pref_backup and check_runtime_available(_pref_backup):
                         runtime = _pref_backup
                     else:

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -14349,21 +14349,36 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             _session_rt = defaults.get("runtime")
             _pref_primary = _get_runtime_pref_mgr().primary()
             _pref_backup = _get_runtime_pref_mgr().backup()
-            runtime = (
-                _session_rt or _pref_primary or _pref_backup or get_default_runtime()
-            )
             if _session_rt:
+                runtime = _session_rt
                 print(
                     f"[RuntimePref] Using session runtime: {runtime}", file=sys.stderr
                 )
             elif _pref_primary:
+                if check_runtime_available(_pref_primary):
+                    runtime = _pref_primary
+                    print(
+                        f"[RuntimePref] Using primary preference runtime: {runtime}",
+                        file=sys.stderr,
+                    )
+                else:
+                    # Primary configured but unavailable — fall back to backup or default
+                    runtime = _pref_backup or get_default_runtime()
+                    print(
+                        f"[RuntimePref] Primary '{_pref_primary}' unavailable, "
+                        f"falling back to: {runtime}",
+                        file=sys.stderr,
+                    )
+            elif _pref_backup:
+                runtime = _pref_backup
                 print(
-                    f"[RuntimePref] Using primary preference runtime: {runtime}",
+                    f"[RuntimePref] Using backup preference runtime: {runtime}",
                     file=sys.stderr,
                 )
             else:
+                runtime = get_default_runtime()
                 print(
-                    f"[RuntimePref] Using backup preference runtime: {runtime}",
+                    f"[RuntimePref] Using default runtime: {runtime}",
                     file=sys.stderr,
                 )
         model = body.model or defaults.get("model", get_default_model())

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1158,8 +1158,14 @@ def get_default_model() -> str:
 
 
 def get_default_runtime() -> str:
-    """Get default runtime from environment or use copilot"""
-    return os.environ.get("COPILOT_DEFAULT_RUNTIME", "copilot")
+    """Get default runtime, preferring env var; falls back to first available runtime."""
+    preferred = os.environ.get("COPILOT_DEFAULT_RUNTIME", "copilot")
+    if check_runtime_available(preferred):
+        return preferred
+    available = get_available_runtimes()
+    if available:
+        return available[0]["id"]
+    return preferred  # nothing available at all — return as last resort
 
 
 MODEL_MANIFEST_PATH = Path(SCRIPT_BASE_DIR) / "model-manifest.json"
@@ -14362,7 +14368,8 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         file=sys.stderr,
                     )
                 else:
-                    # Primary unavailable — validate backup before using it
+                    # Primary configured but unavailable — validate backup before using it;
+                    # get_default_runtime() will scan all available runtimes as last resort.
                     if _pref_backup and check_runtime_available(_pref_backup):
                         runtime = _pref_backup
                     else:

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -14362,15 +14362,21 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         file=sys.stderr,
                     )
                 else:
-                    # Primary configured but unavailable — fall back to backup or default
-                    runtime = _pref_backup or get_default_runtime()
+                    # Primary configured but unavailable — validate backup before using it
+                    if _pref_backup and check_runtime_available(_pref_backup):
+                        runtime = _pref_backup
+                    else:
+                        runtime = get_default_runtime()
                     print(
                         f"[RuntimePref] Primary '{_pref_primary}' unavailable, "
                         f"falling back to: {runtime}",
                         file=sys.stderr,
                     )
             elif _pref_backup:
-                runtime = _pref_backup
+                if check_runtime_available(_pref_backup):
+                    runtime = _pref_backup
+                else:
+                    runtime = get_default_runtime()
                 print(
                     f"[RuntimePref] Using backup preference runtime: {runtime}",
                     file=sys.stderr,

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1158,7 +1158,8 @@ def get_default_model() -> str:
 
 
 def get_default_runtime() -> str:
-    """Get default runtime, preferring env var; falls back to first available runtime."""
+    """Get default runtime, preferring env var; falls back to
+    first available runtime."""
     preferred = os.environ.get("COPILOT_DEFAULT_RUNTIME", "copilot")
     if check_runtime_available(preferred):
         return preferred
@@ -14368,8 +14369,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         file=sys.stderr,
                     )
                 else:
-                    # Primary configured but unavailable — validate backup before using it;
-                    # get_default_runtime() will scan all available runtimes as last resort.
+                    # Primary configured but unavailable — validate
+                    # backup before using it; get_default_runtime()
+                    # will scan all available runtimes as last resort.
                     if _pref_backup and check_runtime_available(_pref_backup):
                         runtime = _pref_backup
                     else:

--- a/tests/test_issue168_runtime_preferences.py
+++ b/tests/test_issue168_runtime_preferences.py
@@ -700,5 +700,92 @@ class TestBackupRuntimeFallback(unittest.TestCase):
             if os.path.exists(tmp):
                 os.unlink(tmp)
 
+    def test_default_used_when_both_primary_and_backup_unavailable(self):
+        """Regression test for #168 MAJOR: when both primary AND backup runtimes are
+        configured but unavailable, the code must fall back to the default runtime —
+        NOT select the unavailable backup. Reproduction: primary='definitely-not-installed',
+        backup='also-not-installed', default='copilot' -> must return 'copilot'."""
+        import tempfile
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        tmp = tempfile.mktemp(suffix="_168_both_unavailable.json")
+        mgr = agent_manager.RuntimePreferencesManager(tmp)
+        mgr.set("definitely-not-installed", "also-not-installed")
+
+        try:
+            with patch.object(agent_manager, "_runtime_pref_mgr", mgr), patch.object(
+                agent_manager,
+                "check_runtime_available",
+                side_effect=lambda rt: rt not in (
+                    "definitely-not-installed", "also-not-installed"
+                ),
+            ), patch.object(
+                agent_manager,
+                "get_default_runtime",
+                return_value="copilot",
+            ), patch.object(
+                agent_manager,
+                "_resolve_telegram_identity",
+                side_effect=lambda x: x,
+            ), patch.object(
+                agent_manager,
+                "_send_pairing_code",
+                return_value=True,
+            ), patch.object(
+                agent_manager,
+                "_compute_bg_task_defaults",
+                return_value={},
+            ):
+                captured = []
+
+                async def fake_bg(
+                    self_sm,
+                    task_id,
+                    session_id,
+                    prompt,
+                    agent,
+                    runtime,
+                    model,
+                    *a,
+                    **kw,
+                ):
+                    captured.append(runtime)
+
+                with patch.object(
+                    agent_manager.SessionManager,
+                    "_execute_background_task",
+                    fake_bg,
+                ):
+                    app = agent_manager.create_api_app()
+                    client = TestClient(app)
+                    resp = client.post(
+                        "/api/v1/background-tasks",
+                        json={
+                            "prompt": "test both runtimes unavailable",
+                            "agent": "orchestrator",
+                        },
+                        headers={
+                            "Authorization": "Bearer shared_test_key_168",
+                        },
+                    )
+                self.assertIn(resp.status_code, [200, 201, 202])
+                task_data = resp.json()
+                self.assertIn("runtime", task_data)
+                self.assertEqual(
+                    task_data["runtime"],
+                    "copilot",
+                    f"Expected default 'copilot' but got '{task_data['runtime']}'. "
+                    "Both primary 'definitely-not-installed' and backup 'also-not-installed' "
+                    "are unavailable — must fall back to default 'copilot'.",
+                )
+        finally:
+            import os
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_issue168_runtime_preferences.py
+++ b/tests/test_issue168_runtime_preferences.py
@@ -616,6 +616,7 @@ class TestBackupRuntimeFallback(unittest.TestCase):
                 )
         finally:
             import os
+
             if os.path.exists(tmp):
                 os.unlink(tmp)
 
@@ -696,6 +697,7 @@ class TestBackupRuntimeFallback(unittest.TestCase):
                 )
         finally:
             import os
+
             if os.path.exists(tmp):
                 os.unlink(tmp)
 
@@ -720,9 +722,8 @@ class TestBackupRuntimeFallback(unittest.TestCase):
             with patch.object(agent_manager, "_runtime_pref_mgr", mgr), patch.object(
                 agent_manager,
                 "check_runtime_available",
-                side_effect=lambda rt: rt not in (
-                    "definitely-not-installed", "also-not-installed"
-                ),
+                side_effect=lambda rt: rt
+                not in ("definitely-not-installed", "also-not-installed"),
             ), patch.object(
                 agent_manager,
                 "get_default_runtime",
@@ -785,6 +786,7 @@ class TestBackupRuntimeFallback(unittest.TestCase):
                 )
         finally:
             import os
+
             if os.path.exists(tmp):
                 os.unlink(tmp)
 

--- a/tests/test_issue168_runtime_preferences.py
+++ b/tests/test_issue168_runtime_preferences.py
@@ -790,6 +790,95 @@ class TestBackupRuntimeFallback(unittest.TestCase):
             if os.path.exists(tmp):
                 os.unlink(tmp)
 
+    def test_available_runtime_selected_when_primary_backup_default_all_dead(self):
+        """Regression for #168 BLOCKER: when primary, backup AND default are all
+        unavailable, the background task must be assigned an actually-available
+        runtime (not the dead default string)."""
+        import tempfile
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        tmp = tempfile.mktemp(suffix="_168_all_dead.json")
+        mgr = agent_manager.RuntimePreferencesManager(tmp)
+        # primary and backup both dead
+        mgr.set("dead-primary", "dead-backup")
+
+        ALIVE_RUNTIME = "opencode"
+
+        def _available(rt):
+            return rt == ALIVE_RUNTIME
+
+        try:
+            with patch.object(agent_manager, "_runtime_pref_mgr", mgr), patch.object(
+                agent_manager,
+                "check_runtime_available",
+                side_effect=_available,
+            ), patch.object(
+                agent_manager,
+                "get_available_runtimes",
+                return_value=[{"id": ALIVE_RUNTIME, "label": ALIVE_RUNTIME}],
+            ), patch.object(
+                agent_manager,
+                "_resolve_telegram_identity",
+                side_effect=lambda x: x,
+            ), patch.object(
+                agent_manager,
+                "_send_pairing_code",
+                return_value=True,
+            ), patch.object(
+                agent_manager,
+                "_compute_bg_task_defaults",
+                return_value={},
+            ):
+                async def fake_bg(
+                    self_sm,
+                    task_id,
+                    session_id,
+                    prompt,
+                    agent,
+                    runtime,
+                    model,
+                    *a,
+                    **kw,
+                ):
+                    pass
+
+                with patch.object(
+                    agent_manager.SessionManager,
+                    "_execute_background_task",
+                    fake_bg,
+                ):
+                    app = agent_manager.create_api_app()
+                    client = TestClient(app)
+                    resp = client.post(
+                        "/api/v1/background-tasks",
+                        json={
+                            "prompt": "test all-dead fallback to available runtime",
+                            "agent": "orchestrator",
+                        },
+                        headers={
+                            "Authorization": "Bearer shared_test_key_168",
+                        },
+                    )
+                self.assertIn(resp.status_code, [200, 201, 202])
+                task_data = resp.json()
+                self.assertIn("runtime", task_data)
+                self.assertEqual(
+                    task_data["runtime"],
+                    ALIVE_RUNTIME,
+                    f"Expected alive runtime '{ALIVE_RUNTIME}' but got "
+                    f"'{task_data['runtime']}'. When primary, backup, and default "
+                    "are all unavailable, the task must use an actually-available "
+                    "runtime.",
+                )
+        finally:
+            import os
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_issue168_runtime_preferences.py
+++ b/tests/test_issue168_runtime_preferences.py
@@ -536,7 +536,6 @@ class TestBackupRuntimeFallback(unittest.TestCase):
             if os.path.exists(tmp):
                 os.unlink(tmp)
 
-
     def test_backup_used_when_primary_unavailable(self):
         """Regression test for #168 BLOCKER: when primary is configured but
         unavailable (not installed), the backup runtime must be selected."""
@@ -703,7 +702,8 @@ class TestBackupRuntimeFallback(unittest.TestCase):
     def test_default_used_when_both_primary_and_backup_unavailable(self):
         """Regression test for #168 MAJOR: when both primary AND backup runtimes are
         configured but unavailable, the code must fall back to the default runtime —
-        NOT select the unavailable backup. Reproduction: primary='definitely-not-installed',
+        NOT select the unavailable backup. Reproduction:
+        primary='definitely-not-installed',
         backup='also-not-installed', default='copilot' -> must return 'copilot'."""
         import tempfile
         from unittest.mock import patch
@@ -779,13 +779,15 @@ class TestBackupRuntimeFallback(unittest.TestCase):
                     task_data["runtime"],
                     "copilot",
                     f"Expected default 'copilot' but got '{task_data['runtime']}'. "
-                    "Both primary 'definitely-not-installed' and backup 'also-not-installed' "
+                    "Both primary 'definitely-not-installed' and backup"
+                    " 'also-not-installed' "
                     "are unavailable — must fall back to default 'copilot'.",
                 )
         finally:
             import os
             if os.path.exists(tmp):
                 os.unlink(tmp)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_issue168_runtime_preferences.py
+++ b/tests/test_issue168_runtime_preferences.py
@@ -537,5 +537,168 @@ class TestBackupRuntimeFallback(unittest.TestCase):
                 os.unlink(tmp)
 
 
+    def test_backup_used_when_primary_unavailable(self):
+        """Regression test for #168 BLOCKER: when primary is configured but
+        unavailable (not installed), the backup runtime must be selected."""
+        import tempfile
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        tmp = tempfile.mktemp(suffix="_168_fallback_unavailable.json")
+        mgr = agent_manager.RuntimePreferencesManager(tmp)
+        # Set primary to something definitely not installed; backup to a real one
+        mgr.set("definitely-not-installed", "gemini")
+
+        try:
+            with patch.object(agent_manager, "_runtime_pref_mgr", mgr), patch.object(
+                agent_manager,
+                "check_runtime_available",
+                side_effect=lambda rt: rt != "definitely-not-installed",
+            ), patch.object(
+                agent_manager,
+                "get_default_runtime",
+                return_value="copilot",
+            ), patch.object(
+                agent_manager,
+                "_resolve_telegram_identity",
+                side_effect=lambda x: x,
+            ), patch.object(
+                agent_manager,
+                "_send_pairing_code",
+                return_value=True,
+            ), patch.object(
+                agent_manager,
+                "_compute_bg_task_defaults",
+                return_value={},
+            ):
+                captured = []
+
+                async def fake_bg(
+                    self_sm,
+                    task_id,
+                    session_id,
+                    prompt,
+                    agent,
+                    runtime,
+                    model,
+                    *a,
+                    **kw,
+                ):
+                    captured.append(runtime)
+
+                with patch.object(
+                    agent_manager.SessionManager,
+                    "_execute_background_task",
+                    fake_bg,
+                ):
+                    app = agent_manager.create_api_app()
+                    client = TestClient(app)
+                    resp = client.post(
+                        "/api/v1/background-tasks",
+                        json={
+                            "prompt": "test unavailable primary fallback",
+                            "agent": "orchestrator",
+                        },
+                        headers={
+                            "Authorization": "Bearer shared_test_key_168",
+                        },
+                    )
+                self.assertIn(resp.status_code, [200, 201, 202])
+                task_data = resp.json()
+                self.assertIn("runtime", task_data)
+                self.assertEqual(
+                    task_data["runtime"],
+                    "gemini",
+                    f"Expected backup 'gemini' but got '{task_data['runtime']}'. "
+                    "Primary 'definitely-not-installed' should be skipped.",
+                )
+        finally:
+            import os
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
+    def test_default_used_when_primary_unavailable_and_no_backup(self):
+        """When primary is unavailable and no backup is set, use the default runtime."""
+        import tempfile
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        tmp = tempfile.mktemp(suffix="_168_fallback_default.json")
+        mgr = agent_manager.RuntimePreferencesManager(tmp)
+        mgr.set("definitely-not-installed", "")
+
+        try:
+            with patch.object(agent_manager, "_runtime_pref_mgr", mgr), patch.object(
+                agent_manager,
+                "check_runtime_available",
+                side_effect=lambda rt: rt != "definitely-not-installed",
+            ), patch.object(
+                agent_manager,
+                "get_default_runtime",
+                return_value="copilot",
+            ), patch.object(
+                agent_manager,
+                "_resolve_telegram_identity",
+                side_effect=lambda x: x,
+            ), patch.object(
+                agent_manager,
+                "_send_pairing_code",
+                return_value=True,
+            ), patch.object(
+                agent_manager,
+                "_compute_bg_task_defaults",
+                return_value={},
+            ):
+                captured = []
+
+                async def fake_bg(
+                    self_sm,
+                    task_id,
+                    session_id,
+                    prompt,
+                    agent,
+                    runtime,
+                    model,
+                    *a,
+                    **kw,
+                ):
+                    captured.append(runtime)
+
+                with patch.object(
+                    agent_manager.SessionManager,
+                    "_execute_background_task",
+                    fake_bg,
+                ):
+                    app = agent_manager.create_api_app()
+                    client = TestClient(app)
+                    resp = client.post(
+                        "/api/v1/background-tasks",
+                        json={
+                            "prompt": "test unavailable primary no backup",
+                            "agent": "orchestrator",
+                        },
+                        headers={
+                            "Authorization": "Bearer shared_test_key_168",
+                        },
+                    )
+                self.assertIn(resp.status_code, [200, 201, 202])
+                task_data = resp.json()
+                self.assertIn("runtime", task_data)
+                self.assertEqual(
+                    task_data["runtime"],
+                    "copilot",
+                    f"Expected default 'copilot' but got '{task_data['runtime']}'.",
+                )
+        finally:
+            import os
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Addresses BLOCKER from QA round 2 for issue #168.\n\nChanges:\n- agent_manager.py: Restructured bg-task runtime selection to call check_runtime_available() before using primary. Unavailable primary falls back to backup or default.\n- tests: 2 new regression tests covering unavailable-primary paths.\n\nAll 23 tests pass.\n\nCloses #168