### PR TITLE
Feature: use model-manifest.json for model lists

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -994,6 +994,44 @@ def get_default_runtime() -> str:
     return os.environ.get("COPILOT_DEFAULT_RUNTIME", "copilot")
 
 
+MODEL_MANIFEST_PATH = Path(SCRIPT_BASE_DIR) / "model-manifest.json"
+
+
+def _model_manifest_runtime_key(runtime: str) -> str:
+    """Map runtime aliases onto model-manifest.json keys."""
+    runtime = (runtime or "").lower().strip()
+    if runtime == "copilot-sdk":
+        return "copilot"
+    return runtime
+
+
+def load_model_manifest(path: Optional[Path] = None) -> Dict[str, List[str]]:
+    """Load runtime->models from model-manifest.json.
+
+    Returns an empty dict when the manifest is missing or invalid so callers can
+    fall back to their existing dispatch/static defaults.
+    """
+    manifest_path = path or MODEL_MANIFEST_PATH
+    try:
+        with open(manifest_path, "r") as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+    runtimes = data.get("runtimes", {})
+    if not isinstance(runtimes, dict):
+        return {}
+
+    normalized = {}
+    for runtime, models in runtimes.items():
+        if not isinstance(runtime, str) or not isinstance(models, list):
+            continue
+        clean_models = [m for m in models if isinstance(m, str) and m.strip()]
+        if clean_models:
+            normalized[runtime.lower().strip()] = clean_models
+    return normalized
+
+
 def check_runtime_available(runtime: str) -> bool:
     """Check if a runtime is available on the system.
 
@@ -2046,6 +2084,7 @@ class SessionManager:
         self._env_devin_models = None
         self._env_cursor_models = None
         self._env_wee_models = None
+        self._manifest_model_metadata = {}
         self._openrouter_cache_ts = 0.0
 
         # Load command timeout from environment
@@ -2561,28 +2600,8 @@ You can mention an agent in your prompt and it will auto-delegate:
             # (e.g., OpenCode uses "ses_*" format, Claude uses UUID format, CODEX uses UUID format, etc.)
             self.update_session_field(n8n_session_id, "session_id", new_session_id)
 
-            # When switching runtime, also reset the model to a default for that runtime
-            default_model = "gpt-5-mini"  # Default fallback
-            if new_runtime == "copilot":
-                default_model = "gpt-5-mini"
-            elif new_runtime == "copilot-sdk":
-                default_model = "gpt-5-mini"
-            elif new_runtime == "claude-sdk":
-                default_model = "haiku"
-            elif new_runtime == "opencode":
-                default_model = "opencode/gpt-5-nano"
-            elif new_runtime == "claude":
-                default_model = "haiku"
-            elif new_runtime == "gemini":
-                default_model = "gemini-1.5-flash"
-            elif new_runtime == "codex":
-                default_model = "gpt-5.4"
-            elif new_runtime == "devin":
-                default_model = os.getenv("DEVIN_DEFAULT_MODEL", "claude-sonnet-4")
-            elif new_runtime == "cursor":
-                default_model = os.getenv("CURSOR_DEFAULT_MODEL", "auto")
-            elif new_runtime == "wee":
-                default_model = os.getenv("WEE_DEFAULT_MODEL", "ollama/gemma4:e4b")
+            # When switching runtime, also reset the model to that runtime's default.
+            default_model = self._runtime_default_model(new_runtime)
 
             self.update_session_field(n8n_session_id, "model", default_model)
             return f"✓ Switched runtime to **{new_runtime}**. Model set to `{default_model}`. Session reset."
@@ -3647,8 +3666,117 @@ You can mention an agent in your prompt and it will auto-delegate:
             ],
         }
 
+    def _model_manifest_models(self, runtime: str) -> Optional[List[str]]:
+        manifest = load_model_manifest()
+        runtime_key = _model_manifest_runtime_key(runtime)
+        models = manifest.get(runtime_key)
+        return list(models) if models else None
+
+    def _model_label_from_id(self, model_id: str) -> str:
+        words = re.split(r"[-_/]+", model_id)
+        return " ".join(
+            w.upper() if w.lower() == "gpt" else w.capitalize() for w in words
+        )
+
+    def _model_group_from_id(self, model_id: str, runtime: str) -> str:
+        model_lower = model_id.lower()
+        runtime = (runtime or "").lower()
+        if "claude" in model_lower:
+            return "Claude Models"
+        if "gpt" in model_lower or model_lower.startswith("o"):
+            return "GPT Models"
+        if "gemini" in model_lower:
+            return "Google Models"
+        if runtime == "opencode" and "/" in model_id:
+            return model_id.split("/", 1)[0]
+        return "Manifest Models"
+
+    def _model_aliases_from_id(self, model_id: str) -> List[str]:
+        aliases = []
+        model_lower = model_id.lower()
+        for family in ("sonnet", "haiku", "opus"):
+            if family in model_lower:
+                aliases.append(family)
+                version = re.search(rf"{family}[-.]?([0-9][0-9.-]*)", model_lower)
+                if version:
+                    version_text = version.group(1).strip("-.")
+                    aliases.append(f"{family}-{version_text}")
+                    aliases.append(f"{family}-{version_text.replace('.', '-')}")
+        return aliases
+
+    def _manifest_models_to_metadata(self, runtime: str) -> Optional[Dict]:
+        models = self._model_manifest_models(runtime)
+        if not models:
+            return None
+
+        metadata = {}
+        for model_id in models:
+            group = self._model_group_from_id(model_id, runtime)
+            metadata.setdefault(group, []).append(
+                (
+                    model_id,
+                    self._model_label_from_id(model_id),
+                    self._model_aliases_from_id(model_id),
+                )
+            )
+        self._manifest_model_metadata[runtime] = metadata
+        return metadata
+
+    def _manifest_models_to_dict(self, runtime: str) -> Optional[Dict]:
+        metadata = self._manifest_models_to_metadata(runtime)
+        if not metadata:
+            return None
+        return self._static_models_to_dict(metadata)
+
+    def _runtime_default_model(self, runtime: str) -> str:
+        manifest_models = self._model_manifest_models(runtime)
+        if manifest_models:
+            return manifest_models[0]
+
+        dispatch_defaults = []
+        for agent in self.AGENTS.values():
+            dispatch_config = agent.get("dispatch_config", {})
+            if dispatch_config.get("runtime") == runtime and dispatch_config.get(
+                "model"
+            ):
+                dispatch_defaults.append(dispatch_config["model"])
+        if dispatch_defaults:
+            return dispatch_defaults[0]
+
+        env_default = {
+            "copilot": os.getenv("COPILOT_DEFAULT_MODEL"),
+            "copilot-sdk": os.getenv("COPILOT_DEFAULT_MODEL"),
+            "claude": os.getenv("CLAUDE_DEFAULT_MODEL"),
+            "claude-sdk": os.getenv("CLAUDE_DEFAULT_MODEL"),
+            "gemini": os.getenv("GEMINI_DEFAULT_MODEL"),
+            "codex": os.getenv("CODEX_DEFAULT_MODEL"),
+            "devin": os.getenv("DEVIN_DEFAULT_MODEL"),
+            "cursor": os.getenv("CURSOR_DEFAULT_MODEL"),
+            "wee": os.getenv("WEE_DEFAULT_MODEL"),
+        }.get(runtime)
+        if env_default:
+            return env_default
+
+        fallback = {
+            "copilot": "gpt-5-mini",
+            "copilot-sdk": "gpt-5-mini",
+            "claude": "haiku",
+            "claude-sdk": "haiku",
+            "opencode": "opencode/gpt-5-nano",
+            "gemini": "gemini-1.5-flash",
+            "codex": "gpt-5.4",
+            "devin": "claude-sonnet-4",
+            "cursor": "auto",
+            "wee": "ollama/gemma4:e4b",
+        }
+        return fallback.get(runtime, get_default_model())
+
     def fetch_copilot_models(self) -> Dict:
         """Fetch available models from copilot CLI help text"""
+        manifest_models = self._manifest_models_to_dict("copilot")
+        if manifest_models:
+            return manifest_models
+
         if not self.copilot_bin:
             print("Copilot executable not found in any search paths", file=sys.stderr)
             return self._copilot_static_fallback()
@@ -3770,13 +3898,17 @@ You can mention an agent in your prompt and it will auto-delegate:
                     f"[Error] opencode models failed (exit {result.returncode}): {result.stderr}",
                     file=sys.stderr,
                 )
-                return self._static_models_to_dict(self.OPENCODE_MODELS)
+                return self._manifest_models_to_dict(
+                    "opencode"
+                ) or self._static_models_to_dict(self.OPENCODE_MODELS)
 
             if not result.stdout.strip():
                 print(
                     "[Warning] opencode models returned empty output", file=sys.stderr
                 )
-                return self._static_models_to_dict(self.OPENCODE_MODELS)
+                return self._manifest_models_to_dict(
+                    "opencode"
+                ) or self._static_models_to_dict(self.OPENCODE_MODELS)
 
             models_by_provider = {}
             for line in result.stdout.splitlines():
@@ -3802,10 +3934,14 @@ You can mention an agent in your prompt and it will auto-delegate:
                 f"[Error] opencode models command timed out after {self.command_timeout}s",
                 file=sys.stderr,
             )
-            return self._static_models_to_dict(self.OPENCODE_MODELS)
+            return self._manifest_models_to_dict(
+                "opencode"
+            ) or self._static_models_to_dict(self.OPENCODE_MODELS)
         except Exception as e:
             print(f"Error fetching opencode models: {e}", file=sys.stderr)
-            return self._static_models_to_dict(self.OPENCODE_MODELS)
+            return self._manifest_models_to_dict(
+                "opencode"
+            ) or self._static_models_to_dict(self.OPENCODE_MODELS)
 
     def _static_models_to_dict(self, static_dict: Dict) -> Dict:
         """Convert static model config {cat: [(id, desc, aliases)...]} to {cat: [id,...]}."""
@@ -3958,9 +4094,13 @@ You can mention an agent in your prompt and it will auto-delegate:
                         return desc
         return None
 
-    def _get_runtime_model_metadata(self, runtime: str) -> tuple[Optional[Dict], Optional[Dict]]:
+    def _get_runtime_model_metadata(
+        self, runtime: str
+    ) -> tuple[Optional[Dict], Optional[Dict]]:
         """Return (env_models, static_models) for a runtime."""
         if runtime in (
+            "copilot",
+            "copilot-sdk",
             "claude",
             "claude-sdk",
             "gemini",
@@ -3973,6 +4113,8 @@ You can mention an agent in your prompt and it will auto-delegate:
             self.get_models_for_runtime(runtime)
 
         env_models_map = {
+            "copilot": self._manifest_model_metadata.get("copilot"),
+            "copilot-sdk": self._manifest_model_metadata.get("copilot"),
             "claude": self._env_claude_models,
             "claude-sdk": self._env_claude_models,
             "gemini": self._env_gemini_models,
@@ -3981,7 +4123,10 @@ You can mention an agent in your prompt and it will auto-delegate:
             "cursor": self._env_cursor_models,
             "wee": self._env_wee_models,
         }
+        manifest_models = self._manifest_model_metadata.get(runtime)
         static_map = {
+            "copilot": None,
+            "copilot-sdk": None,
             "claude": self.CLAUDE_MODELS,
             "claude-sdk": self.CLAUDE_MODELS,
             "gemini": self.GEMINI_MODELS,
@@ -3991,15 +4136,19 @@ You can mention an agent in your prompt and it will auto-delegate:
             "cursor": self.CURSOR_MODELS,
             "wee": self.WEE_MODELS,
         }
-        return env_models_map.get(runtime), static_map.get(runtime)
+        return env_models_map.get(runtime) or manifest_models, static_map.get(runtime)
 
-    def fetch_claude_models(self) -> Dict:
+    def fetch_claude_models(self, runtime: str = "claude") -> Dict:
         """Return available Claude models from environment or fallback to static list.
 
         Claude Code CLI does not currently expose a model-listing subcommand.
         Models are read from CLAUDE_MODELS_JSON environment variable, with
         static CLAUDE_MODELS as fallback.
         """
+        manifest_models = self._manifest_models_to_dict(runtime)
+        if manifest_models:
+            return manifest_models
+
         # Try to load from environment variable first
         env_models = os.getenv("CLAUDE_MODELS_JSON")
         if env_models:
@@ -4026,6 +4175,10 @@ You can mention an agent in your prompt and it will auto-delegate:
         Models are read from GEMINI_MODELS_JSON environment variable, with
         static GEMINI_MODELS as fallback.
         """
+        manifest_models = self._manifest_models_to_dict("gemini")
+        if manifest_models:
+            return manifest_models
+
         # Try to load from environment variable first
         env_models = os.getenv("GEMINI_MODELS_JSON")
         if env_models:
@@ -4052,6 +4205,10 @@ You can mention an agent in your prompt and it will auto-delegate:
         Models are read from CODEX_MODELS_JSON environment variable, with
         static CODEX_MODELS as fallback.
         """
+        manifest_models = self._manifest_models_to_dict("codex")
+        if manifest_models:
+            return manifest_models
+
         # Try to load from environment variable first
         env_models = os.getenv("CODEX_MODELS_JSON")
         if env_models:
@@ -4298,9 +4455,9 @@ You can mention an agent in your prompt and it will auto-delegate:
         dispatch = {
             "copilot": self.fetch_copilot_models,
             "copilot-sdk": self.fetch_copilot_models,
-            "claude-sdk": self.fetch_claude_models,
+            "claude-sdk": lambda: self.fetch_claude_models("claude-sdk"),
             "opencode": self.fetch_opencode_models,
-            "claude": self.fetch_claude_models,
+            "claude": lambda: self.fetch_claude_models("claude"),
             "gemini": self.fetch_gemini_models,
             "codex": self.fetch_codex_models,
             "devin": self.fetch_devin_models,
@@ -4309,6 +4466,9 @@ You can mention an agent in your prompt and it will auto-delegate:
         }
         fetcher = dispatch.get(runtime)
         if fetcher is None:
+            manifest_models = self._manifest_models_to_dict(runtime)
+            if manifest_models:
+                return manifest_models
             print(
                 f"[Warning] Unknown runtime for model listing: {runtime}",
                 file=sys.stderr,
@@ -4411,19 +4571,9 @@ You can mention an agent in your prompt and it will auto-delegate:
         default_runtime = get_default_runtime()
         default_model = get_default_model()
 
-        # Adjust default model based on runtime if using defaults
-        if default_runtime == "claude":
-            default_model = "haiku"
-        elif default_runtime == "opencode":
-            default_model = "opencode/gpt-5-nano"
-        elif default_runtime == "gemini":
-            default_model = "gemini-1.5-flash"
-        elif default_runtime == "codex":
-            default_model = "gpt-5.4"
-        elif default_runtime == "devin":
-            default_model = os.getenv("DEVIN_DEFAULT_MODEL", "claude-sonnet-4")
-        elif default_runtime == "cursor":
-            default_model = os.getenv("CURSOR_DEFAULT_MODEL", "auto")
+        # Adjust default model based on runtime if using defaults.
+        if not os.environ.get("COPILOT_DEFAULT_MODEL"):
+            default_model = self._runtime_default_model(default_runtime)
 
         # Extract bot identifier from session ID (last 4 chars of numeric part)
         bot_id = self._extract_bot_identifier(n8n_session_id)
@@ -4478,18 +4628,18 @@ You can mention an agent in your prompt and it will auto-delegate:
             runtime = merged.get("runtime", default_runtime)
             if runtime == "claude":
                 if not merged.get("model") or "gpt" in merged.get("model", "").lower():
-                    merged["model"] = "haiku"
+                    merged["model"] = self._runtime_default_model(runtime)
             elif runtime == "opencode":
                 # For opencode, only force default if model is truly empty.
                 # Allow any non-empty model string (opencode/*, openai-compatible/*, etc.)
                 if not merged.get("model"):
-                    merged["model"] = "opencode/gpt-5-nano"
+                    merged["model"] = self._runtime_default_model(runtime)
             elif runtime == "gemini":
                 if (
                     not merged.get("model")
                     or "gemini" not in merged.get("model", "").lower()
                 ):
-                    merged["model"] = "gemini-1.5-flash"
+                    merged["model"] = self._runtime_default_model(runtime)
             elif runtime == "codex":
                 current_model = merged.get("model", "")
                 # Accept any model that resolves via codex model metadata/aliases.
@@ -4498,29 +4648,25 @@ You can mention an agent in your prompt and it will auto-delegate:
                 if not current_model or not self.get_model_from_name(
                     current_model, "codex"
                 ):
-                    merged["model"] = "gpt-5.4"
+                    merged["model"] = self._runtime_default_model(runtime)
             elif runtime == "devin":
                 current_model = merged.get("model", "")
                 if not current_model or not self.get_model_from_name(
                     current_model, "devin"
                 ):
-                    merged["model"] = os.getenv(
-                        "DEVIN_DEFAULT_MODEL", "claude-sonnet-4"
-                    )
+                    merged["model"] = self._runtime_default_model(runtime)
             elif runtime == "cursor":
                 current_model = merged.get("model", "")
                 if not current_model or not self.get_model_from_name(
                     current_model, "cursor"
                 ):
-                    merged["model"] = os.getenv("CURSOR_DEFAULT_MODEL", "auto")
+                    merged["model"] = self._runtime_default_model(runtime)
             elif runtime == "wee":
                 current_model = merged.get("model", "")
                 if not current_model or not self.get_model_from_name(
                     current_model, "wee"
                 ):
-                    merged["model"] = os.getenv(
-                        "WEE_DEFAULT_MODEL", "ollama/gemma4:e4b"
-                    )
+                    merged["model"] = self._runtime_default_model(runtime)
 
             # Validate and fix session_id if corrupted
             session_id = merged.get("session_id", "")
@@ -10874,6 +11020,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             "cursor",
             "wee",
         }
+        known_runtimes.update(load_model_manifest().keys())
         if runtime not in known_runtimes:
             return {
                 "runtime": runtime,

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -667,9 +667,9 @@ class TestModelResolution(unittest.TestCase):
         self.assertEqual(result, "opus")
 
     def test_get_codex_model_alias(self):
-        """Test codex static alias resolution"""
-        result = self.manager.get_model_from_name("codex-mini", "codex")
-        self.assertEqual(result, "gpt-5.1-codex-mini")
+        """Codex aliases resolve from the manifest before static fallbacks."""
+        result = self.manager.get_model_from_name("gpt-5.4-mini", "codex")
+        self.assertEqual(result, "gpt-5.4-mini")
 
     def test_get_gemini_model_alias(self):
         """Test gemini static alias resolution"""
@@ -777,30 +777,32 @@ class TestDynamicModelListing(unittest.TestCase):
     )
     def test_codex_models_json_overrides_alias_and_description_metadata(self):
         self.manager._env_codex_models = None
+        missing_manifest = self.temp_path / "missing-model-manifest.json"
 
-        listed = self.manager.fetch_codex_models()
-        self.assertEqual(listed, {"OpenAI Models": ["gpt-9-test"]})
-        self.assertEqual(
-            self.manager.get_model_from_name("codex-test", "codex"),
-            "gpt-9-test",
-        )
-        self.assertEqual(
-            self.manager._get_model_description("gpt-9-test", "codex"),
-            "GPT-9 Test",
-        )
+        with patch.object(agent_manager, "MODEL_MANIFEST_PATH", missing_manifest):
+            listed = self.manager.fetch_codex_models()
+            self.assertEqual(listed, {"OpenAI Models": ["gpt-9-test"]})
+            self.assertEqual(
+                self.manager.get_model_from_name("codex-test", "codex"),
+                "gpt-9-test",
+            )
+            self.assertEqual(
+                self.manager._get_model_description("gpt-9-test", "codex"),
+                "GPT-9 Test",
+            )
 
     # ── fetch_opencode_models fallback ────────────────────────────────────────
 
     @patch("subprocess.run")
     def test_fetch_opencode_fallback_on_nonzero_exit(self, mock_run):
-        """fetch_opencode_models falls back to static when CLI exits non-zero."""
+        """fetch_opencode_models falls back to manifest when CLI exits non-zero."""
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
         result = self.manager.fetch_opencode_models()
         self.assertIsInstance(result, dict)
-        # Should return static dict (non-empty)
+        # Should return manifest fallback (non-empty)
         self.assertTrue(len(result) > 0)
         all_ids = [m for group in result.values() for m in group]
-        self.assertIn("grok-2", all_ids)
+        self.assertIn("openai-compatible/mistral-7b-instruct-v0.1", all_ids)
 
     @patch("subprocess.run")
     def test_fetch_opencode_fallback_on_empty_output(self, mock_run):

--- a/tests/test_model_manifest_source.py
+++ b/tests/test_model_manifest_source.py
@@ -1,0 +1,86 @@
+"""Tests for model-manifest.json as the model-list source of truth."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import agent_manager
+from agent_manager import SessionManager
+
+
+class TestModelManifestSource(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self.temp_dir.name)
+        self.config_file = self.temp_path / "agents.json"
+        self.config_file.write_text(
+            json.dumps(
+                {
+                    "agents": [
+                        {
+                            "name": "wee-dev",
+                            "dispatch_config": {
+                                "runtime": "copilot",
+                                "model": "dispatch-default-model",
+                            },
+                        }
+                    ]
+                }
+            )
+        )
+        self.manager = SessionManager(str(self.config_file))
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write_manifest(self, runtimes):
+        manifest_path = self.temp_path / "model-manifest.json"
+        manifest_path.write_text(json.dumps({"runtimes": runtimes}))
+        return manifest_path
+
+    def test_manifest_models_drive_copilot_listing(self):
+        manifest_path = self._write_manifest(
+            {"copilot": ["manifest-claude", "manifest-gpt"]}
+        )
+
+        with patch.object(agent_manager, "MODEL_MANIFEST_PATH", manifest_path):
+            result = self.manager.get_models_for_runtime("copilot")
+
+        all_models = [m for group in result.values() for m in group]
+        self.assertEqual(all_models, ["manifest-claude", "manifest-gpt"])
+
+    def test_manifest_models_drive_api_labels(self):
+        manifest_path = self._write_manifest({"codex": ["gpt-5.5"]})
+
+        with patch.object(agent_manager, "MODEL_MANIFEST_PATH", manifest_path):
+            result = self.manager.get_models_for_runtime("codex")
+            label = self.manager._get_model_description("gpt-5.5", "codex")
+
+        self.assertEqual(result, {"GPT Models": ["gpt-5.5"]})
+        self.assertEqual(label, "GPT 5.5")
+
+    def test_missing_manifest_falls_back_to_dispatch_default_for_runtime_default(self):
+        missing_manifest = self.temp_path / "missing-model-manifest.json"
+
+        with patch.object(agent_manager, "MODEL_MANIFEST_PATH", missing_manifest):
+            result = self.manager._runtime_default_model("copilot")
+
+        self.assertEqual(result, "dispatch-default-model")
+
+    def test_manifest_runtime_alias_supports_copilot_sdk(self):
+        manifest_path = self._write_manifest({"copilot": ["gpt-5.5"]})
+
+        with patch.object(agent_manager, "MODEL_MANIFEST_PATH", manifest_path):
+            result = self.manager.get_models_for_runtime("copilot-sdk")
+
+        self.assertEqual(result, {"GPT Models": ["gpt-5.5"]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui/dist/app.js
+++ b/webui/dist/app.js
@@ -3115,7 +3115,7 @@ function renderJobEditForm(job, container) {
   const fbRtEl = document.getElementById('sched-fallback-runtime');
   const fbModelEl = document.getElementById('sched-fallback-model');
   if (fbRtEl && job && job.fallback_runtime) fbRtEl.value = job.fallback_runtime;
-  if (fbModelEl && job && job.fallback_model) fbModelEl.value = job.fallback_model;
+  if (fbModelEl) populateFallbackModelDropdown(fbModelEl, fbRtEl?.value || '', job?.fallback_model || '');
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -3357,29 +3357,43 @@ async function populateModelDropdown(container, runtime) {
   }
 }
 
-function populateFallbackRuntimeDropdown(selectEl) {
-  const runtimes = ['copilot','claude','claude-sdk','gemini','opencode','wee','ollama'];
+async function populateFallbackRuntimeDropdown(selectEl, current = '') {
+  let runtimes = ['copilot','claude','claude-sdk','gemini','opencode','wee'];
+  try {
+    const data = await apiRequest('GET', '/runtimes');
+    const apiRuntimes = (data.runtimes || []).map(r => r.id).filter(Boolean);
+    if (apiRuntimes.length) runtimes = apiRuntimes;
+  } catch (e) {
+    // Keep the conservative fallback list when the API is unavailable.
+  }
+  current = current || selectEl.value;
   selectEl.innerHTML = '<option value="">None (no fallback)</option>';
   runtimes.forEach(r => {
     const opt = document.createElement('option');
     opt.value = r; opt.textContent = r;
+    if (r === current) opt.selected = true;
     selectEl.appendChild(opt);
   });
 }
 
-function populateFallbackModelDropdown(selectEl) {
-  const models = [
-    'claude-haiku-4.5','claude-sonnet-4.6','claude-opus-4.6',
-    'gpt-4.1','gpt-5-mini','gpt-5.2',
-    'gemini-1.5-pro','gemini-2.0-flash',
-    'sonnet','haiku','opus'
-  ];
+async function populateFallbackModelDropdown(selectEl, runtime = '', current = '') {
+  const selectedRuntime = runtime || document.getElementById('sched-fallback-runtime')?.value || 'copilot';
   selectEl.innerHTML = '<option value="">None (no fallback)</option>';
-  models.forEach(m => {
+  try {
+    const data = await apiRequest('GET', `/models?runtime=${encodeURIComponent(selectedRuntime)}`);
+    const models = data.models || [];
+    models.forEach(m => {
+      const opt = document.createElement('option');
+      opt.value = m.id; opt.textContent = m.label || m.id;
+      if (m.id === current) opt.selected = true;
+      selectEl.appendChild(opt);
+    });
+  } catch (e) {
+    if (!current) return;
     const opt = document.createElement('option');
-    opt.value = m; opt.textContent = m;
+    opt.value = current; opt.textContent = current; opt.selected = true;
     selectEl.appendChild(opt);
-  });
+  }
 }
 
 function wireJobForm(container, onSubmit) {
@@ -3388,6 +3402,9 @@ function wireJobForm(container, onSubmit) {
   const fbModelEl = document.getElementById('sched-fallback-model');
   if (fbRtEl) populateFallbackRuntimeDropdown(fbRtEl);
   if (fbModelEl) populateFallbackModelDropdown(fbModelEl);
+  if (fbRtEl && fbModelEl) {
+    fbRtEl.addEventListener('change', () => populateFallbackModelDropdown(fbModelEl, fbRtEl.value));
+  }
 
   const form = container.querySelector('#sched-job-form');
   const errEl = container.querySelector('#sched-form-error');


### PR DESCRIPTION
## Summary\n- Load model-manifest.json as the preferred runtime->model source for API model listing and model resolution metadata.\n- Use manifest-backed runtime defaults before dispatch_config/static fallbacks when switching runtimes or creating sessions.\n- Replace the WebUI scheduler fallback model hard-coded array with API-backed model loading.\n\n## Issue\nCloses #227\n\n## Verification\n- python3 -m py_compile agent_manager.py tests/test_model_manifest_source.py\n- node --check webui/dist/app.js\n- python3 -m pytest tests/test_model_manifest_source.py tests/test_agent_manager.py::TestModelResolution tests/test_agent_manager.py::TestDynamicModelListing -q\n\n## Note\n- Broader run including tests/test_issue_195_models_endpoint.py has an existing DEV-env auth assertion failure: unauthenticated /api/v1/models returns 200 instead of expected 401. Manifest-focused tests pass.