### PR TITLE
Fix #245: Propagate agent-level permission_mode/yolo to background tasks (unblocks wee-qa SSH)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -3640,6 +3640,8 @@ You can mention an agent in your prompt and it will auto-delegate:
                         "primary_model": agent.get("primary_model") or agent.get("model", ""),
                         "fallback_runtime": agent.get("fallback_runtime"),
                         "fallback_model": agent.get("fallback_model"),
+                        "permission_mode": agent.get("permission_mode"),
+                        "yolo": agent.get("yolo"),
                         "dispatch_config": agent.get("dispatch_config", {}),
                     }
                 return agents
@@ -3694,6 +3696,8 @@ You can mention an agent in your prompt and it will auto-delegate:
                 "primary_model": agent.get("primary_model") or agent.get("model", ""),
                 "fallback_runtime": agent.get("fallback_runtime"),
                 "fallback_model": agent.get("fallback_model"),
+                "permission_mode": agent.get("permission_mode"),
+                "yolo": agent.get("yolo"),
                 "dispatch_config": agent.get("dispatch_config", {}),
             }
 
@@ -13427,6 +13431,8 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                             "--dangerously-bypass-approvals-and-sandbox",
                             "-c",
                             "shell_environment_policy.inherit=all",
+                            "--sandbox",
+                            "danger-full-access",
                         ]
                     )
                 if model:
@@ -13977,6 +13983,8 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 "fallback_runtime": agent_cfg.get("fallback_runtime"),
                 "fallback_model": agent_cfg.get("fallback_model"),
                 "timeout": agent_cfg.get("timeout", 3600),
+                "permission_mode": agent_cfg.get("permission_mode"),
+                "yolo": agent_cfg.get("yolo"),
             }
             print(f"[DispatchConfig] Built from new schema for agent={agent}: {_dispatch_config}", file=sys.stderr)
         if body.runtime:

--- a/agents.json
+++ b/agents.json
@@ -257,9 +257,9 @@
       "path": "/opt/wee-qa",
       "description": "QA validation agent for Wee Orchestrator. You are a QA agent in a bad mood \u2014 scrutinize everything, trust nothing, and be brutal. Tear apart every change wee-dev submits. If it can break, assume it will. Reject anything that isn't airtight. CROSS-VENDOR REVIEW: You will always be dispatched with a different model vendor than the one that wrote the code \u2014 the author model and vendor will be stated in your prompt. Use your independent judgment and look for blind spots the author model's vendor commonly exhibits. Reviews changes via static analysis, API testing, and WebUI validation on the dev environment (192.168.1.100).",
       "primary_runtime": "codex",
-      "primary_model": "gpt-5.4-mini",
+      "primary_model": "gpt-5.4",
       "fallback_runtime": "copilot",
-      "fallback_model": "auto",
+      "fallback_model": "claude-sonnet-4.6",
       "max_concurrent": 1,
       "permissions": {
         "mode": "restricted",
@@ -286,7 +286,9 @@
             "*"
           ]
         }
-      }
+      },
+      "permission_mode": "elevated",
+      "yolo": true
     },
     {
       "name": "wee-doc",

--- a/tests/test_issue245_agent_permission_mode_propagation.py
+++ b/tests/test_issue245_agent_permission_mode_propagation.py
@@ -1,0 +1,153 @@
+"""Regression tests for Issue #245.
+
+Bug: When an agent in agents.json uses the new schema (primary_runtime/
+primary_model) and declares ``permission_mode: "elevated"`` and/or
+``yolo: true`` at the top level, those fields are silently dropped when
+the background task is dispatched.  The synthesized _dispatch_config in
+create_background_task() only copied runtime/model/fallback fields,
+causing perm_mode to fall through to "restricted".
+
+Symptom: wee-qa (declared elevated) ran codex in the default sandbox,
+which blocked SSH to the dev host.
+
+Fix: include permission_mode and yolo in the synthesized _dispatch_config
+when building it from the new schema.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
+os.environ["API_SHARED_KEY"] = "test_key_123"
+os.environ.setdefault("APP_ENV", "DEV")
+
+
+def _isolated_app():
+    import agent_manager as am
+
+    tmp = tempfile.mkdtemp()
+    app = am.create_api_app()
+    app.state.bg_task_mgr._path = os.path.join(tmp, "background-tasks.json")
+    app.state.bg_task_mgr._tasks_cache = None
+    return app, SimpleNamespace(
+        name=tmp,
+        cleanup=lambda: shutil.rmtree(tmp, ignore_errors=True),
+    )
+
+
+class TestNewSchemaPermissionPropagation(unittest.TestCase):
+    """Top-level permission_mode/yolo on a new-schema agent must propagate."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi.testclient import TestClient
+
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        cfg_path = os.path.join(cls.temp_dir.name, "agents.json")
+        with open(cfg_path, "w") as f:
+            json.dump(
+                {
+                    "agents": [
+                        {
+                            # Mirrors the real wee-qa entry: new schema +
+                            # top-level permission_mode/yolo (no
+                            # dispatch_config block).
+                            "name": "wee-qa",
+                            "description": "QA agent",
+                            "path": "/opt/wee-qa",
+                            "primary_runtime": "codex",
+                            "primary_model": "gpt-5.4",
+                            "fallback_runtime": "copilot",
+                            "fallback_model": "claude-sonnet-4.6",
+                            "permission_mode": "elevated",
+                            "yolo": True,
+                        },
+                        {
+                            # Agent that opts into sandboxed via top-level
+                            # permission_mode (no yolo).
+                            "name": "ro-agent",
+                            "description": "Read-only agent",
+                            "path": "/opt/plain",
+                            "primary_runtime": "copilot",
+                            "primary_model": "claude-haiku-4.5",
+                            "permission_mode": "sandboxed",
+                        },
+                        {
+                            # New-schema agent without any permission hints —
+                            # must default to restricted.
+                            "name": "default-agent",
+                            "description": "Default agent",
+                            "path": "/opt/default",
+                            "primary_runtime": "copilot",
+                            "primary_model": "claude-haiku-4.5",
+                        },
+                    ]
+                },
+                f,
+            )
+        os.environ["AGENT_CONFIG_FILE"] = cfg_path
+        cls.app, cls.bg_store_dir = _isolated_app()
+        cls.client = TestClient(cls.app, raise_server_exceptions=False)
+        cls.headers = {"Authorization": "Bearer shared_test_key_123"}
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.bg_store_dir.cleanup()
+        cls.temp_dir.cleanup()
+
+    def _post(self, payload):
+        resp = self.client.post(
+            "/api/v1/background-tasks", json=payload, headers=self.headers
+        )
+        self.assertIn(
+            resp.status_code,
+            (200, 201),
+            f"Unexpected status {resp.status_code}: {resp.text[:300]}",
+        )
+        return resp.json()
+
+    def test_top_level_yolo_true_promotes_to_elevated(self):
+        """yolo:true at top level on new-schema agent → elevated."""
+        data = self._post({"prompt": "test", "agent": "wee-qa"})
+        self.assertEqual(
+            data.get("permission_mode"),
+            "elevated",
+            "wee-qa declares yolo:true at top level — must yield elevated. "
+            "Got: %r (full response: %r)" % (data.get("permission_mode"), data),
+        )
+
+    def test_top_level_permission_mode_sandboxed_honored(self):
+        """permission_mode:sandboxed at top level on new-schema agent."""
+        data = self._post({"prompt": "test", "agent": "ro-agent"})
+        self.assertEqual(data.get("permission_mode"), "sandboxed")
+
+    def test_new_schema_without_perm_defaults_restricted(self):
+        """No perm hints on new-schema agent → restricted (unchanged)."""
+        data = self._post({"prompt": "test", "agent": "default-agent"})
+        self.assertEqual(data.get("permission_mode"), "restricted")
+
+    def test_body_yolo_false_overrides_agent_elevated(self):
+        """body.yolo=False must override agent-level yolo:true."""
+        data = self._post({"prompt": "test", "agent": "wee-qa", "yolo": False})
+        self.assertEqual(data.get("permission_mode"), "restricted")
+
+    def test_body_permission_mode_overrides_agent(self):
+        """body.permission_mode wins over agent-level permission_mode."""
+        data = self._post(
+            {
+                "prompt": "test",
+                "agent": "ro-agent",
+                "permission_mode": "elevated",
+            }
+        )
+        self.assertEqual(data.get("permission_mode"), "elevated")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #245

## Problem
Top-level `permission_mode: "elevated"` and `yolo: true` on new-schema agents were silently dropped before reaching codex. wee-qa thus ran in the default sandbox and SSH to the dev host was blocked.

## Root cause
1. `_load_agents_config` and `reload_agents_from_disk` did not copy `permission_mode` / `yolo` into the AGENTS dict.
2. The synthesized `_dispatch_config` in `create_background_task` only carried runtime/model/fallback fields.

## Fix
- Preserve `permission_mode` and `yolo` in both agent loaders.
- Include `permission_mode` and `yolo` when synthesizing `_dispatch_config` from the new schema.
- Add `--sandbox danger-full-access` to the codex background-task invocation (parity with synchronous `run_codex()`).
- Update dev `agents.json` wee-qa entry to mirror prod (elevated + correct primary/fallback models).

## Regression test (per AGENTS.md zero-tolerance policy)
`tests/test_issue245_agent_permission_mode_propagation.py` — 5 tests:
- top-level `yolo: true` → `elevated`
- top-level `permission_mode: sandboxed` honored
- new-schema agent without perm hints → `restricted`
- `body.yolo=False` overrides agent-level elevated
- `body.permission_mode` overrides agent-level

## End-to-end verification
```
$ curl ... -d '{"agent":"wee-qa","prompt":"ssh root@192.168.1.100 hostname"}'
{"task_id":"bg_c24685c1", "permission_mode":"elevated", ...}

# Task output:
Exit code: 0
cli-tools
SSH_OK
```

All 30 tests across #193 + #245 pass.