### PR TITLE
feat: Service status panel for Telegram and WebEx in sidebar drawer

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9601,6 +9601,47 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             "active_sessions": len(session_mgr.load_session_map()),
         }
 
+    @app.get("/api/v1/service-status")
+    async def get_service_status():
+        """Query systemctl status for connector services."""
+        import asyncio
+        import socket as _socket
+
+        env_suffix = "-dev" if APP_ENV == "DEV" else ""
+        services = {
+            "telegram": f"telegram-bot-listener{env_suffix}.service",
+            "webex": f"webex-connector{env_suffix}.service",
+        }
+
+        results = {}
+        for name, svc in services.items():
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "systemctl", "is-active", svc,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+                status = stdout.decode().strip()
+                results[name] = {
+                    "service": svc,
+                    "status": status,
+                    "active": status == "active",
+                }
+            except Exception as e:
+                results[name] = {
+                    "service": svc,
+                    "status": "unknown",
+                    "active": False,
+                    "error": str(e),
+                }
+
+        return {
+            "services": results,
+            "node": _socket.gethostname(),
+            "checked_at": time.time(),
+        }
+
     @app.get("/api/v1/config")
     async def get_config():
         """Public endpoint — returns feature flags for the WebUI."""

--- a/tests/test_issue_236_service_status.py
+++ b/tests/test_issue_236_service_status.py
@@ -1,0 +1,113 @@
+"""Tests for issue #236: Service status endpoint for Telegram and WebEx connectors."""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ["API_SHARED_KEY"] = "test_key_123"
+os.environ["APP_ENV"] = "DEV"
+os.environ["API_PORT"] = "8099"
+
+
+class TestServiceStatusEndpoint(unittest.TestCase):
+    """Test the /api/v1/service-status endpoint added in issue #236."""
+
+    @classmethod
+    def setUpClass(cls):
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        cls._telegram_patch = patch.object(
+            agent_manager,
+            "_resolve_telegram_identity",
+            side_effect=lambda identity: identity,
+        )
+        cls._telegram_patch.start()
+        cls._send_pairing_patch = patch.object(
+            agent_manager,
+            "_send_pairing_code",
+            return_value=True,
+        )
+        cls._send_pairing_patch.start()
+        cls.app = agent_manager.create_api_app()
+        cls.client = TestClient(cls.app)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._telegram_patch.stop()
+        cls._send_pairing_patch.stop()
+
+    def test_service_status_endpoint_exists(self):
+        """Endpoint must return 200 (not 404)."""
+        resp = self.client.get("/api/v1/service-status")
+        self.assertNotEqual(resp.status_code, 404, "service-status endpoint must exist")
+
+    def test_service_status_returns_both_services(self):
+        """Response must include both 'telegram' and 'webex' entries."""
+        resp = self.client.get("/api/v1/service-status")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("services", data)
+        services = data["services"]
+        self.assertIn("telegram", services, "telegram must be present in services")
+        self.assertIn("webex", services, "webex must be present in services")
+
+    def test_service_status_schema(self):
+        """Each service entry must have required fields."""
+        resp = self.client.get("/api/v1/service-status")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        for name in ("telegram", "webex"):
+            svc = data["services"][name]
+            self.assertIn("service", svc, f"{name}.service must be present")
+            self.assertIn("status", svc, f"{name}.status must be present")
+            self.assertIn("active", svc, f"{name}.active must be boolean")
+            self.assertIsInstance(svc["active"], bool)
+
+    def test_service_status_includes_node(self):
+        """Response must include node hostname."""
+        resp = self.client.get("/api/v1/service-status")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("node", data)
+        self.assertIsInstance(data["node"], str)
+        self.assertGreater(len(data["node"]), 0)
+
+    def test_service_status_includes_timestamp(self):
+        """Response must include checked_at timestamp."""
+        resp = self.client.get("/api/v1/service-status")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("checked_at", data)
+        self.assertIsInstance(data["checked_at"], (int, float))
+        self.assertGreater(data["checked_at"], 0)
+
+    def test_dev_environment_uses_dev_service_names(self):
+        """In DEV environment, service names must have -dev suffix."""
+        resp = self.client.get("/api/v1/service-status")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        telegram_svc = data["services"]["telegram"]["service"]
+        webex_svc = data["services"]["webex"]["service"]
+        self.assertIn("-dev", telegram_svc, "telegram service name must have -dev suffix in DEV env")
+        self.assertIn("-dev", webex_svc, "webex service name must have -dev suffix in DEV env")
+
+    def test_service_status_active_field_valid_type(self):
+        """active field must always be boolean, never string."""
+        resp = self.client.get("/api/v1/service-status")
+        data = resp.json()
+        for name, svc in data["services"].items():
+            self.assertIsInstance(
+                svc["active"], bool,
+                f"{name}.active must be bool, got {type(svc['active'])}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/webui/dist/app.css
+++ b/webui/dist/app.css
@@ -3135,7 +3135,8 @@ html, body {
 .request-queue-panel.queue-minimized .queue-pause-btn,
 .request-queue-panel.queue-minimized .queue-items-list,
 .request-queue-panel.queue-minimized .queue-footer,
-.request-queue-panel.queue-minimized .scratch-section {  display: none;
+.request-queue-panel.queue-minimized .scratch-section {
+  display: none;
 }
 
 .queue-header {

--- a/webui/dist/app.css
+++ b/webui/dist/app.css
@@ -3135,8 +3135,7 @@ html, body {
 .request-queue-panel.queue-minimized .queue-pause-btn,
 .request-queue-panel.queue-minimized .queue-items-list,
 .request-queue-panel.queue-minimized .queue-footer,
-.request-queue-panel.queue-minimized .scratch-section {
-  display: none;
+.request-queue-panel.queue-minimized .scratch-section {  display: none;
 }
 
 .queue-header {
@@ -7051,4 +7050,112 @@ html, body {
   background: rgba(80, 160, 255, 0.12);
   color: #6cb4ff;
   border: 1px solid rgba(80, 160, 255, 0.2);
+}
+
+/* ── Service Status Section ──────────────────────────────────────────── */
+.service-status-section {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 12px 8px;
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+  gap: 6px;
+}
+
+.request-queue-panel.queue-minimized .service-status-section {
+  display: none;
+}
+
+.service-status-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.service-status-icon {
+  font-size: 13px;
+}
+
+.service-status-label {
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.btn-refresh-status {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.2s, transform 0.3s;
+  border-radius: 4px;
+}
+
+.btn-refresh-status:hover {
+  color: var(--accent);
+  background: rgba(255,255,255,0.06);
+}
+
+.btn-refresh-status.spinning {
+  transform: rotate(360deg);
+  transition: transform 0.5s linear;
+}
+
+.service-status-items {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.service-status-item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+}
+
+.service-name {
+  flex: 1;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.service-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dot-loading { background: var(--text-muted); opacity: 0.5; }
+.dot-active  { background: #4ade80; box-shadow: 0 0 6px rgba(74,222,128,0.6); }
+.dot-inactive{ background: #f87171; box-shadow: 0 0 6px rgba(248,113,113,0.6); }
+.dot-failed  { background: #fb923c; box-shadow: 0 0 6px rgba(251,146,60,0.6); }
+.dot-unknown { background: var(--text-muted); }
+
+.service-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.badge-loading  { background: rgba(255,255,255,0.08); color: var(--text-muted); }
+.badge-active   { background: rgba(74,222,128,0.15);  color: #4ade80; }
+.badge-inactive { background: rgba(248,113,113,0.15); color: #f87171; }
+.badge-failed   { background: rgba(251,146,60,0.15);  color: #fb923c; }
+.badge-unknown  { background: rgba(255,255,255,0.08); color: var(--text-muted); }
+
+.service-status-footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 2px;
 }

--- a/webui/dist/app.js
+++ b/webui/dist/app.js
@@ -7219,3 +7219,66 @@ function closeAgentsPanel() {
   clearInterval(_agentsRefreshTimer);
   _agentsRefreshTimer = null;
 }
+
+// ── Service Status Panel ──────────────────────────────────────────────────────
+let _svcStatusPollInterval = null;
+const SVC_POLL_MS = 30000;
+
+function _formatSvcTimestamp(ts) {
+  const d = new Date(ts * 1000);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function _applySvcStatus(name, info) {
+  const dot   = document.getElementById('svc-dot-' + name);
+  const badge = document.getElementById('svc-badge-' + name);
+  if (!dot || !badge) return;
+
+  const status = info.status || 'unknown';
+  const dotClass   = status === 'active'   ? 'dot-active'
+                   : status === 'inactive' ? 'dot-inactive'
+                   : status === 'failed'   ? 'dot-failed'
+                   : 'dot-unknown';
+  const badgeClass = status === 'active'   ? 'badge-active'
+                   : status === 'inactive' ? 'badge-inactive'
+                   : status === 'failed'   ? 'badge-failed'
+                   : 'badge-unknown';
+
+  dot.className   = 'service-dot ' + dotClass;
+  badge.className = 'service-badge ' + badgeClass;
+  badge.textContent = status;
+}
+
+async function fetchServiceStatus() {
+  const refreshBtn = document.getElementById('btn-refresh-service-status');
+  if (refreshBtn) {
+    refreshBtn.classList.add('spinning');
+    setTimeout(function() { refreshBtn.classList.remove('spinning'); }, 600);
+  }
+
+  try {
+    const data = await apiRequest('GET', '/service-status');
+    const services = data.services || {};
+    for (const name of Object.keys(services)) {
+      _applySvcStatus(name, services[name]);
+    }
+    const tsEl   = document.getElementById('service-status-timestamp');
+    const nodeEl = document.getElementById('service-status-node');
+    if (tsEl)   tsEl.textContent = 'Updated ' + _formatSvcTimestamp(data.checked_at);
+    if (nodeEl) nodeEl.textContent = data.node ? 'node: ' + data.node : '';
+  } catch (err) {
+    const tsEl = document.getElementById('service-status-timestamp');
+    if (tsEl) tsEl.textContent = 'Status unavailable';
+  }
+}
+
+function _initServiceStatus() {
+  const refreshBtn = document.getElementById('btn-refresh-service-status');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', function() { fetchServiceStatus(); });
+  }
+  fetchServiceStatus();
+  _svcStatusPollInterval = setInterval(fetchServiceStatus, SVC_POLL_MS);
+}
+
+document.addEventListener('DOMContentLoaded', _initServiceStatus);

--- a/webui/dist/index.html
+++ b/webui/dist/index.html
@@ -234,6 +234,31 @@
     <!-- REQUEST QUEUE PANEL (right side) -->
     <aside id="request-queue-panel" class="request-queue-panel queue-minimized">
 
+      <!-- Service Status Section -->
+      <div id="service-status-section" class="service-status-section">
+        <div class="service-status-header">
+          <span class="service-status-icon">🔌</span>
+          <span class="service-status-label">Services</span>
+          <button id="btn-refresh-service-status" class="btn-refresh-status" title="Refresh status">↻</button>
+        </div>
+        <div id="service-status-items" class="service-status-items">
+          <div class="service-status-item" id="svc-item-telegram">
+            <span class="service-dot dot-loading" id="svc-dot-telegram"></span>
+            <span class="service-name">Telegram</span>
+            <span class="service-badge badge-loading" id="svc-badge-telegram">…</span>
+          </div>
+          <div class="service-status-item" id="svc-item-webex">
+            <span class="service-dot dot-loading" id="svc-dot-webex"></span>
+            <span class="service-name">WebEx</span>
+            <span class="service-badge badge-loading" id="svc-badge-webex">…</span>
+          </div>
+        </div>
+        <div class="service-status-footer">
+          <small id="service-status-node"></small>
+          <small id="service-status-timestamp">Checking…</small>
+        </div>
+      </div>
+
       <!-- Queue Section (Collapsible) -->
       <div id="queue-section" class="queue-section queue-section-collapsed">
         <!-- Queue Header -->


### PR DESCRIPTION
## Summary

Closes #236

- **New API**: `GET /api/v1/service-status` queries systemctl for `telegram-bot-listener` and `webex-connector` services — uses `-dev` suffix in DEV env automatically
- **UI Panel**: Service status section added above the queue in the right-side drawer, showing color-coded status dots and badges for each service
- **Auto-refresh**: Polls every 30 seconds; manual refresh button with spin animation
- **Node ID**: Shows hostname so users can verify which node is running each service
- **Mobile-safe**: Panel hides when drawer is minimized, no layout breakage
- **Tests**: 7 unit tests cover endpoint schema, DEV env service naming, field types, and boolean validation

## Test plan
- [x] `GET /api/v1/service-status` returns 200 with telegram and webex service info
- [x] DEV environment uses `-dev` suffixed service names
- [x] 7 unit tests all pass: `pytest tests/test_issue_236_service_status.py`
- [x] Service panel visible in sidebar drawer above queue section
- [x] Minimized panel hides the service section correctly
- [x] Refresh button triggers status update

🤖 Generated with [Claude Code](https://claude.com/claude-code)