### PR TITLE
fix: prevent call_agent 429 on background-tasks status queries (#251)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9965,6 +9965,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             ("Model not found:", 422, "model_not_found"),
             ("NotFoundError:", 422, "resource_not_found"),
             ("Resource not found", 422, "resource_not_found"),
+            ("weekly rate limit", 429, "weekly_rate_limit_exceeded"),
             ("rate limit", 429, "rate_limited"),
             ("RateLimitError", 429, "rate_limited"),
             ("PermissionDeniedError", 403, "permission_denied"),
@@ -11987,6 +11988,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             x_user_identity=request.headers.get("x-user-identity"),
             x_auth_channel=request.headers.get("x-auth-channel"),
         )
+        client_ip = request.client.host if request.client else "unknown"
+        if not rate_limiter.check(client_ip, "bg_tasks_list", max_requests=120, window=60):
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
         tasks = bg_task_mgr.list_all_tasks()
         # Check if running tasks are still alive
         for t in tasks:

--- a/scripts/wee_executor.py
+++ b/scripts/wee_executor.py
@@ -39,6 +39,7 @@ Exit codes:
 
 Capabilities:
     - create_background_task: Create background tasks via orchestrator API
+    - list_background_tasks: List background tasks/counts (direct HTTP, no LLM quota used)
     - get_secret: Retrieve secrets from secure store (elevated mode required)
 
 Future capabilities (not yet implemented):
@@ -452,6 +453,66 @@ def cap_create_background_task(
     }
 
 
+
+# ── Capability: list_background_tasks ──────────────────────────────────
+
+
+def cap_list_background_tasks(
+    args: Dict, session_id: Optional[str], mode: str
+) -> Dict:
+    """List background tasks via the orchestrator API.
+
+    Direct HTTP call — does NOT invoke an LLM session. Safe to call frequently
+    for status checks without consuming Copilot/Claude weekly quota.
+
+    Args (in args dict):
+        status_filter: Optional status to filter by (running, queued, done, failed)
+
+    Returns:
+        {total, running, queued, done, failed, tasks: [...summary list...]}
+    """
+    rate_key = session_id or "anonymous"
+    if not _check_rate_limit(rate_key):
+        return {
+            "error": f"Rate limit exceeded ({MAX_RATE_PER_MINUTE}/min)",
+            "code": "RATE_LIMITED",
+        }
+
+    result = _api_request("GET", "/api/v1/background-tasks")
+
+    if "error" in result:
+        logger.error("Failed to list background tasks: %s", result["error"])
+        return result
+
+    tasks = result.get("tasks", [])
+    status_filter = args.get("status_filter")
+
+    counts: Dict[str, int] = {"running": 0, "queued": 0, "done": 0, "failed": 0}
+    for t in tasks:
+        s = t.get("status", "unknown")
+        if s in counts:
+            counts[s] += 1
+
+    summary = [
+        {
+            "task_id": t.get("task_id"),
+            "agent": t.get("agent"),
+            "status": t.get("status"),
+            "prompt": (t.get("prompt") or "")[:80],
+        }
+        for t in tasks
+        if not status_filter or t.get("status") == status_filter
+    ]
+
+    return {
+        "total": len(tasks),
+        "running": counts["running"],
+        "queued": counts["queued"],
+        "done": counts["done"],
+        "failed": counts["failed"],
+        "tasks": summary,
+    }
+
 # ── Capability: get_secret ─────────────────────────────────────────────
 
 
@@ -619,6 +680,18 @@ register_capability(
         "model": "claude-haiku-4.5",
         "timeout": 600,
     },
+)
+
+register_capability(
+    name="list_background_tasks",
+    handler=cap_list_background_tasks,
+    allowed_modes=[MODE_INTERACTIVE, MODE_SYNC, MODE_BACKGROUND],
+    description=(
+        "List background tasks and counts -- lightweight HTTP call, no LLM session needed"
+    ),
+    required_args=[],
+    optional_args=["status_filter"],
+    example={"status_filter": "running"},
 )
 
 register_capability(

--- a/scripts/wee_executor.py
+++ b/scripts/wee_executor.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-wee_executor.py — Unified executor for Wee agents to safely perform privileged operations.
+wee_executor.py -- Unified executor for Wee agents to safely perform privileged
+operations.
 
 Provides a secure, audited CLI for agents to execute privileged operations
 (background task creation, etc.) without direct access to API tokens or
@@ -39,7 +40,8 @@ Exit codes:
 
 Capabilities:
     - create_background_task: Create background tasks via orchestrator API
-    - list_background_tasks: List background tasks/counts (direct HTTP, no LLM quota used)
+    - list_background_tasks: List background tasks/counts
+      (direct HTTP, no LLM quota used)
     - get_secret: Retrieve secrets from secure store (elevated mode required)
 
 Future capabilities (not yet implemented):
@@ -332,9 +334,7 @@ def _resolve_identity() -> Tuple[str, str]:
         if SESSIONS_JSON.exists():
             data = json.loads(SESSIONS_JSON.read_text())
             active = [
-                s
-                for s in data.values()
-                if isinstance(s, dict) and s.get("identity")
+                s for s in data.values() if isinstance(s, dict) and s.get("identity")
             ]
             if active:
                 latest = max(active, key=lambda s: s.get("created_at", 0))
@@ -441,9 +441,7 @@ def cap_create_background_task(
                 "monitor_url": f"{api_url}/api/v1/background-tasks/{task_id}",
             }
         else:
-            logger.warning(
-                "Task %s verification returned status=%s", task_id, status
-            )
+            logger.warning("Task %s verification returned status=%s", task_id, status)
 
     return {
         "task_id": task_id,
@@ -453,13 +451,10 @@ def cap_create_background_task(
     }
 
 
-
 # ── Capability: list_background_tasks ──────────────────────────────────
 
 
-def cap_list_background_tasks(
-    args: Dict, session_id: Optional[str], mode: str
-) -> Dict:
+def cap_list_background_tasks(args: Dict, session_id: Optional[str], mode: str) -> Dict:
     """List background tasks via the orchestrator API.
 
     Direct HTTP call — does NOT invoke an LLM session. Safe to call frequently
@@ -513,12 +508,11 @@ def cap_list_background_tasks(
         "tasks": summary,
     }
 
+
 # ── Capability: get_secret ─────────────────────────────────────────────
 
 
-def cap_get_secret(
-    args: Dict, session_id: Optional[str], mode: str
-) -> Dict:
+def cap_get_secret(args: Dict, session_id: Optional[str], mode: str) -> Dict:
     """Retrieve a secret from the secret store via secret_tool.
 
     Requires WEE_ELEVATED=true env var for defense-in-depth security.
@@ -685,9 +679,10 @@ register_capability(
 register_capability(
     name="list_background_tasks",
     handler=cap_list_background_tasks,
-    allowed_modes=[MODE_INTERACTIVE, MODE_SYNC, MODE_BACKGROUND],
+    allowed_modes=[MODE_INTERACTIVE, MODE_SYNC, MODE_BACKGROUND, MODE_API],
     description=(
-        "List background tasks and counts -- lightweight HTTP call, no LLM session needed"
+        "List background tasks and counts --"
+        " lightweight HTTP call, no LLM session needed"
     ),
     required_args=[],
     optional_args=["status_filter"],
@@ -699,8 +694,7 @@ register_capability(
     handler=cap_get_secret,
     allowed_modes=[MODE_INTERACTIVE, MODE_SYNC],
     description=(
-        "Retrieve a secret from the secure store "
-        "(requires WEE_ELEVATED=true)"
+        "Retrieve a secret from the secure store " "(requires WEE_ELEVATED=true)"
     ),
     required_args=["name"],
     optional_args=["backend"],
@@ -797,10 +791,7 @@ def main() -> None:
     cap = CAPABILITIES[cap_name]
 
     if mode not in cap["modes"]:
-        avail = [
-            c["name"]
-            for c in list_capabilities(mode)
-        ]
+        avail = [c["name"] for c in list_capabilities(mode)]
         print(
             json.dumps(
                 {

--- a/tests/test_issue_251_bg_tasks_rate_limit.py
+++ b/tests/test_issue_251_bg_tasks_rate_limit.py
@@ -1,0 +1,250 @@
+"""
+Regression tests for issue #251:
+Bug: call_agent hitting 429 rate limit on /api/v1/background-tasks query
+
+Root causes addressed:
+  1. No lightweight capability to list background tasks — agents were forced
+     to spin up a full Copilot/LLM session just to check task counts, burning
+     weekly quota and triggering rate limits.
+  2. "weekly rate limit" from Copilot not mapped to its own distinct error
+     code (weekly_rate_limit_exceeded) — was swallowed by the generic
+     "rate_limited" bucket, losing the actionable reset-time info.
+  3. GET /api/v1/background-tasks had no server-side rate limiting, leaving
+     it susceptible to polling storms from misbehaving agents.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ── Path setup ─────────────────────────────────────────────────────────
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "scripts"))
+
+
+class TestIssue251ListBgTasksCapability(unittest.TestCase):
+    """Test the new list_background_tasks wee_executor capability."""
+
+    def _import_executor(self):
+        import importlib
+        import wee_executor as we
+        importlib.reload(we)
+        return we
+
+    def test_capability_registered(self):
+        """list_background_tasks must appear in the capability registry."""
+        we = self._import_executor()
+        caps = {c["name"] for c in we.list_capabilities(we.MODE_INTERACTIVE)}
+        self.assertIn(
+            "list_background_tasks",
+            caps,
+            "list_background_tasks capability not registered",
+        )
+
+    def test_capability_available_in_background_mode(self):
+        """Capability must be available in background mode (agents run in background)."""
+        we = self._import_executor()
+        caps = {c["name"] for c in we.list_capabilities(we.MODE_BACKGROUND)}
+        self.assertIn(
+            "list_background_tasks",
+            caps,
+            "list_background_tasks must be available in background mode",
+        )
+
+    def test_capability_no_required_args(self):
+        """list_background_tasks must work with no arguments."""
+        we = self._import_executor()
+        cap = we.CAPABILITIES.get("list_background_tasks")
+        self.assertIsNotNone(cap)
+        self.assertEqual(cap.get("required_args", []), [])
+
+    def test_capability_returns_counts(self):
+        """Capability should return running/queued/done/failed counts."""
+        we = self._import_executor()
+
+        fake_tasks = {
+            "tasks": [
+                {"task_id": "bg_aaa", "agent": "devops", "status": "running", "prompt": "check cluster"},
+                {"task_id": "bg_bbb", "agent": "research", "status": "running", "prompt": "search news"},
+                {"task_id": "bg_ccc", "agent": "wee-dev", "status": "queued", "prompt": "implement feature"},
+                {"task_id": "bg_ddd", "agent": "email-triage", "status": "done", "prompt": "triage inbox"},
+                {"task_id": "bg_eee", "agent": "devops", "status": "failed", "prompt": "deploy service"},
+            ]
+        }
+
+        with patch.object(we, "_api_request", return_value=fake_tasks):
+            with patch.object(we, "_check_rate_limit", return_value=True):
+                result = we.cap_list_background_tasks({}, "test_session", we.MODE_INTERACTIVE)
+
+        self.assertEqual(result["total"], 5)
+        self.assertEqual(result["running"], 2)
+        self.assertEqual(result["queued"], 1)
+        self.assertEqual(result["done"], 1)
+        self.assertEqual(result["failed"], 1)
+        self.assertEqual(len(result["tasks"]), 5)
+
+    def test_capability_status_filter(self):
+        """status_filter arg should limit returned tasks to that status."""
+        we = self._import_executor()
+
+        fake_tasks = {
+            "tasks": [
+                {"task_id": "bg_aaa", "agent": "devops", "status": "running", "prompt": "check cluster"},
+                {"task_id": "bg_bbb", "agent": "research", "status": "done", "prompt": "search news"},
+            ]
+        }
+
+        with patch.object(we, "_api_request", return_value=fake_tasks):
+            with patch.object(we, "_check_rate_limit", return_value=True):
+                result = we.cap_list_background_tasks(
+                    {"status_filter": "running"}, "test_session", we.MODE_INTERACTIVE
+                )
+
+        self.assertEqual(result["total"], 2)  # total counts all tasks
+        self.assertEqual(result["running"], 1)
+        self.assertEqual(len(result["tasks"]), 1)  # filter applied to task list
+        self.assertEqual(result["tasks"][0]["task_id"], "bg_aaa")
+
+    def test_capability_handles_api_error(self):
+        """API error should be returned as dict with 'error' key."""
+        we = self._import_executor()
+
+        with patch.object(we, "_api_request", return_value={"error": "HTTP 503: Service unavailable", "code": "HTTP_503"}):
+            with patch.object(we, "_check_rate_limit", return_value=True):
+                result = we.cap_list_background_tasks({}, "test_session", we.MODE_INTERACTIVE)
+
+        self.assertIn("error", result)
+
+    def test_capability_does_not_invoke_llm(self):
+        """list_background_tasks must call _api_request, NOT a subprocess (no LLM)."""
+        we = self._import_executor()
+        api_call_count = []
+
+        def fake_api(method, path, **kwargs):
+            api_call_count.append((method, path))
+            return {"tasks": []}
+
+        with patch.object(we, "_api_request", side_effect=fake_api):
+            with patch.object(we, "_check_rate_limit", return_value=True):
+                with patch("subprocess.run") as mock_subproc:
+                    we.cap_list_background_tasks({}, "test_session", we.MODE_INTERACTIVE)
+                    mock_subproc.assert_not_called()
+
+        self.assertEqual(len(api_call_count), 1)
+        self.assertEqual(api_call_count[0], ("GET", "/api/v1/background-tasks"))
+
+
+class TestIssue251WeeklyRateLimitDetection(unittest.TestCase):
+    """Test that 'weekly rate limit' from Copilot is detected with its own error code."""
+
+    def _get_runtime_error_patterns(self):
+        """Extract _RUNTIME_ERROR_PATTERNS from agent_manager source without full import."""
+        am_path = REPO / "agent_manager.py"
+        source = am_path.read_text()
+        # Find the _RUNTIME_ERROR_PATTERNS list in source
+        import ast
+        # Parse just enough to extract the list
+        start = source.index("_RUNTIME_ERROR_PATTERNS = [")
+        end = source.index("]", start) + 1
+        snippet = "_RUNTIME_ERROR_PATTERNS = " + source[start + len("_RUNTIME_ERROR_PATTERNS = "):end]
+        tree = ast.parse(snippet)
+        # The list value
+        assign = tree.body[0]
+        patterns = []
+        for elt in assign.value.elts:
+            tup = tuple(c.value for c in elt.elts)
+            patterns.append(tup)
+        return patterns
+
+    def test_weekly_rate_limit_has_distinct_error_code(self):
+        """'weekly rate limit' must map to weekly_rate_limit_exceeded, not rate_limited."""
+        patterns = self._get_runtime_error_patterns()
+        weekly_patterns = [(p, s, c) for p, s, c in patterns if "weekly" in p.lower()]
+        self.assertTrue(len(weekly_patterns) > 0, "No pattern for 'weekly rate limit' found")
+        for _, status, code in weekly_patterns:
+            self.assertEqual(status, 429)
+            self.assertEqual(
+                code,
+                "weekly_rate_limit_exceeded",
+                f"Expected 'weekly_rate_limit_exceeded', got '{code}'",
+            )
+
+    def test_weekly_rate_limit_pattern_before_generic_rate_limit(self):
+        """'weekly rate limit' pattern must appear before generic 'rate limit' to take priority."""
+        patterns = self._get_runtime_error_patterns()
+        pattern_names = [p for p, _, _ in patterns]
+        self.assertIn("weekly rate limit", pattern_names, "weekly rate limit pattern missing")
+        self.assertIn("rate limit", pattern_names, "rate limit pattern missing")
+        weekly_idx = pattern_names.index("weekly rate limit")
+        generic_idx = pattern_names.index("rate limit")
+        self.assertLess(
+            weekly_idx,
+            generic_idx,
+            "weekly rate limit pattern must come before generic rate limit for proper matching priority",
+        )
+
+    def test_copilot_weekly_limit_message_triggers_429(self):
+        """Simulated Copilot weekly-limit message must produce a 429 with the right error code."""
+        patterns = self._get_runtime_error_patterns()
+        copilot_msg = "You've reached your weekly rate limit. Please wait for your limit to reset in 3 hours 42 minutes"
+
+        matched_code = None
+        matched_status = None
+        for pattern, status, code in patterns:
+            if pattern.lower() in copilot_msg.lower():
+                matched_code = code
+                matched_status = status
+                break
+
+        self.assertEqual(matched_status, 429)
+        self.assertEqual(
+            matched_code,
+            "weekly_rate_limit_exceeded",
+            f"Copilot weekly-limit message should produce weekly_rate_limit_exceeded, got {matched_code!r}",
+        )
+
+
+class TestIssue251BgTasksListEndpointRateLimit(unittest.TestCase):
+    """Test that GET /api/v1/background-tasks has a server-side rate limit."""
+
+    def test_endpoint_has_rate_limit_check(self):
+        """GET /api/v1/background-tasks handler must call rate_limiter.check."""
+        am_path = REPO / "agent_manager.py"
+        source = am_path.read_text()
+
+        # Find the list_background_tasks handler
+        handler_start = source.index('@app.get("/api/v1/background-tasks")\n    async def list_background_tasks')
+        # Find the next route definition after it
+        next_route_start = source.index('@app.get("/api/v1/background-tasks/{task_id}")')
+        handler_body = source[handler_start:next_route_start]
+
+        self.assertIn(
+            "rate_limiter.check",
+            handler_body,
+            "GET /api/v1/background-tasks must have a rate_limiter.check() call",
+        )
+
+    def test_rate_limit_is_generous_for_status_checks(self):
+        """Rate limit for bg_tasks_list must be >= 60 req/min (status checks must not false-trigger)."""
+        am_path = REPO / "agent_manager.py"
+        source = am_path.read_text()
+
+        handler_start = source.index('@app.get("/api/v1/background-tasks")\n    async def list_background_tasks')
+        next_route_start = source.index('@app.get("/api/v1/background-tasks/{task_id}")')
+        handler_body = source[handler_start:next_route_start]
+
+        import re
+        m = re.search(r'bg_tasks_list.*?max_requests=(\d+)', handler_body)
+        self.assertIsNotNone(m, "Could not find bg_tasks_list rate limit configuration")
+        limit = int(m.group(1))
+        self.assertGreaterEqual(
+            limit, 60,
+            f"bg_tasks_list rate limit ({limit}/min) is too low — must be >= 60 to avoid false positives on routine status checks",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_issue_251_bg_tasks_rate_limit.py
+++ b/tests/test_issue_251_bg_tasks_rate_limit.py
@@ -56,6 +56,17 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
             "list_background_tasks must be available in background mode",
         )
 
+
+    def test_capability_available_in_api_mode(self):
+        """Capability must be available in api mode (wee_executor runs without WEE_TASK_ID)."""
+        we = self._import_executor()
+        caps = {c["name"] for c in we.list_capabilities(we.MODE_API)}
+        self.assertIn(
+            "list_background_tasks",
+            caps,
+            "list_background_tasks must be available in api mode",
+        )
+
     def test_capability_no_required_args(self):
         """list_background_tasks must work with no arguments."""
         we = self._import_executor()

--- a/tests/test_issue_251_bg_tasks_rate_limit.py
+++ b/tests/test_issue_251_bg_tasks_rate_limit.py
@@ -13,11 +13,10 @@ Root causes addressed:
      it susceptible to polling storms from misbehaving agents.
 """
 
-import json
 import sys
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 # ── Path setup ─────────────────────────────────────────────────────────
 REPO = Path(__file__).resolve().parent.parent
@@ -30,7 +29,9 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
 
     def _import_executor(self):
         import importlib
+
         import wee_executor as we
+
         importlib.reload(we)
         return we
 
@@ -45,7 +46,8 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
         )
 
     def test_capability_available_in_background_mode(self):
-        """Capability must be available in background mode (agents run in background)."""
+        """Capability must be available in background mode
+        (agents run in background)."""
         we = self._import_executor()
         caps = {c["name"] for c in we.list_capabilities(we.MODE_BACKGROUND)}
         self.assertIn(
@@ -67,17 +69,44 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
 
         fake_tasks = {
             "tasks": [
-                {"task_id": "bg_aaa", "agent": "devops", "status": "running", "prompt": "check cluster"},
-                {"task_id": "bg_bbb", "agent": "research", "status": "running", "prompt": "search news"},
-                {"task_id": "bg_ccc", "agent": "wee-dev", "status": "queued", "prompt": "implement feature"},
-                {"task_id": "bg_ddd", "agent": "email-triage", "status": "done", "prompt": "triage inbox"},
-                {"task_id": "bg_eee", "agent": "devops", "status": "failed", "prompt": "deploy service"},
+                {
+                    "task_id": "bg_aaa",
+                    "agent": "devops",
+                    "status": "running",
+                    "prompt": "check cluster",
+                },
+                {
+                    "task_id": "bg_bbb",
+                    "agent": "research",
+                    "status": "running",
+                    "prompt": "search news",
+                },
+                {
+                    "task_id": "bg_ccc",
+                    "agent": "wee-dev",
+                    "status": "queued",
+                    "prompt": "implement feature",
+                },
+                {
+                    "task_id": "bg_ddd",
+                    "agent": "email-triage",
+                    "status": "done",
+                    "prompt": "triage inbox",
+                },
+                {
+                    "task_id": "bg_eee",
+                    "agent": "devops",
+                    "status": "failed",
+                    "prompt": "deploy service",
+                },
             ]
         }
 
         with patch.object(we, "_api_request", return_value=fake_tasks):
             with patch.object(we, "_check_rate_limit", return_value=True):
-                result = we.cap_list_background_tasks({}, "test_session", we.MODE_INTERACTIVE)
+                result = we.cap_list_background_tasks(
+                    {}, "test_session", we.MODE_INTERACTIVE
+                )
 
         self.assertEqual(result["total"], 5)
         self.assertEqual(result["running"], 2)
@@ -92,8 +121,18 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
 
         fake_tasks = {
             "tasks": [
-                {"task_id": "bg_aaa", "agent": "devops", "status": "running", "prompt": "check cluster"},
-                {"task_id": "bg_bbb", "agent": "research", "status": "done", "prompt": "search news"},
+                {
+                    "task_id": "bg_aaa",
+                    "agent": "devops",
+                    "status": "running",
+                    "prompt": "check cluster",
+                },
+                {
+                    "task_id": "bg_bbb",
+                    "agent": "research",
+                    "status": "done",
+                    "prompt": "search news",
+                },
             ]
         }
 
@@ -112,9 +151,15 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
         """API error should be returned as dict with 'error' key."""
         we = self._import_executor()
 
-        with patch.object(we, "_api_request", return_value={"error": "HTTP 503: Service unavailable", "code": "HTTP_503"}):
+        with patch.object(
+            we,
+            "_api_request",
+            return_value={"error": "HTTP 503: Service unavailable", "code": "HTTP_503"},
+        ):
             with patch.object(we, "_check_rate_limit", return_value=True):
-                result = we.cap_list_background_tasks({}, "test_session", we.MODE_INTERACTIVE)
+                result = we.cap_list_background_tasks(
+                    {}, "test_session", we.MODE_INTERACTIVE
+                )
 
         self.assertIn("error", result)
 
@@ -130,7 +175,9 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
         with patch.object(we, "_api_request", side_effect=fake_api):
             with patch.object(we, "_check_rate_limit", return_value=True):
                 with patch("subprocess.run") as mock_subproc:
-                    we.cap_list_background_tasks({}, "test_session", we.MODE_INTERACTIVE)
+                    we.cap_list_background_tasks(
+                        {}, "test_session", we.MODE_INTERACTIVE
+                    )
                     mock_subproc.assert_not_called()
 
         self.assertEqual(len(api_call_count), 1)
@@ -138,18 +185,24 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
 
 
 class TestIssue251WeeklyRateLimitDetection(unittest.TestCase):
-    """Test that 'weekly rate limit' from Copilot is detected with its own error code."""
+    """Test that 'weekly rate limit' from Copilot is detected
+    with its own error code."""
 
     def _get_runtime_error_patterns(self):
-        """Extract _RUNTIME_ERROR_PATTERNS from agent_manager source without full import."""
+        """Extract _RUNTIME_ERROR_PATTERNS from agent_manager source
+        without full import."""
         am_path = REPO / "agent_manager.py"
         source = am_path.read_text()
         # Find the _RUNTIME_ERROR_PATTERNS list in source
         import ast
+
         # Parse just enough to extract the list
         start = source.index("_RUNTIME_ERROR_PATTERNS = [")
         end = source.index("]", start) + 1
-        snippet = "_RUNTIME_ERROR_PATTERNS = " + source[start + len("_RUNTIME_ERROR_PATTERNS = "):end]
+        snippet = (
+            "_RUNTIME_ERROR_PATTERNS = "
+            + source[start + len("_RUNTIME_ERROR_PATTERNS = ") : end]
+        )
         tree = ast.parse(snippet)
         # The list value
         assign = tree.body[0]
@@ -160,10 +213,13 @@ class TestIssue251WeeklyRateLimitDetection(unittest.TestCase):
         return patterns
 
     def test_weekly_rate_limit_has_distinct_error_code(self):
-        """'weekly rate limit' must map to weekly_rate_limit_exceeded, not rate_limited."""
+        """'weekly rate limit' must map to weekly_rate_limit_exceeded,
+        not rate_limited."""
         patterns = self._get_runtime_error_patterns()
         weekly_patterns = [(p, s, c) for p, s, c in patterns if "weekly" in p.lower()]
-        self.assertTrue(len(weekly_patterns) > 0, "No pattern for 'weekly rate limit' found")
+        self.assertTrue(
+            len(weekly_patterns) > 0, "No pattern for 'weekly rate limit' found"
+        )
         for _, status, code in weekly_patterns:
             self.assertEqual(status, 429)
             self.assertEqual(
@@ -173,23 +229,31 @@ class TestIssue251WeeklyRateLimitDetection(unittest.TestCase):
             )
 
     def test_weekly_rate_limit_pattern_before_generic_rate_limit(self):
-        """'weekly rate limit' pattern must appear before generic 'rate limit' to take priority."""
+        """'weekly rate limit' pattern must appear before generic
+        'rate limit' to take priority."""
         patterns = self._get_runtime_error_patterns()
         pattern_names = [p for p, _, _ in patterns]
-        self.assertIn("weekly rate limit", pattern_names, "weekly rate limit pattern missing")
+        self.assertIn(
+            "weekly rate limit", pattern_names, "weekly rate limit pattern missing"
+        )
         self.assertIn("rate limit", pattern_names, "rate limit pattern missing")
         weekly_idx = pattern_names.index("weekly rate limit")
         generic_idx = pattern_names.index("rate limit")
         self.assertLess(
             weekly_idx,
             generic_idx,
-            "weekly rate limit pattern must come before generic rate limit for proper matching priority",
+            "weekly rate limit pattern must come before generic rate limit"
+            " for proper matching priority",
         )
 
     def test_copilot_weekly_limit_message_triggers_429(self):
-        """Simulated Copilot weekly-limit message must produce a 429 with the right error code."""
+        """Simulated Copilot weekly-limit message must produce a 429
+        with the right error code."""
         patterns = self._get_runtime_error_patterns()
-        copilot_msg = "You've reached your weekly rate limit. Please wait for your limit to reset in 3 hours 42 minutes"
+        copilot_msg = (
+            "You've reached your weekly rate limit. Please wait for"
+            " your limit to reset in 3 hours 42 minutes"
+        )
 
         matched_code = None
         matched_status = None
@@ -203,7 +267,8 @@ class TestIssue251WeeklyRateLimitDetection(unittest.TestCase):
         self.assertEqual(
             matched_code,
             "weekly_rate_limit_exceeded",
-            f"Copilot weekly-limit message should produce weekly_rate_limit_exceeded, got {matched_code!r}",
+            f"Copilot weekly-limit message should produce weekly_rate_limit_exceeded,"
+            f" got {matched_code!r}",
         )
 
 
@@ -216,9 +281,13 @@ class TestIssue251BgTasksListEndpointRateLimit(unittest.TestCase):
         source = am_path.read_text()
 
         # Find the list_background_tasks handler
-        handler_start = source.index('@app.get("/api/v1/background-tasks")\n    async def list_background_tasks')
+        handler_start = source.index(
+            '@app.get("/api/v1/background-tasks")\n    async def list_background_tasks'
+        )
         # Find the next route definition after it
-        next_route_start = source.index('@app.get("/api/v1/background-tasks/{task_id}")')
+        next_route_start = source.index(
+            '@app.get("/api/v1/background-tasks/{task_id}")'
+        )
         handler_body = source[handler_start:next_route_start]
 
         self.assertIn(
@@ -228,21 +297,31 @@ class TestIssue251BgTasksListEndpointRateLimit(unittest.TestCase):
         )
 
     def test_rate_limit_is_generous_for_status_checks(self):
-        """Rate limit for bg_tasks_list must be >= 60 req/min (status checks must not false-trigger)."""
+        """Rate limit for bg_tasks_list must be >= 60 req/min
+        (status checks must not false-trigger)."""
         am_path = REPO / "agent_manager.py"
         source = am_path.read_text()
 
-        handler_start = source.index('@app.get("/api/v1/background-tasks")\n    async def list_background_tasks')
-        next_route_start = source.index('@app.get("/api/v1/background-tasks/{task_id}")')
+        handler_start = source.index(
+            '@app.get("/api/v1/background-tasks")\n    async def list_background_tasks'
+        )
+        next_route_start = source.index(
+            '@app.get("/api/v1/background-tasks/{task_id}")'
+        )
         handler_body = source[handler_start:next_route_start]
 
         import re
-        m = re.search(r'bg_tasks_list.*?max_requests=(\d+)', handler_body)
+
+        m = re.search(r"bg_tasks_list.*?max_requests=(\d+)", handler_body)
         self.assertIsNotNone(m, "Could not find bg_tasks_list rate limit configuration")
         limit = int(m.group(1))
         self.assertGreaterEqual(
-            limit, 60,
-            f"bg_tasks_list rate limit ({limit}/min) is too low — must be >= 60 to avoid false positives on routine status checks",
+            limit,
+            60,
+            (
+                f"bg_tasks_list rate limit ({limit}/min) is too low -- must be >= 60"
+                " to avoid false positives on routine status checks"
+            ),
         )
 
 


### PR DESCRIPTION
## Summary

- Adds `list_background_tasks` capability to `wee_executor.py` — agents can now query task counts/status via a direct HTTP call without spawning a Copilot/Claude LLM session, eliminating weekly quota consumption for routine status checks
- Adds `weekly rate limit` as a distinct pattern in `_RUNTIME_ERROR_PATTERNS` (mapped to `weekly_rate_limit_exceeded`) before the generic `rate limit` pattern, so callers can distinguish quota exhaustion from transient rate limiting
- Adds `rate_limiter.check()` to `GET /api/v1/background-tasks` with a generous 120 req/min limit to prevent polling storms

## Regression Tests (12 tests, all passing)

- `TestIssue251ListBgTasksCapability` — verifies capability is registered, available in background mode, returns correct counts, supports status filtering, handles API errors, and never invokes an LLM subprocess
- `TestIssue251WeeklyRateLimitDetection` — verifies the Copilot weekly-limit message maps to `weekly_rate_limit_exceeded` with priority over the generic `rate_limited` code
- `TestIssue251BgTasksListEndpointRateLimit` — verifies the GET endpoint has a rate limit check >= 60 req/min

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)