### PR TITLE
feat(#32): config schema validation for agents.json, telegram, and webex configs (v5)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -31,7 +31,7 @@ from session_manager_components import (
     StreamingManager,
 )
 
-# Dynamically determine the repo base directory (works regardless of where repo is cloned)  # noqa: E501
+# Repo base dir — resolved at runtime, works in any clone or Docker path
 SCRIPT_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 # ── Theme constants (F025) ──────────────────────────────────────────────
@@ -3286,40 +3286,42 @@ You can mention an agent in your prompt and it will auto-delegate:
             self._agents_json_mtime = config_path.stat().st_mtime
             with open(config_path, "r") as f:
                 config = json.load(f)
-                try:
-                    from pydantic import ValidationError as _ValidationError
-
-                    from config_schemas import validate_agents_config
-
-                    validate_agents_config(config)
-                except ImportError:
-                    pass
-                except _ValidationError as _schema_exc:
-                    logger.error(
-                        f"[config] agents.json schema validation failed: "
-                        f"{_schema_exc}. Refusing to load agents from invalid config."
-                    )
-                    return {}
-                agents = {}
-                for agent in config.get("agents", []):
-                    name = agent.get("name")
-                    if not name:
-                        logger.warning("[Warning] Agent entry missing 'name' field")
-                        continue
-                    agents[name] = {
-                        "path": agent.get("path", ""),
-                        "description": agent.get("description", ""),
-                        "max_concurrent": agent.get("max_concurrent", 1),
-                        "runtime": agent.get("runtime", "copilot"),
-                        "model": agent.get("model", ""),
-                    }
-                return agents
         except json.JSONDecodeError as e:
-            logger.error(f"[Error] Failed to parse agents config: {e}")
+            logger.error("[Error] Failed to parse agents config: %s", e)
             return {}
         except Exception as e:
-            logger.error(f"[Error] Failed to load agents config: {e}")
+            logger.error("[Error] Failed to load agents config: %s", e)
             return {}
+
+        try:
+            from pydantic import ValidationError as _ValidationError
+
+            from config_schemas import validate_agents_config
+
+            validate_agents_config(config)
+        except ImportError:
+            pass
+        except _ValidationError as _schema_exc:
+            logger.critical(
+                "[config] agents.json schema validation failed: %s",
+                _schema_exc,
+            )
+            raise
+
+        agents = {}
+        for agent in config.get("agents", []):
+            name = agent.get("name")
+            if not name:
+                logger.warning("[Warning] Agent entry missing 'name' field")
+                continue
+            agents[name] = {
+                "path": agent.get("path", ""),
+                "description": agent.get("description", ""),
+                "max_concurrent": agent.get("max_concurrent", 1),
+                "runtime": agent.get("runtime", "copilot"),
+                "model": agent.get("model", ""),
+            }
+        return agents
 
     def reload_agents_from_disk(self) -> tuple:
         """Hot-reload agents.json with validation and safe fallback.

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -3286,6 +3286,15 @@ You can mention an agent in your prompt and it will auto-delegate:
             self._agents_json_mtime = config_path.stat().st_mtime
             with open(config_path, "r") as f:
                 config = json.load(f)
+                try:
+                    from config_schemas import validate_agents_config
+                    validate_agents_config(config)
+                except ImportError:
+                    pass
+                except Exception as _schema_exc:
+                    logger.warning(
+                        f"[config] agents.json schema warning: {_schema_exc}"
+                    )
                 agents = {}
                 for agent in config.get("agents", []):
                     name = agent.get("name")

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -3292,9 +3292,11 @@ You can mention an agent in your prompt and it will auto-delegate:
                 except ImportError:
                     pass
                 except Exception as _schema_exc:
-                    logger.warning(
-                        f"[config] agents.json schema warning: {_schema_exc}"
+                    logger.error(
+                        f"[config] agents.json schema validation failed: "
+                        f"{_schema_exc}. Refusing to load agents from invalid config."
                     )
+                    return {}
                 agents = {}
                 for agent in config.get("agents", []):
                     name = agent.get("name")

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -3288,11 +3288,12 @@ You can mention an agent in your prompt and it will auto-delegate:
                 config = json.load(f)
                 try:
                     from config_schemas import validate_agents_config
+                    from pydantic import ValidationError as _ValidationError
 
                     validate_agents_config(config)
                 except ImportError:
                     pass
-                except Exception as _schema_exc:
+                except _ValidationError as _schema_exc:
                     logger.error(
                         f"[config] agents.json schema validation failed: "
                         f"{_schema_exc}. Refusing to load agents from invalid config."

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -3287,8 +3287,9 @@ You can mention an agent in your prompt and it will auto-delegate:
             with open(config_path, "r") as f:
                 config = json.load(f)
                 try:
-                    from config_schemas import validate_agents_config
                     from pydantic import ValidationError as _ValidationError
+
+                    from config_schemas import validate_agents_config
 
                     validate_agents_config(config)
                 except ImportError:

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -3288,6 +3288,7 @@ You can mention an agent in your prompt and it will auto-delegate:
                 config = json.load(f)
                 try:
                     from config_schemas import validate_agents_config
+
                     validate_agents_config(config)
                 except ImportError:
                     pass

--- a/base_connector.py
+++ b/base_connector.py
@@ -39,7 +39,16 @@ class BaseConfig:
         if self.config_file.exists():
             try:
                 with open(self.config_file, "r") as f:
-                    return json.load(f)
+                    data = json.load(f)
+                try:
+                    from config_schemas import CONNECTOR_VALIDATORS
+
+                    validator = CONNECTOR_VALIDATORS.get(self.config_file.name)
+                    if validator:
+                        validator(data)
+                except ImportError:
+                    pass
+                return data
             except Exception as e:
                 print(f"Error loading config: {e}", file=sys.stderr)
                 return self._default_config()

--- a/base_connector.py
+++ b/base_connector.py
@@ -51,7 +51,8 @@ class BaseConfig:
                     validator(data)
             except ImportError:
                 pass
-            # ValidationError from validator() is not swallowed — it propagates to caller
+            # ValidationError from validator() is not swallowed —
+            # it propagates to caller
             return data
         return self._default_config()
 

--- a/base_connector.py
+++ b/base_connector.py
@@ -40,18 +40,19 @@ class BaseConfig:
             try:
                 with open(self.config_file, "r") as f:
                     data = json.load(f)
-                try:
-                    from config_schemas import CONNECTOR_VALIDATORS
-
-                    validator = CONNECTOR_VALIDATORS.get(self.config_file.name)
-                    if validator:
-                        validator(data)
-                except ImportError:
-                    pass
-                return data
             except Exception as e:
                 print(f"Error loading config: {e}", file=sys.stderr)
                 return self._default_config()
+            try:
+                from config_schemas import CONNECTOR_VALIDATORS
+
+                validator = CONNECTOR_VALIDATORS.get(self.config_file.name)
+                if validator:
+                    validator(data)
+            except ImportError:
+                pass
+            # ValidationError from validator() is not swallowed — it propagates to caller
+            return data
         return self._default_config()
 
     def _default_config(self) -> Dict:

--- a/base_connector.py
+++ b/base_connector.py
@@ -48,7 +48,8 @@ class BaseConfig:
 
                 validator = CONNECTOR_VALIDATORS.get(self.config_file.name)
                 if validator:
-                    validator(data)
+                    validated = validator(data)
+                    data = validated.model_dump()
             except ImportError:
                 pass
             # ValidationError from validator() is not swallowed —

--- a/config_schemas.py
+++ b/config_schemas.py
@@ -1,0 +1,298 @@
+"""
+Pydantic schemas for Wee Orchestrator configuration files.
+
+Validates agents.json, telegram_config.json, and webex_config.json.
+Unknown keys generate warnings; missing required fields raise ValidationError.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+def _warn_unknown_keys(values: Any, known: set, context: str) -> None:
+    """Emit a UserWarning for each key in *values* that is not in *known*."""
+    if not isinstance(values, dict):
+        return
+    for key in values:
+        if key not in known:
+            warnings.warn(
+                f"[config_schemas] {context}: unknown key '{key}' — "
+                "possible typo, value will be ignored",
+                UserWarning,
+                stacklevel=5,
+            )
+
+
+# ---------------------------------------------------------------------------
+# agents.json schemas
+# ---------------------------------------------------------------------------
+
+_BOT_CONFIG_KNOWN = {"token_secret", "allowed_users"}
+
+
+class BotConfig(BaseModel):
+    """Per-channel bot configuration inside an agent entry."""
+
+    model_config = ConfigDict(extra="allow")
+
+    token_secret: Optional[str] = None
+    allowed_users: Optional[List[str]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_unknown(cls, values: Any) -> Any:
+        _warn_unknown_keys(values, _BOT_CONFIG_KNOWN, "agents[].bots.<channel>")
+        return values
+
+
+_AGENT_BOTS_CONFIG_KNOWN = {"telegram", "webex"}
+
+
+class AgentBotsConfig(BaseModel):
+    """Optional 'bots' block for an agent."""
+
+    model_config = ConfigDict(extra="allow")
+
+    telegram: Optional[BotConfig] = None
+    webex: Optional[BotConfig] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_unknown(cls, values: Any) -> Any:
+        _warn_unknown_keys(values, _AGENT_BOTS_CONFIG_KNOWN, "agents[].bots")
+        return values
+
+
+_DISPATCH_KNOWN = {
+    "runtime",
+    "model",
+    "vendor",
+    "permission_mode",
+    "yolo",
+    "timeout",
+    "fallback_runtime",
+    "fallback_model",
+}
+
+
+class AgentDispatchConfig(BaseModel):
+    """Optional 'dispatch_config' specifying how to launch an agent."""
+
+    model_config = ConfigDict(extra="allow")
+
+    runtime: Optional[str] = None
+    model: Optional[str] = None
+    vendor: Optional[str] = None
+    permission_mode: Optional[str] = None
+    yolo: Optional[bool] = None
+    timeout: Optional[int] = None
+    fallback_runtime: Optional[str] = None
+    fallback_model: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_unknown(cls, values: Any) -> Any:
+        _warn_unknown_keys(values, _DISPATCH_KNOWN, "dispatch_config")
+        return values
+
+
+_AGENT_KNOWN = {
+    "name",
+    "description",
+    "path",
+    "bots",
+    "dispatch_config",
+    "max_concurrent",
+    "runtime",
+    "model",
+}
+
+
+class AgentEntry(BaseModel):
+    """A single entry in the 'agents' list of agents.json."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    description: Optional[str] = ""
+    path: Optional[str] = ""
+    bots: Optional[AgentBotsConfig] = None
+    dispatch_config: Optional[AgentDispatchConfig] = None
+    max_concurrent: Optional[int] = 1
+    runtime: Optional[str] = "copilot"
+    model: Optional[str] = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_unknown(cls, values: Any) -> Any:
+        name = values.get("name", "?") if isinstance(values, dict) else "?"
+        _warn_unknown_keys(values, _AGENT_KNOWN, f"agents['{name}']")
+        return values
+
+
+_AGENTS_CONFIG_KNOWN = {"agents"}
+
+
+class AgentsConfig(BaseModel):
+    """Top-level structure of agents.json."""
+
+    model_config = ConfigDict(extra="allow")
+
+    agents: List[AgentEntry]
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_unknown(cls, values: Any) -> Any:
+        _warn_unknown_keys(values, _AGENTS_CONFIG_KNOWN, "agents.json")
+        return values
+
+
+# ---------------------------------------------------------------------------
+# telegram_config.json schema
+# ---------------------------------------------------------------------------
+
+_TELEGRAM_KNOWN = {
+    "token",
+    "allowed_users",
+    "user_pairings",
+    "enable_auto_pair",
+    "default_agent",
+    "default_model",
+    "pinned_users",
+    "yolo_allowed_users",
+    "user_rate_limit_max_requests",
+    "user_rate_limit_window_seconds",
+}
+
+
+class TelegramConfigSchema(BaseModel):
+    """Schema for telegram_config.json."""
+
+    model_config = ConfigDict(extra="allow")
+
+    token: str = ""
+    allowed_users: List[Union[int, str]] = Field(default_factory=list)
+    user_pairings: Dict[str, Any] = Field(default_factory=dict)
+    enable_auto_pair: bool = False
+    default_agent: str = "orchestrator"
+    default_model: str = "gpt-5-mini"
+    pinned_users: Dict[str, Any] = Field(default_factory=dict)
+    yolo_allowed_users: List[Union[int, str]] = Field(default_factory=list)
+    user_rate_limit_max_requests: Optional[int] = None
+    user_rate_limit_window_seconds: Optional[int] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_unknown(cls, values: Any) -> Any:
+        _warn_unknown_keys(values, _TELEGRAM_KNOWN, "telegram_config.json")
+        return values
+
+
+# ---------------------------------------------------------------------------
+# webex_config.json schema
+# ---------------------------------------------------------------------------
+
+_WEBEX_KNOWN = {
+    "token",
+    "rabbitmq_host",
+    "rabbitmq_port",
+    "rabbitmq_user",
+    "rabbitmq_password",
+    "rabbitmq_queue",
+    "rabbitmq_vhost",
+    "rabbitmq_ssl",
+    "rabbitmq_ssl_verify",
+    "rabbitmq_host_ip",
+    "rabbitmq_payload_key",
+    "allowed_users",
+    "user_pairings",
+    "enable_auto_pair",
+    "default_agent",
+    "default_model",
+    "pinned_users",
+    "yolo_allowed_users",
+    "user_rate_limit_max_requests",
+    "user_rate_limit_window_seconds",
+    "bot_token",
+}
+
+
+class WebEXConfigSchema(BaseModel):
+    """Schema for webex_config.json."""
+
+    model_config = ConfigDict(extra="allow")
+
+    token: str = ""
+    rabbitmq_host: str = "192.168.0.85"
+    rabbitmq_port: int = 5672
+    rabbitmq_user: str = "admin"
+    rabbitmq_password: str = ""
+    rabbitmq_queue: str = "webex"
+    rabbitmq_vhost: str = "/"
+    rabbitmq_ssl: Optional[bool] = None
+    rabbitmq_ssl_verify: Optional[bool] = True
+    rabbitmq_host_ip: Optional[str] = None
+    rabbitmq_payload_key: Optional[str] = None
+    allowed_users: List[str] = Field(default_factory=list)
+    user_pairings: Dict[str, Any] = Field(default_factory=dict)
+    enable_auto_pair: bool = False
+    default_agent: str = "orchestrator"
+    default_model: str = "gpt-5-mini"
+    pinned_users: Dict[str, Any] = Field(default_factory=dict)
+    yolo_allowed_users: List[str] = Field(default_factory=list)
+    user_rate_limit_max_requests: Optional[int] = None
+    user_rate_limit_window_seconds: Optional[int] = None
+    bot_token: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_unknown(cls, values: Any) -> Any:
+        _warn_unknown_keys(values, _WEBEX_KNOWN, "webex_config.json")
+        return values
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_agents_config(data: dict) -> AgentsConfig:
+    """Validate agents.json data, warning on unknown keys.
+
+    Raises pydantic.ValidationError on structural failures (e.g. missing
+    required fields, wrong types). Unknown keys produce UserWarnings.
+    """
+    return AgentsConfig.model_validate(data)
+
+
+def validate_telegram_config(data: dict) -> TelegramConfigSchema:
+    """Validate telegram_config.json data.
+
+    Raises pydantic.ValidationError on structural failures. Unknown keys
+    produce UserWarnings so typos are immediately visible.
+    """
+    return TelegramConfigSchema.model_validate(data)
+
+
+def validate_webex_config(data: dict) -> WebEXConfigSchema:
+    """Validate webex_config.json data.
+
+    Raises pydantic.ValidationError on structural failures. Unknown keys
+    produce UserWarnings so typos are immediately visible.
+    """
+    return WebEXConfigSchema.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Registry: maps config file basename -> validator function
+# Used by base_connector.BaseConfig._load_config to auto-validate on load.
+# ---------------------------------------------------------------------------
+
+CONNECTOR_VALIDATORS = {
+    "telegram_config.json": validate_telegram_config,
+    "webex_config.json": validate_webex_config,
+}

--- a/tests/test_issue32_config_schema_validation.py
+++ b/tests/test_issue32_config_schema_validation.py
@@ -528,7 +528,8 @@ class TestAgentManagerIntegration:
 
 
 class TestAgentManagerInvalidSchemaRejected:
-    """Regression: _load_agents_config must not load agents when schema validation fails.
+    """Regression: _load_agents_config must not load agents when schema
+    validation fails.
 
     Issue #32 Round 5 — max_concurrent="oops" was previously loaded silently.
     """
@@ -613,7 +614,9 @@ class TestAgentManagerInvalidSchemaRejected:
 
         result = mgr._load_agents_config(str(config_file))
 
-        assert "good-agent" in result, f"Valid config should load cleanly, got: {result!r}"
+        assert (
+            "good-agent" in result
+        ), f"Valid config should load cleanly, got: {result!r}"
         assert result["good-agent"]["max_concurrent"] == 2
 
 
@@ -645,7 +648,8 @@ class TestBaseConfigSchemaValidationSurfaced:
             FakeTelegramConfig(str(cfg_file))
 
     def test_webex_invalid_allowed_users_raises(self, tmp_path):
-        """_load_config raises ValidationError when webex allowed_users is not a list."""
+        """_load_config raises ValidationError when webex allowed_users is not
+        a list."""
         cfg_data = {"token": "webex-token", "allowed_users": "not-a-list"}
         cfg_file = tmp_path / "webex_config.json"
         cfg_file.write_text(json.dumps(cfg_data))
@@ -683,9 +687,9 @@ class TestBaseConfigSchemaValidationSurfaced:
             f"Expected an exception to propagate, but got config: {result!r}. "
             "Schema validation failure must not be silently swallowed."
         )
-        assert isinstance(caught_exc, ValidationError), (
-            f"Expected ValidationError, got {type(caught_exc).__name__}: {caught_exc}"
-        )
+        assert isinstance(
+            caught_exc, ValidationError
+        ), f"Expected ValidationError, got {type(caught_exc).__name__}: {caught_exc}"
 
     def test_json_parse_error_still_returns_defaults(self, tmp_path):
         """I/O errors and JSON parse errors still fall back to defaults (unchanged)."""
@@ -699,6 +703,6 @@ class TestBaseConfigSchemaValidationSurfaced:
                 return {"defaulted": True}
 
         instance = FakeTelegramConfig(str(cfg_file))
-        assert instance.config == {"defaulted": True}, (
-            "JSON parse errors should still fall back to _default_config()"
-        )
+        assert instance.config == {
+            "defaulted": True
+        }, "JSON parse errors should still fall back to _default_config()"

--- a/tests/test_issue32_config_schema_validation.py
+++ b/tests/test_issue32_config_schema_validation.py
@@ -706,3 +706,102 @@ class TestBaseConfigSchemaValidationSurfaced:
         assert instance.config == {
             "defaulted": True
         }, "JSON parse errors should still fall back to _default_config()"
+
+
+# ===========================================================================
+# Regression: _load_config uses model_dump() so schema defaults are applied
+# ===========================================================================
+
+
+class TestBaseConfigConnectorDefaults:
+    """Regression: BaseConfig._load_config must use model_dump() so Pydantic
+    schema defaults (e.g. allowed_users=[]) are present in the loaded config.
+
+    Without model_dump(), a minimal config like {"token":"abc"} is returned
+    as-is; BaseConfig.allow_user() (and any other method that expects the full
+    schema) then raises KeyError on missing keys.
+    """
+
+    def test_minimal_telegram_config_gets_defaults(self, tmp_path):
+        """A telegram_config.json with only 'token' gets all schema defaults."""
+        cfg_file = tmp_path / "telegram_config.json"
+        cfg_file.write_text(json.dumps({"token": "bot123:FAKE"}))
+
+        import base_connector as bc
+
+        class FakeTelegramConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {}
+
+        instance = FakeTelegramConfig(str(cfg_file))
+
+        # Pydantic schema default for allowed_users is []
+        assert "allowed_users" in instance.config, (
+            "allowed_users must be present after loading a minimal config — "
+            "model_dump() must be called to apply Pydantic defaults"
+        )
+        assert instance.config["allowed_users"] == [], (
+        )
+
+    def test_minimal_telegram_config_allow_user_no_keyerror(self, tmp_path):
+        """allow_user() must not raise KeyError when config was loaded from a
+        minimal file (only 'token' present — all other keys come from schema
+        defaults via model_dump()).
+        """
+        cfg_file = tmp_path / "telegram_config.json"
+        cfg_file.write_text(json.dumps({"token": "bot123:FAKE"}))
+
+        import base_connector as bc
+
+        class FakeTelegramConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {}
+
+        instance = FakeTelegramConfig(str(cfg_file))
+        # Should not raise KeyError — allowed_users default [] must be present
+        try:
+            instance.allow_user(12345)
+        except KeyError as exc:
+            pytest.fail(
+                f"allow_user() raised KeyError({exc}) — model_dump() was not called "
+                "so the Pydantic default for allowed_users was not applied"
+            )
+
+    def test_minimal_webex_config_gets_defaults(self, tmp_path):
+        """A webex_config.json with only 'token' gets all schema defaults."""
+        cfg_file = tmp_path / "webex_config.json"
+        cfg_file.write_text(json.dumps({"token": "webex-token"}))
+
+        import base_connector as bc
+
+        class FakeWebEXConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {}
+
+        instance = FakeWebEXConfig(str(cfg_file))
+
+        assert "allowed_users" in instance.config, (
+            "allowed_users must be present after loading a minimal webex config"
+        )
+        assert instance.config["allowed_users"] == [], (
+        )
+        # Schema defaults for rabbitmq_host etc. must also be present
+        assert instance.config.get("rabbitmq_host") == "192.168.0.85", (
+        )
+
+    def test_is_user_allowed_works_on_minimal_config(self, tmp_path):
+        """is_user_allowed() must work on a config loaded from a minimal file."""
+        cfg_file = tmp_path / "telegram_config.json"
+        cfg_file.write_text(json.dumps({"token": "bot123:FAKE"}))
+
+        import base_connector as bc
+
+        class FakeTelegramConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {}
+
+        instance = FakeTelegramConfig(str(cfg_file))
+        # Empty allowed_users means everyone is allowed
+        assert instance.is_user_allowed(999) is True, (
+            "is_user_allowed() must return True when allowed_users is empty (default)"
+        )

--- a/tests/test_issue32_config_schema_validation.py
+++ b/tests/test_issue32_config_schema_validation.py
@@ -528,14 +528,13 @@ class TestAgentManagerIntegration:
 
 
 class TestAgentManagerInvalidSchemaRejected:
-    """Regression: _load_agents_config must not load agents when schema
-    validation fails.
+    """Regression: _load_agents_config must raise on schema validation failure.
 
-    Issue #32 Round 5 — max_concurrent="oops" was previously loaded silently.
+    Issue #32 — invalid agents.json must halt startup, not silently return {}.
     """
 
-    def test_invalid_max_concurrent_returns_empty_agents(self, tmp_path):
-        """_load_agents_config returns {} when max_concurrent has wrong type."""
+    def test_invalid_max_concurrent_raises(self, tmp_path):
+        """_load_agents_config raises ValidationError when max_concurrent has wrong type."""
         config = {
             "agents": [
                 {
@@ -554,15 +553,11 @@ class TestAgentManagerInvalidSchemaRejected:
         mgr._agents_config_path = config_file
         mgr._agents_json_mtime = 0.0
 
-        result = mgr._load_agents_config(str(config_file))
+        with pytest.raises(ValidationError):
+            mgr._load_agents_config(str(config_file))
 
-        assert result == {}, (
-            f"Expected empty dict when schema validation fails, got: {result!r}. "
-            "Invalid agents.json must not be loaded into the live agent roster."
-        )
-
-    def test_invalid_schema_does_not_load_any_agents(self, tmp_path):
-        """_load_agents_config rejects the entire config, not just the bad entry."""
+    def test_invalid_schema_raises_not_partial_load(self, tmp_path):
+        """_load_agents_config raises on any schema failure — no partial loading."""
         config = {
             "agents": [
                 {
@@ -585,12 +580,8 @@ class TestAgentManagerInvalidSchemaRejected:
         mgr._agents_config_path = config_file
         mgr._agents_json_mtime = 0.0
 
-        result = mgr._load_agents_config(str(config_file))
-
-        assert result == {}, (
-            f"Expected empty dict for any schema failure, got: {result!r}. "
-            "A single invalid entry must prevent loading the entire file."
-        )
+        with pytest.raises(ValidationError):
+            mgr._load_agents_config(str(config_file))
 
     def test_valid_config_still_loads_normally(self, tmp_path):
         """_load_agents_config loads valid config without regression."""
@@ -618,6 +609,20 @@ class TestAgentManagerInvalidSchemaRejected:
             "good-agent" in result
         ), f"Valid config should load cleanly, got: {result!r}"
         assert result["good-agent"]["max_concurrent"] == 2
+
+    def test_missing_agents_key_raises_on_load(self, tmp_path):
+        """agents.json = {} (missing 'agents') must fail loudly, not return {}."""
+        config_file = tmp_path / "agents.json"
+        config_file.write_text("{}")
+
+        import agent_manager as am
+
+        mgr = am.SessionManager.__new__(am.SessionManager)
+        mgr._agents_config_path = config_file
+        mgr._agents_json_mtime = 0.0
+
+        with pytest.raises(ValidationError):
+            mgr._load_agents_config(str(config_file))
 
 
 # ===========================================================================

--- a/tests/test_issue32_config_schema_validation.py
+++ b/tests/test_issue32_config_schema_validation.py
@@ -740,8 +740,7 @@ class TestBaseConfigConnectorDefaults:
             "allowed_users must be present after loading a minimal config — "
             "model_dump() must be called to apply Pydantic defaults"
         )
-        assert instance.config["allowed_users"] == [], (
-        )
+        assert instance.config["allowed_users"] == [], ()
 
     def test_minimal_telegram_config_allow_user_no_keyerror(self, tmp_path):
         """allow_user() must not raise KeyError when config was loaded from a
@@ -780,14 +779,12 @@ class TestBaseConfigConnectorDefaults:
 
         instance = FakeWebEXConfig(str(cfg_file))
 
-        assert "allowed_users" in instance.config, (
-            "allowed_users must be present after loading a minimal webex config"
-        )
-        assert instance.config["allowed_users"] == [], (
-        )
+        assert (
+            "allowed_users" in instance.config
+        ), "allowed_users must be present after loading a minimal webex config"
+        assert instance.config["allowed_users"] == [], ()
         # Schema defaults for rabbitmq_host etc. must also be present
-        assert instance.config.get("rabbitmq_host") == "192.168.0.85", (
-        )
+        assert instance.config.get("rabbitmq_host") == "192.168.0.85", ()
 
     def test_is_user_allowed_works_on_minimal_config(self, tmp_path):
         """is_user_allowed() must work on a config loaded from a minimal file."""
@@ -802,6 +799,6 @@ class TestBaseConfigConnectorDefaults:
 
         instance = FakeTelegramConfig(str(cfg_file))
         # Empty allowed_users means everyone is allowed
-        assert instance.is_user_allowed(999) is True, (
-            "is_user_allowed() must return True when allowed_users is empty (default)"
-        )
+        assert (
+            instance.is_user_allowed(999) is True
+        ), "is_user_allowed() must return True when allowed_users is empty (default)"

--- a/tests/test_issue32_config_schema_validation.py
+++ b/tests/test_issue32_config_schema_validation.py
@@ -1,0 +1,522 @@
+"""
+Regression tests for Issue #32 — Config schema validation.
+
+Verifies that agents.json, telegram_config.json, and webex_config.json are
+validated via Pydantic on load, unknown keys produce warnings, and required
+field violations raise ValidationError.
+"""
+
+import json
+import os
+import sys
+import warnings
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pydantic import ValidationError  # noqa: E402
+
+from config_schemas import (  # noqa: E402
+    CONNECTOR_VALIDATORS,
+    AgentsConfig,
+    TelegramConfigSchema,
+    WebEXConfigSchema,
+    validate_agents_config,
+    validate_telegram_config,
+    validate_webex_config,
+)
+
+# ===========================================================================
+# validate_agents_config
+# ===========================================================================
+
+
+class TestAgentsConfigSchema:
+    """Tests for agents.json schema validation."""
+
+    def _valid_config(self) -> dict:
+        return {
+            "agents": [
+                {
+                    "name": "orchestrator",
+                    "description": "Main agent",
+                    "path": "/opt/",
+                }
+            ]
+        }
+
+    def test_valid_config_passes(self):
+        cfg = validate_agents_config(self._valid_config())
+        assert isinstance(cfg, AgentsConfig)
+        assert len(cfg.agents) == 1
+        assert cfg.agents[0].name == "orchestrator"
+
+    def test_missing_agents_key_raises(self):
+        with pytest.raises(ValidationError):
+            validate_agents_config({})
+
+    def test_agents_must_be_list(self):
+        with pytest.raises(ValidationError):
+            validate_agents_config({"agents": "bad"})
+
+    def test_missing_agent_name_raises(self):
+        with pytest.raises(ValidationError):
+            validate_agents_config({"agents": [{"path": "/opt/"}]})
+
+    def test_unknown_top_level_key_warns(self):
+        data = self._valid_config()
+        data["typo_field"] = "oops"
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_agents_config(data)
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "typo_field" in m for m in messages
+        ), f"Expected warning about 'typo_field', got: {messages}"
+
+    def test_unknown_agent_key_warns(self):
+        data = self._valid_config()
+        data["agents"][0]["typo_key"] = "value"
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_agents_config(data)
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "typo_key" in m for m in messages
+        ), f"Expected warning about 'typo_key', got: {messages}"
+
+    def test_dispatch_config_unknown_key_warns(self):
+        data = self._valid_config()
+        data["agents"][0]["dispatch_config"] = {
+            "runtime": "copilot",
+            "typo_dispatch_key": "val",
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_agents_config(data)
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "typo_dispatch_key" in m for m in messages
+        ), f"Expected warning about 'typo_dispatch_key', got: {messages}"
+
+    def test_known_fields_no_spurious_warnings(self):
+        data = {
+            "agents": [
+                {
+                    "name": "wee-dev",
+                    "description": "Dev agent",
+                    "path": "/opt/wee-dev/",
+                    "dispatch_config": {
+                        "runtime": "copilot",
+                        "model": "claude-sonnet-4.6",
+                        "permission_mode": "elevated",
+                        "yolo": True,
+                        "timeout": 3600,
+                    },
+                }
+            ]
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_agents_config(data)
+        unknown_warnings = [
+            w for w in caught if "unknown key" in str(w.message).lower()
+        ]
+        assert (
+            not unknown_warnings
+        ), f"Unexpected unknown-key warnings: {unknown_warnings}"
+
+    def test_unknown_bots_channel_warns(self):
+        """Typo in channel name under agents[].bots should produce a warning."""
+        data = {
+            "agents": [
+                {
+                    "name": "a",
+                    "path": "/tmp",
+                    "bots": {"telegrm": {"token_secret": "X"}},
+                }
+            ]
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_agents_config(data)
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "telegrm" in m for m in messages
+        ), f"Expected warning about 'telegrm', got: {messages}"
+
+    def test_unknown_telegram_bot_config_key_warns(self):
+        """Typo in key inside bots.telegram should produce a warning."""
+        data = {
+            "agents": [
+                {
+                    "name": "a",
+                    "path": "/tmp",
+                    "bots": {"telegram": {"tokn_secret": "X"}},
+                }
+            ]
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_agents_config(data)
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "tokn_secret" in m for m in messages
+        ), f"Expected warning about 'tokn_secret', got: {messages}"
+
+    def test_unknown_webex_bot_config_key_warns(self):
+        """Typo in key inside bots.webex should produce a warning."""
+        data = {
+            "agents": [
+                {
+                    "name": "a",
+                    "path": "/tmp",
+                    "bots": {"webex": {"allowd_users": ["foster"]}},
+                }
+            ]
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_agents_config(data)
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "allowd_users" in m for m in messages
+        ), f"Expected warning about 'allowd_users', got: {messages}"
+
+    def test_dispatch_config_fallback_fields_no_warnings(self):
+        """fallback_runtime and fallback_model are known fields."""
+        data = {
+            "agents": [
+                {
+                    "name": "wee-dev",
+                    "path": "/opt/wee-dev/",
+                    "dispatch_config": {
+                        "runtime": "copilot",
+                        "fallback_runtime": "claude-sdk",
+                        "fallback_model": "claude-haiku-4.5",
+                    },
+                }
+            ]
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_agents_config(data)
+        unknown_warnings = [
+            w for w in caught if "unknown key" in str(w.message).lower()
+        ]
+        assert (
+            not unknown_warnings
+        ), f"Unexpected unknown-key warnings: {unknown_warnings}"
+
+
+# ===========================================================================
+# validate_telegram_config
+# ===========================================================================
+
+
+class TestTelegramConfigSchema:
+    """Tests for telegram_config.json schema validation."""
+
+    def _valid_config(self) -> dict:
+        return {
+            "token": "bot123:FAKE",
+            "allowed_users": [8193231291],
+            "user_pairings": {},
+            "enable_auto_pair": False,
+            "default_agent": "orchestrator",
+            "default_model": "gpt-5-mini",
+        }
+
+    def test_valid_config_passes(self):
+        cfg = validate_telegram_config(self._valid_config())
+        assert isinstance(cfg, TelegramConfigSchema)
+        assert cfg.token == "bot123:FAKE"
+        assert cfg.default_agent == "orchestrator"
+
+    def test_empty_config_uses_defaults(self):
+        cfg = validate_telegram_config({})
+        assert cfg.token == ""
+        assert cfg.allowed_users == []
+        assert cfg.enable_auto_pair is False
+
+    def test_unknown_key_warns(self):
+        data = self._valid_config()
+        data["tok3n"] = "typo"
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_telegram_config(data)
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "tok3n" in m for m in messages
+        ), f"Expected warning about 'tok3n', got: {messages}"
+
+    def test_no_spurious_warnings_for_valid_config(self):
+        data = self._valid_config()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_telegram_config(data)
+        unknown_warnings = [
+            w for w in caught if "unknown key" in str(w.message).lower()
+        ]
+        assert (
+            not unknown_warnings
+        ), f"Unexpected unknown-key warnings: {unknown_warnings}"
+
+    def test_returns_as_dict_via_model_dump(self):
+        cfg = validate_telegram_config(self._valid_config())
+        d = cfg.model_dump()
+        assert isinstance(d, dict)
+        assert "token" in d
+
+
+# ===========================================================================
+# validate_webex_config
+# ===========================================================================
+
+
+class TestWebEXConfigSchema:
+    """Tests for webex_config.json schema validation."""
+
+    def _valid_config(self) -> dict:
+        return {
+            "token": "bot_abc",
+            "rabbitmq_host": "192.168.0.85",
+            "rabbitmq_port": 5672,
+            "rabbitmq_user": "admin",
+            "rabbitmq_password": "secret",
+            "rabbitmq_queue": "webex",
+            "rabbitmq_vhost": "/",
+            "allowed_users": [],
+            "user_pairings": {},
+            "enable_auto_pair": False,
+            "default_agent": "orchestrator",
+            "default_model": "gpt-5-mini",
+        }
+
+    def test_valid_config_passes(self):
+        cfg = validate_webex_config(self._valid_config())
+        assert isinstance(cfg, WebEXConfigSchema)
+        assert cfg.rabbitmq_host == "192.168.0.85"
+        assert cfg.rabbitmq_port == 5672
+
+    def test_empty_config_uses_defaults(self):
+        cfg = validate_webex_config({})
+        assert cfg.rabbitmq_host == "192.168.0.85"
+        assert cfg.rabbitmq_port == 5672
+
+    def test_unknown_key_warns(self):
+        data = self._valid_config()
+        data["rabbitmq_h0st"] = "typo"
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_webex_config(data)
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "rabbitmq_h0st" in m for m in messages
+        ), f"Expected warning about 'rabbitmq_h0st', got: {messages}"
+
+    def test_no_spurious_warnings_for_valid_config(self):
+        data = self._valid_config()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_webex_config(data)
+        unknown_warnings = [
+            w for w in caught if "unknown key" in str(w.message).lower()
+        ]
+        assert (
+            not unknown_warnings
+        ), f"Unexpected unknown-key warnings: {unknown_warnings}"
+
+    def test_returns_as_dict_via_model_dump(self):
+        cfg = validate_webex_config(self._valid_config())
+        d = cfg.model_dump()
+        assert isinstance(d, dict)
+        assert "token" in d
+        assert "rabbitmq_host" in d
+
+
+# ===========================================================================
+# CONNECTOR_VALIDATORS registry
+# ===========================================================================
+
+
+class TestConnectorValidatorsRegistry:
+    """Verify CONNECTOR_VALIDATORS maps the right keys to the right validators."""
+
+    def test_telegram_validator_registered(self):
+        assert "telegram_config.json" in CONNECTOR_VALIDATORS
+        assert CONNECTOR_VALIDATORS["telegram_config.json"] is validate_telegram_config
+
+    def test_webex_validator_registered(self):
+        assert "webex_config.json" in CONNECTOR_VALIDATORS
+        assert CONNECTOR_VALIDATORS["webex_config.json"] is validate_webex_config
+
+    def test_telegram_validator_warns_on_unknown_key(self):
+        data = {"token": "x", "unknwon_key": "oops"}
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            CONNECTOR_VALIDATORS["telegram_config.json"](data)
+        messages = [str(w.message) for w in caught]
+        assert any("unknwon_key" in m for m in messages)
+
+    def test_webex_validator_warns_on_unknown_key(self):
+        data = {"token": "x", "rabbitmq_h0st": "oops"}
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            CONNECTOR_VALIDATORS["webex_config.json"](data)
+        messages = [str(w.message) for w in caught]
+        assert any("rabbitmq_h0st" in m for m in messages)
+
+
+# ===========================================================================
+# Integration: BaseConfig._load_config invokes the registry validator
+# ===========================================================================
+
+
+class TestBaseConfigIntegration:
+    """Verify BaseConfig._load_config calls schema validation via registry."""
+
+    def test_telegram_config_load_warns_on_unknown_key(self, tmp_path):
+        """BaseConfig._load_config should warn for unknown telegram_config.json keys."""
+        cfg_data = {"token": "bot123:FAKE", "tok3n": "typo"}
+        cfg_file = tmp_path / "telegram_config.json"
+        cfg_file.write_text(json.dumps(cfg_data))
+
+        import base_connector as bc
+
+        class FakeTelegramConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            FakeTelegramConfig(str(cfg_file))
+
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "tok3n" in m for m in messages
+        ), f"Expected warning about 'tok3n', got: {messages}"
+
+    def test_webex_config_load_warns_on_unknown_key(self, tmp_path):
+        """BaseConfig._load_config should warn for unknown webex_config.json keys."""
+        cfg_data = {"token": "x", "rabbitmq_h0st": "typo"}
+        cfg_file = tmp_path / "webex_config.json"
+        cfg_file.write_text(json.dumps(cfg_data))
+
+        import base_connector as bc
+
+        class FakeWebEXConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            FakeWebEXConfig(str(cfg_file))
+
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "rabbitmq_h0st" in m for m in messages
+        ), f"Expected warning about 'rabbitmq_h0st', got: {messages}"
+
+    def test_unknown_config_file_no_warning(self, tmp_path):
+        """Files not in CONNECTOR_VALIDATORS registry don't trigger schema checks."""
+        cfg_data = {"some_key": "value", "another_key": "data"}
+        cfg_file = tmp_path / "other_config.json"
+        cfg_file.write_text(json.dumps(cfg_data))
+
+        import base_connector as bc
+
+        class FakeOtherConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            FakeOtherConfig(str(cfg_file))
+
+        unknown_warnings = [
+            w for w in caught if "unknown key" in str(w.message).lower()
+        ]
+        assert (
+            not unknown_warnings
+        ), f"Expected no unknown-key warnings, got: {unknown_warnings}"
+
+
+# ===========================================================================
+# Integration: AgentManager._load_agents_config uses validation
+# ===========================================================================
+
+
+class TestAgentManagerIntegration:
+    """Verify AgentManager._load_agents_config calls schema validation."""
+
+    def test_unknown_agent_key_emits_warning(self, tmp_path):
+        """AgentManager._load_agents_config should warn on unknown keys."""
+        config = {
+            "agents": [
+                {
+                    "name": "test-agent",
+                    "path": "/opt/test/",
+                    "typo_unknown_key": "bad_value",
+                }
+            ]
+        }
+        config_file = tmp_path / "agents.json"
+        config_file.write_text(json.dumps(config))
+
+        import agent_manager as am
+
+        mgr = am.SessionManager.__new__(am.SessionManager)
+        mgr._agents_config_path = config_file
+        mgr._agents_json_mtime = 0.0
+
+        import io
+
+        captured = io.StringIO()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("sys.stderr", captured):
+                mgr._load_agents_config(str(config_file))
+
+        messages = [str(w.message) for w in caught]
+        has_warning = any("typo_unknown_key" in m for m in messages) or (
+            "typo_unknown_key" in captured.getvalue()
+        )
+        assert has_warning, (
+            f"Expected warning about unknown key, "
+            f"warnings={messages!r}, stderr={captured.getvalue()!r}"
+        )
+
+    def test_valid_agents_config_loads_without_unknown_warnings(self, tmp_path):
+        """AgentManager._load_agents_config should load cleanly."""
+        config = {
+            "agents": [
+                {
+                    "name": "orchestrator",
+                    "description": "Main agent",
+                    "path": "/opt/",
+                }
+            ]
+        }
+        config_file = tmp_path / "agents.json"
+        config_file.write_text(json.dumps(config))
+
+        import agent_manager as am
+
+        mgr = am.SessionManager.__new__(am.SessionManager)
+        mgr._agents_config_path = config_file
+        mgr._agents_json_mtime = 0.0
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = mgr._load_agents_config(str(config_file))
+
+        assert "orchestrator" in result
+        unknown_warnings = [
+            w for w in caught if "unknown key" in str(w.message).lower()
+        ]
+        assert (
+            not unknown_warnings
+        ), f"Expected no unknown-key warnings, got: {unknown_warnings}"

--- a/tests/test_issue32_config_schema_validation.py
+++ b/tests/test_issue32_config_schema_validation.py
@@ -520,3 +520,185 @@ class TestAgentManagerIntegration:
         assert (
             not unknown_warnings
         ), f"Expected no unknown-key warnings, got: {unknown_warnings}"
+
+
+# ===========================================================================
+# Regression: _load_agents_config rejects structurally invalid agents.json
+# ===========================================================================
+
+
+class TestAgentManagerInvalidSchemaRejected:
+    """Regression: _load_agents_config must not load agents when schema validation fails.
+
+    Issue #32 Round 5 — max_concurrent="oops" was previously loaded silently.
+    """
+
+    def test_invalid_max_concurrent_returns_empty_agents(self, tmp_path):
+        """_load_agents_config returns {} when max_concurrent has wrong type."""
+        config = {
+            "agents": [
+                {
+                    "name": "bad-agent",
+                    "path": "/opt/bad/",
+                    "max_concurrent": "oops",  # must be int
+                }
+            ]
+        }
+        config_file = tmp_path / "agents.json"
+        config_file.write_text(json.dumps(config))
+
+        import agent_manager as am
+
+        mgr = am.SessionManager.__new__(am.SessionManager)
+        mgr._agents_config_path = config_file
+        mgr._agents_json_mtime = 0.0
+
+        result = mgr._load_agents_config(str(config_file))
+
+        assert result == {}, (
+            f"Expected empty dict when schema validation fails, got: {result!r}. "
+            "Invalid agents.json must not be loaded into the live agent roster."
+        )
+
+    def test_invalid_schema_does_not_load_any_agents(self, tmp_path):
+        """_load_agents_config rejects the entire config, not just the bad entry."""
+        config = {
+            "agents": [
+                {
+                    "name": "good-agent",
+                    "path": "/opt/good/",
+                },
+                {
+                    "name": "bad-agent",
+                    "path": "/opt/bad/",
+                    "max_concurrent": "oops",
+                },
+            ]
+        }
+        config_file = tmp_path / "agents.json"
+        config_file.write_text(json.dumps(config))
+
+        import agent_manager as am
+
+        mgr = am.SessionManager.__new__(am.SessionManager)
+        mgr._agents_config_path = config_file
+        mgr._agents_json_mtime = 0.0
+
+        result = mgr._load_agents_config(str(config_file))
+
+        assert result == {}, (
+            f"Expected empty dict for any schema failure, got: {result!r}. "
+            "A single invalid entry must prevent loading the entire file."
+        )
+
+    def test_valid_config_still_loads_normally(self, tmp_path):
+        """_load_agents_config loads valid config without regression."""
+        config = {
+            "agents": [
+                {
+                    "name": "good-agent",
+                    "path": "/opt/good/",
+                    "max_concurrent": 2,
+                }
+            ]
+        }
+        config_file = tmp_path / "agents.json"
+        config_file.write_text(json.dumps(config))
+
+        import agent_manager as am
+
+        mgr = am.SessionManager.__new__(am.SessionManager)
+        mgr._agents_config_path = config_file
+        mgr._agents_json_mtime = 0.0
+
+        result = mgr._load_agents_config(str(config_file))
+
+        assert "good-agent" in result, f"Valid config should load cleanly, got: {result!r}"
+        assert result["good-agent"]["max_concurrent"] == 2
+
+
+# ===========================================================================
+# Regression: BaseConfig._load_config surfaces connector schema failures
+# ===========================================================================
+
+
+class TestBaseConfigSchemaValidationSurfaced:
+    """Regression: BaseConfig._load_config must not swallow ValidationError.
+
+    Issue #32 Round 5 — allowed_users="not-a-list" was previously silently
+    defaulted instead of surfacing the schema failure.
+    """
+
+    def test_telegram_invalid_allowed_users_raises(self, tmp_path):
+        """_load_config raises ValidationError when allowed_users is not a list."""
+        cfg_data = {"token": "bot123:FAKE", "allowed_users": "not-a-list"}
+        cfg_file = tmp_path / "telegram_config.json"
+        cfg_file.write_text(json.dumps(cfg_data))
+
+        import base_connector as bc
+
+        class FakeTelegramConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {"defaulted": True}
+
+        with pytest.raises(ValidationError):
+            FakeTelegramConfig(str(cfg_file))
+
+    def test_webex_invalid_allowed_users_raises(self, tmp_path):
+        """_load_config raises ValidationError when webex allowed_users is not a list."""
+        cfg_data = {"token": "webex-token", "allowed_users": "not-a-list"}
+        cfg_file = tmp_path / "webex_config.json"
+        cfg_file.write_text(json.dumps(cfg_data))
+
+        import base_connector as bc
+
+        class FakeWebEXConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {"defaulted": True}
+
+        with pytest.raises(ValidationError):
+            FakeWebEXConfig(str(cfg_file))
+
+    def test_invalid_connector_config_does_not_return_defaults(self, tmp_path):
+        """_load_config raises rather than silently returning default config."""
+        cfg_data = {"token": "bot123:FAKE", "allowed_users": 12345}  # must be list
+        cfg_file = tmp_path / "telegram_config.json"
+        cfg_file.write_text(json.dumps(cfg_data))
+
+        import base_connector as bc
+
+        class FakeTelegramConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {"defaulted": True}
+
+        caught_exc = None
+        result = None
+        try:
+            instance = FakeTelegramConfig(str(cfg_file))
+            result = instance.config
+        except Exception as e:
+            caught_exc = e
+
+        assert caught_exc is not None, (
+            f"Expected an exception to propagate, but got config: {result!r}. "
+            "Schema validation failure must not be silently swallowed."
+        )
+        assert isinstance(caught_exc, ValidationError), (
+            f"Expected ValidationError, got {type(caught_exc).__name__}: {caught_exc}"
+        )
+
+    def test_json_parse_error_still_returns_defaults(self, tmp_path):
+        """I/O errors and JSON parse errors still fall back to defaults (unchanged)."""
+        cfg_file = tmp_path / "telegram_config.json"
+        cfg_file.write_text("{{invalid json")
+
+        import base_connector as bc
+
+        class FakeTelegramConfig(bc.BaseConfig):
+            def _default_config(self):
+                return {"defaulted": True}
+
+        instance = FakeTelegramConfig(str(cfg_file))
+        assert instance.config == {"defaulted": True}, (
+            "JSON parse errors should still fall back to _default_config()"
+        )


### PR DESCRIPTION
## Summary

- Adds `config_schemas.py` with Pydantic v2 models for `agents.json`, `telegram_config.json`, and `webex_config.json`
- Unknown keys emit `UserWarning` so typos are immediately visible instead of being silently ignored
- Structural violations (wrong types, missing required fields) raise `ValidationError` and halt startup
- `base_connector.BaseConfig._load_config` uses `CONNECTOR_VALIDATORS` registry to auto-validate connector configs on load, applying Pydantic schema defaults via `model_dump()`
- `agent_manager.SessionManager._load_agents_config` calls `validate_agents_config` and raises on failure
- 43 regression tests covering all validation paths, warning behavior, and integration with `BaseConfig` and `SessionManager`

Closes #32

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>