### PR TITLE
refactor(#238): consolidate agent config into single source of truth

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -214,7 +214,9 @@
             "*"
           ]
         }
-      }
+      },
+      "permission_mode": "elevated",
+      "yolo": true
     },
     {
       "name": "smarthome",
@@ -325,11 +327,6 @@
           ]
         }
       }
-    },
-    {
-      "name": "wee-doc",
-      "description": "Documentation and starter-kit maintenance agent for Wee Orchestrator. Updates README/docs, keeps the starter kit in sync, and verifies documentation changes after feature work.",
-      "path": "/opt/wee-doc"
     }
   ]
 }

--- a/scripts/dispatch_wee_dev_work_queue.py
+++ b/scripts/dispatch_wee_dev_work_queue.py
@@ -35,7 +35,6 @@ RUNNING_STATUSES = {"created", "queued", "pending", "running", "in_progress"}
 
 AGENT_MANAGER_PATH = Path("/opt/n8n-copilot-shim/agent_manager.py")
 AGENTS_CONFIG_PATH = Path("/opt/n8n-copilot-shim/agents.json")
-AGENTS_DISPATCH_CONFIG_PATH = Path("/opt/n8n-copilot-shim/config/agents.json")
 DISPATCH_LOG_DIR = Path("/tmp/wee-dispatch-logs")
 
 # Labels required in the repository (name → colour hex without #)
@@ -330,61 +329,65 @@ def clear_lock() -> None:
 def get_agent_dispatch_config(agent_name: str) -> dict:
     """Get dispatch configuration for an agent.
 
-    Resolution order (issue #238 consolidation):
-    1. ``dispatch_config`` block in agents.json (legacy / explicit override)
-    2. ``dispatch_config`` block in config/agents.json (protected overlay)
-    3. Flat ``primary_runtime``/``primary_model`` fields in agents.json (issue #225 format)
+    Single-source resolution: reads only from agents.json (issue #238).
+    Supports two schemas:
+    1. Legacy dispatch_config block (explicit override, kept for compatibility)
+    2. Flat primary_runtime/primary_model fields (canonical since issue #225)
+
+    config/agents.json overlay is no longer consulted -- all dispatch data
+    must live directly in agents.json.
 
     Raises RuntimeError if no configuration can be found.
     """
-    # Load main agents.json
     if not AGENTS_CONFIG_PATH.exists():
         raise RuntimeError(f"agents.json not found at {AGENTS_CONFIG_PATH}")
     main_config = json.loads(AGENTS_CONFIG_PATH.read_text())
 
-    main_agent = next(
+    agent = next(
         (a for a in main_config.get("agents", []) if a.get("name") == agent_name),
         None,
     )
-    if main_agent is None:
+    if agent is None:
         raise RuntimeError(f"Agent {agent_name!r} not found in agents.json")
 
-    # 1. Explicit dispatch_config in agents.json
-    if main_agent.get("dispatch_config"):
-        return dict(main_agent["dispatch_config"])
+    # 1. Legacy dispatch_config block (kept for backward compat)
+    if agent.get("dispatch_config"):
+        cfg = dict(agent["dispatch_config"])
+        # Back-fill fallback fields from top-level if missing in dispatch_config
+        if "fallback_runtime" not in cfg and agent.get("fallback_runtime"):
+            cfg["fallback_runtime"] = agent["fallback_runtime"]
+        if "fallback_model" not in cfg and agent.get("fallback_model"):
+            cfg["fallback_model"] = agent["fallback_model"]
+        return cfg
 
-    # 2. Protected overlay in config/agents.json
-    if AGENTS_DISPATCH_CONFIG_PATH.exists():
-        overlay = json.loads(AGENTS_DISPATCH_CONFIG_PATH.read_text())
-        for a in overlay.get("agents", []):
-            if a.get("name") == agent_name and a.get("dispatch_config"):
-                cfg = dict(a["dispatch_config"])
-                # Back-fill fallback from main agents.json flat fields if absent
-                if "fallback_runtime" not in cfg and main_agent.get("fallback_runtime"):
-                    cfg["fallback_runtime"] = main_agent["fallback_runtime"]
-                if "fallback_model" not in cfg and main_agent.get("fallback_model"):
-                    cfg["fallback_model"] = main_agent["fallback_model"]
-                return cfg
-
-    # 3. Build from flat primary_runtime/primary_model fields (issue #225 format)
-    if main_agent.get("primary_runtime"):
+    # 2. Flat primary_runtime/primary_model fields (canonical schema)
+    if agent.get("primary_runtime"):
+        # permission_mode: explicit field > permissions.mode block > sensible default
+        default_perm = "elevated" if agent_name in ("wee-dev", "wee-qa") else "restricted"
+        permission_mode = (
+            agent.get("permission_mode")
+            or agent.get("permissions", {}).get("mode")
+            or default_perm
+        )
+        # yolo: explicit field > sensible default (True for wee-dev/wee-qa)
+        yolo_val = agent.get("yolo")
+        if yolo_val is None:
+            yolo_val = agent_name in ("wee-dev", "wee-qa")
         return {
-            "runtime": main_agent["primary_runtime"],
-            "model": main_agent.get("primary_model", "auto"),
-            "fallback_runtime": main_agent.get("fallback_runtime", "copilot"),
-            "fallback_model": main_agent.get("fallback_model", "auto"),
-            "permission_mode": "elevated",
-            "yolo": True,
+            "runtime": agent["primary_runtime"],
+            "model": agent.get("primary_model", "auto"),
+            "fallback_runtime": agent.get("fallback_runtime"),
+            "fallback_model": agent.get("fallback_model"),
+            "vendor": f"{agent['primary_runtime']} ({agent.get('primary_model', 'auto')})",
+            "permission_mode": permission_mode,
+            "yolo": bool(yolo_val),
             "timeout": 3600,
-            "vendor": f"{main_agent['primary_runtime']}/{main_agent.get('primary_model', 'auto')}",
         }
 
     raise RuntimeError(
         f"No dispatch_config found for agent {agent_name!r}. "
-        f"Add a dispatch_config block to agents.json or config/agents.json."
+        f"Add primary_runtime/primary_model fields to agents.json."
     )
-
-
 def load_api_key() -> str:
     for line in ENV_PATH.read_text().splitlines():
         if line.startswith("API_SHARED_KEY="):

--- a/scripts/dispatch_wee_dev_work_queue.py
+++ b/scripts/dispatch_wee_dev_work_queue.py
@@ -363,7 +363,9 @@ def get_agent_dispatch_config(agent_name: str) -> dict:
     # 2. Flat primary_runtime/primary_model fields (canonical schema)
     if agent.get("primary_runtime"):
         # permission_mode: explicit field > permissions.mode block > sensible default
-        default_perm = "elevated" if agent_name in ("wee-dev", "wee-qa") else "restricted"
+        default_perm = (
+            "elevated" if agent_name in ("wee-dev", "wee-qa") else "restricted"
+        )
         permission_mode = (
             agent.get("permission_mode")
             or agent.get("permissions", {}).get("mode")
@@ -378,7 +380,9 @@ def get_agent_dispatch_config(agent_name: str) -> dict:
             "model": agent.get("primary_model", "auto"),
             "fallback_runtime": agent.get("fallback_runtime"),
             "fallback_model": agent.get("fallback_model"),
-            "vendor": f"{agent['primary_runtime']} ({agent.get('primary_model', 'auto')})",
+            "vendor": (
+                f"{agent['primary_runtime']} ({agent.get('primary_model', 'auto')})"
+            ),
             "permission_mode": permission_mode,
             "yolo": bool(yolo_val),
             "timeout": 3600,
@@ -388,6 +392,8 @@ def get_agent_dispatch_config(agent_name: str) -> dict:
         f"No dispatch_config found for agent {agent_name!r}. "
         f"Add primary_runtime/primary_model fields to agents.json."
     )
+
+
 def load_api_key() -> str:
     for line in ENV_PATH.read_text().splitlines():
         if line.startswith("API_SHARED_KEY="):
@@ -432,7 +438,7 @@ def dispatch_via_api(
 
     Uses the orchestrator's background-tasks API instead of direct subprocess spawning
     so tasks are properly registered, visible in the Tasks menu, and fully audited.
-    
+
     Returns the task_id.
     """
     import hashlib
@@ -507,7 +513,8 @@ def dispatch_via_api(
             task_id = result.get("task_id", "")
             if task_id:
                 log(
-                    f"Dispatched {agent} via API: task_id={task_id} status={result.get('status')}"
+                    f"Dispatched {agent} via API: task_id={task_id}"
+                    f" status={result.get('status')}"
                 )
                 return task_id
             else:
@@ -526,23 +533,23 @@ def dispatch_via_subprocess(
     """DEPRECATED: Spawn agent_manager.py as a detached subprocess.
 
     ⚠️ This method is deprecated. Use dispatch_via_api() instead.
-    
+
     Old design: bypassed API due to session leakage concerns (issue #74).
     New design: use API with proper session isolation to keep tasks visible.
-    
+
     Kept for backward compatibility only.
     Returns the PID of the spawned process.
     """
     sid = session_id or str(uuid.uuid4())
     DISPATCH_LOG_DIR.mkdir(exist_ok=True)
     log_file = DISPATCH_LOG_DIR / f"{agent}-{sid[:8]}.log"
-    
+
     # Use claude runtime (copilot runtime hangs in background mode)
     # Map models appropriately: for claude runtime, use claude models
     runtime = "claude"
     # For claude runtime, use claude-opus-4.6 as default (works with claude runtime)
     effective_model = "claude-opus-4.6" if model and "gpt" in model.lower() else model
-    
+
     cmd = [
         sys.executable,
         str(AGENT_MANAGER_PATH),

--- a/tests/test_issue_238_config_consolidation.py
+++ b/tests/test_issue_238_config_consolidation.py
@@ -1,0 +1,288 @@
+"""Regression tests for issue #238: Consolidate agent config into single source of truth.
+
+Verifies:
+1. get_agent_dispatch_config reads only from agents.json (no config/agents.json dependency)
+2. Flat primary_runtime/primary_model fields are used correctly
+3. permission_mode defaults correctly per agent (elevated for wee-dev/wee-qa, restricted for others)
+4. yolo defaults correctly per agent
+5. Explicit permission_mode/yolo fields in agents.json override defaults
+6. Legacy dispatch_config block still works for backward compat
+7. Missing agent raises RuntimeError without consulting config/agents.json
+8. AGENTS_DISPATCH_CONFIG_PATH constant is removed from dispatch script
+"""
+
+import ast
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
+
+
+def _make_dispatch_func(agents_json_content: dict):
+    """Helper: create a get_agent_dispatch_config function bound to a temp agents.json."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "dispatch_mod",
+        "/opt/n8n-copilot-shim-dev/scripts/dispatch_wee_dev_work_queue.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+        json.dump(agents_json_content, tmp)
+        tmp_path = tmp.name
+
+    mod.AGENTS_CONFIG_PATH = Path(tmp_path)
+
+    try:
+        spec.loader.exec_module(mod)
+    except (SystemExit, Exception):
+        pass
+
+    mod.AGENTS_CONFIG_PATH = Path(tmp_path)
+    return mod.get_agent_dispatch_config, tmp_path
+
+
+class TestIssue238SingleSourceOfTruth(unittest.TestCase):
+    """Issue #238: agents.json is the single source of truth for dispatch config."""
+
+    def _make_agents(self, extra_agents=None):
+        """Build a minimal agents.json-style dict."""
+        agents = [
+            {
+                "name": "wee-dev",
+                "path": "/opt/wee-dev",
+                "primary_runtime": "claude",
+                "primary_model": "sonnet",
+                "fallback_runtime": "copilot",
+                "fallback_model": "auto",
+                "permission_mode": "elevated",
+                "yolo": True,
+            },
+            {
+                "name": "wee-qa",
+                "path": "/opt/wee-qa",
+                "primary_runtime": "codex",
+                "primary_model": "gpt-5.4-mini",
+                "fallback_runtime": "copilot",
+                "fallback_model": "auto",
+                "permission_mode": "elevated",
+                "yolo": True,
+            },
+            {
+                "name": "orchestrator",
+                "path": "/opt/",
+                "primary_runtime": "claude",
+                "primary_model": "haiku",
+                "fallback_runtime": "copilot",
+                "fallback_model": "auto",
+            },
+        ]
+        if extra_agents:
+            agents.extend(extra_agents)
+        return {"agents": agents}
+
+    def test_wee_dev_uses_flat_fields_from_agents_json(self):
+        """wee-dev config is read from agents.json flat fields without needing config/agents.json."""
+        get_cfg, tmp = _make_dispatch_func(self._make_agents())
+        try:
+            cfg = get_cfg("wee-dev")
+            self.assertEqual(cfg["runtime"], "claude")
+            self.assertEqual(cfg["model"], "sonnet")
+            self.assertEqual(cfg["fallback_runtime"], "copilot")
+            self.assertEqual(cfg["permission_mode"], "elevated")
+            self.assertTrue(cfg["yolo"])
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_wee_qa_uses_flat_fields_from_agents_json(self):
+        """wee-qa config is read from agents.json flat fields."""
+        get_cfg, tmp = _make_dispatch_func(self._make_agents())
+        try:
+            cfg = get_cfg("wee-qa")
+            self.assertEqual(cfg["runtime"], "codex")
+            self.assertEqual(cfg["model"], "gpt-5.4-mini")
+            self.assertEqual(cfg["permission_mode"], "elevated")
+            self.assertTrue(cfg["yolo"])
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_regular_agent_gets_restricted_permission_mode(self):
+        """Non wee-dev/wee-qa agents default to restricted permission_mode."""
+        get_cfg, tmp = _make_dispatch_func(self._make_agents())
+        try:
+            cfg = get_cfg("orchestrator")
+            self.assertEqual(cfg["permission_mode"], "restricted")
+            self.assertFalse(cfg["yolo"])
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_explicit_permission_mode_overrides_default(self):
+        """Explicit permission_mode field overrides the agent-name-based default."""
+        agents = self._make_agents(extra_agents=[{
+            "name": "custom-agent",
+            "path": "/opt/custom",
+            "primary_runtime": "claude",
+            "primary_model": "haiku",
+            "permission_mode": "elevated",
+        }])
+        get_cfg, tmp = _make_dispatch_func(agents)
+        try:
+            cfg = get_cfg("custom-agent")
+            self.assertEqual(cfg["permission_mode"], "elevated")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_explicit_yolo_false_overrides_default_for_wee_dev(self):
+        """Explicit yolo=False in agents.json overrides the wee-dev default of True."""
+        agents = {
+            "agents": [{
+                "name": "wee-dev",
+                "path": "/opt/wee-dev",
+                "primary_runtime": "claude",
+                "primary_model": "sonnet",
+                "yolo": False,
+            }]
+        }
+        get_cfg, tmp = _make_dispatch_func(agents)
+        try:
+            cfg = get_cfg("wee-dev")
+            self.assertFalse(cfg["yolo"])
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_legacy_dispatch_config_block_still_works(self):
+        """Legacy dispatch_config block in agents.json is still respected."""
+        agents = {
+            "agents": [{
+                "name": "wee-dev",
+                "path": "/opt/wee-dev",
+                "dispatch_config": {
+                    "runtime": "copilot",
+                    "model": "claude-opus-4.6",
+                    "permission_mode": "elevated",
+                    "yolo": True,
+                    "timeout": 1800,
+                },
+                "fallback_runtime": "codex",
+                "fallback_model": "gpt-5.4-mini",
+            }]
+        }
+        get_cfg, tmp = _make_dispatch_func(agents)
+        try:
+            cfg = get_cfg("wee-dev")
+            self.assertEqual(cfg["runtime"], "copilot")
+            self.assertEqual(cfg["model"], "claude-opus-4.6")
+            self.assertEqual(cfg["timeout"], 1800)
+            # fallback fields back-filled from top-level
+            self.assertEqual(cfg["fallback_runtime"], "codex")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_missing_agent_raises_runtime_error(self):
+        """Unknown agent name raises RuntimeError immediately (no fallback to other files)."""
+        get_cfg, tmp = _make_dispatch_func(self._make_agents())
+        try:
+            with self.assertRaises(RuntimeError) as ctx:
+                get_cfg("nonexistent-agent")
+            self.assertIn("nonexistent-agent", str(ctx.exception))
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_no_agents_dispatch_config_path_constant(self):
+        """AGENTS_DISPATCH_CONFIG_PATH constant must not exist in the dispatch script.
+
+        This is the core of issue #238: the old overlay path was removed so
+        config/agents.json can never be silently consulted.
+        """
+        script_path = Path("/opt/n8n-copilot-shim-dev/scripts/dispatch_wee_dev_work_queue.py")
+        self.assertTrue(script_path.exists(), "dispatch script missing")
+        content = script_path.read_text()
+        self.assertNotIn(
+            "AGENTS_DISPATCH_CONFIG_PATH",
+            content,
+            "AGENTS_DISPATCH_CONFIG_PATH still present in dispatch script — "
+            "config/agents.json overlay not removed (issue #238)",
+        )
+
+    def test_no_path_instantiation_for_config_agents_json(self):
+        """Path('config/agents.json') must not be instantiated anywhere in the dispatch script.
+
+        Checks actual AST to distinguish docstring mentions from live code.
+        """
+        script_path = Path("/opt/n8n-copilot-shim-dev/scripts/dispatch_wee_dev_work_queue.py")
+        content = script_path.read_text()
+        try:
+            tree = ast.parse(content)
+        except SyntaxError as e:
+            self.fail(f"dispatch script has syntax errors: {e}")
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "Path":
+                    for arg in node.args:
+                        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                            self.assertNotIn(
+                                "config/agents.json",
+                                arg.value,
+                                f"Path('config/agents.json') still in dispatch script "
+                                f"(issue #238 consolidation): {arg.value!r}",
+                            )
+
+    def test_wee_dev_has_permission_mode_and_yolo_in_agents_json(self):
+        """wee-dev entry in agents.json has explicit permission_mode and yolo fields."""
+        agents_path = Path("/opt/n8n-copilot-shim-dev/agents.json")
+        self.assertTrue(agents_path.exists(), "agents.json missing")
+        config = json.loads(agents_path.read_text())
+        wee_dev = next(
+            (a for a in config.get("agents", []) if a.get("name") == "wee-dev"),
+            None,
+        )
+        self.assertIsNotNone(wee_dev, "wee-dev agent not found in agents.json")
+        self.assertIn(
+            "permission_mode",
+            wee_dev,
+            "wee-dev missing permission_mode in agents.json (issue #238)",
+        )
+        self.assertEqual(wee_dev["permission_mode"], "elevated")
+        self.assertIn("yolo", wee_dev, "wee-dev missing yolo in agents.json (issue #238)")
+        self.assertTrue(wee_dev["yolo"])
+
+    def test_no_duplicate_agents_in_agents_json(self):
+        """agents.json must not have duplicate agent name entries."""
+        agents_path = Path("/opt/n8n-copilot-shim-dev/agents.json")
+        config = json.loads(agents_path.read_text())
+        names = [a.get("name") for a in config.get("agents", [])]
+        duplicates = [n for n in set(names) if names.count(n) > 1]
+        self.assertEqual(
+            duplicates,
+            [],
+            f"Duplicate agent entries in agents.json: {duplicates}",
+        )
+
+    def test_scheduler_job_points_to_scripts_version(self):
+        """Scheduler job for wee-dev work queue must use the scripts/ version, not /opt/bin/."""
+        jobs_path = Path("/opt/.task-scheduler-dev/jobs.json")
+        self.assertTrue(jobs_path.exists(), "scheduler jobs file missing")
+        jobs = json.loads(jobs_path.read_text())
+        wee_dev_jobs = [
+            j for j in jobs.get("jobs", [])
+            if "dispatch_wee_dev" in j.get("task", "")
+               or "work-queue" in j.get("id", "")
+        ]
+        self.assertTrue(len(wee_dev_jobs) > 0, "No wee-dev work queue scheduler job found")
+        for job in wee_dev_jobs:
+            self.assertIn(
+                "scripts/dispatch_wee_dev",
+                job.get("task", ""),
+                f"Scheduler job {job['id']} still points to old /opt/bin/ path. "
+                "Update it to use /opt/n8n-copilot-shim/scripts/ (issue #238).",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Remove `AGENTS_DISPATCH_CONFIG_PATH` from dispatch script — `config/agents.json` overlay is no longer consulted
- Update `get_agent_dispatch_config` to read exclusively from `agents.json` flat fields
- Fix `permission_mode` default: restricted for regular agents, elevated for wee-dev/wee-qa (was incorrectly hardcoded to elevated for all agents in step 3)
- Add explicit `permission_mode=elevated` and `yolo=true` to wee-dev in `agents.json`
- Remove duplicate `wee-doc` entry from `agents.json`
- Add scheduler job pointing to `scripts/dispatch_wee_dev_work_queue.py` (not the old `/opt/bin/` copy)
- 12 regression tests in `test_issue_238_config_consolidation.py`

## Root cause (from issue #238)
`dispatch_wee_dev_work_queue.py` in `scripts/` still had a 3-step lookup that consulted a `config/agents.json` overlay that does not exist on dev. This caused `RuntimeError: No dispatch_config found` when agents only had flat fields.

## Test plan
- [ ] All 12 tests in `test_issue_238_config_consolidation.py` pass
- [ ] `AGENTS_DISPATCH_CONFIG_PATH` not present in `scripts/dispatch_wee_dev_work_queue.py`
- [ ] `agents.json` has explicit `permission_mode` and `yolo` for wee-dev
- [ ] No duplicate entries in `agents.json`
- [ ] Scheduler job references `scripts/` version

Closes #238