### PR TITLE
feat(#248): display agent name badge in session list

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1023,7 +1023,9 @@ class HistoryManager:
                     return s.get("messages", [])
         return None
 
-    def create_session(self, channel: str, identity: str, session_id: str, agent: str = "") -> dict:
+    def create_session(
+        self, channel: str, identity: str, session_id: str, agent: str = ""
+    ) -> dict:
         """Create a new session entry, pruning oldest if over cap."""
         with self._lock:
             data = self._load()
@@ -9830,7 +9832,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         # Use provided session_id or generate a new one
         session_id = body.session_id if body.session_id else str(uuid4())[:8]
         session_mgr.get_or_create_session_data(session_id, identity=user["identity"])
-        history_mgr.create_session(user["channel"], user["identity"], session_id, agent=body.agent or "")
+        history_mgr.create_session(
+            user["channel"], user["identity"], session_id, agent=body.agent or ""
+        )
 
         # Store channel in session so file instructions are channel-aware
         session_mgr.update_session_field(session_id, "channel", user["channel"])

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1023,7 +1023,7 @@ class HistoryManager:
                     return s.get("messages", [])
         return None
 
-    def create_session(self, channel: str, identity: str, session_id: str) -> dict:
+    def create_session(self, channel: str, identity: str, session_id: str, agent: str = "") -> dict:
         """Create a new session entry, pruning oldest if over cap."""
         with self._lock:
             data = self._load()
@@ -1040,6 +1040,7 @@ class HistoryManager:
                 "session_id": session_id,
                 "title": "",
                 "preview": "",
+                "agent": agent or "",
                 "created_at": now,
                 "updated_at": now,
                 "messages": [],
@@ -1160,6 +1161,22 @@ class HistoryManager:
             data[key]["sessions"] = new_sessions
             self._save(data)
             return True
+
+    def update_session_agent(
+        self, channel: str, identity: str, session_id: str, agent: str
+    ) -> bool:
+        """Update the agent associated with a session."""
+        with self._lock:
+            data = self._load()
+            key = self._user_key(channel, identity)
+            for s in data.get(key, {}).get("sessions", []):
+                if s["session_id"] == session_id:
+                    s["agent"] = agent or ""
+                    s["updated_at"] = time.time()
+                    self._save(data)
+                    return True
+        return False
+
 
 class RuntimeUsageTracker:
     """Queries GitHub Copilot premium request usage from the billing API."""
@@ -9813,7 +9830,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         # Use provided session_id or generate a new one
         session_id = body.session_id if body.session_id else str(uuid4())[:8]
         session_mgr.get_or_create_session_data(session_id, identity=user["identity"])
-        history_mgr.create_session(user["channel"], user["identity"], session_id)
+        history_mgr.create_session(user["channel"], user["identity"], session_id, agent=body.agent or "")
 
         # Store channel in session so file instructions are channel-aware
         session_mgr.update_session_field(session_id, "channel", user["channel"])
@@ -9936,6 +9953,12 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         session_data = session_mgr.get_or_create_session_data(
             session_id, identity=user["identity"]
         )
+        # Sync agent to history so session list always shows current agent
+        current_agent = session_data.get("agent") or ""
+        if current_agent:
+            history_mgr.update_session_agent(
+                user["channel"], user["identity"], session_id, current_agent
+            )
         runtime = session_data.get("runtime", "copilot")
         return {
             "session_id": session_id,
@@ -10246,6 +10269,12 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 )
 
                 session_data = session_mgr.get_or_create_session_data(session_id)
+                # Sync agent to history so session list always shows current agent
+                current_agent = session_data.get("agent") or ""
+                if current_agent:
+                    history_mgr.update_session_agent(
+                        user["channel"], user["identity"], session_id, current_agent
+                    )
                 runtime = session_data.get("runtime", "copilot")
                 done_payload = _json.dumps(
                     {
@@ -10253,6 +10282,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         "response": result,
                         "runtime": runtime,
                         "model": session_data.get("model"),
+                        "agent": current_agent,
                     }
                 )
                 yield f"data: {done_payload}\n\n"

--- a/tests/test_issue248_agent_name_in_session_list.py
+++ b/tests/test_issue248_agent_name_in_session_list.py
@@ -18,7 +18,6 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 def _make_history_manager():
     """Create a HistoryManager with a temp file."""
-    import importlib
     import agent_manager as am
     mgr = am.HistoryManager.__new__(am.HistoryManager)
     # Point to a temp file
@@ -38,7 +37,9 @@ def test_create_session_stores_agent():
         mgr.create_session("telegram", "testuser", "sess001", agent="wee-dev")
         sessions = mgr.get_sessions("telegram", "testuser")
         assert len(sessions) == 1
-        assert sessions[0]["agent"] == "wee-dev", f"Expected 'wee-dev', got {sessions[0].get('agent')}"
+        assert (
+            sessions[0]["agent"] == "wee-dev"
+        ), f"Expected 'wee-dev', got {sessions[0].get('agent')}"
     finally:
         os.unlink(path)
 
@@ -50,7 +51,9 @@ def test_create_session_no_agent_defaults_empty():
         mgr.create_session("telegram", "testuser", "sess002")
         sessions = mgr.get_sessions("telegram", "testuser")
         assert len(sessions) == 1
-        assert sessions[0]["agent"] == "", f"Expected empty string, got {sessions[0].get('agent')}"
+        assert (
+            sessions[0]["agent"] == ""
+        ), f"Expected empty string, got {sessions[0].get('agent')}"
     finally:
         os.unlink(path)
 
@@ -59,9 +62,11 @@ def test_get_sessions_returns_agent_field():
     """get_sessions() must include agent in returned data."""
     mgr, path = _make_history_manager()
     try:
-        mgr.create_session("telegram", "testuser", "sess003", agent="orchestrator")
+        mgr.create_session(
+            "telegram", "testuser", "sess003", agent="orchestrator"
+        )
         sessions = mgr.get_sessions("telegram", "testuser")
-        assert "agent" in sessions[0], "agent field missing from get_sessions() output"
+        assert "agent" in sessions[0], "agent field missing from get_sessions()"
         assert sessions[0]["agent"] == "orchestrator"
     finally:
         os.unlink(path)
@@ -71,11 +76,15 @@ def test_update_session_agent():
     """update_session_agent() should update the agent on an existing session."""
     mgr, path = _make_history_manager()
     try:
-        mgr.create_session("telegram", "testuser", "sess004", agent="orchestrator")
+        mgr.create_session(
+            "telegram", "testuser", "sess004", agent="orchestrator"
+        )
         result = mgr.update_session_agent("telegram", "testuser", "sess004", "wee-qa")
         assert result is True, "update_session_agent should return True on success"
         sessions = mgr.get_sessions("telegram", "testuser")
-        assert sessions[0]["agent"] == "wee-qa", f"Expected 'wee-qa', got {sessions[0].get('agent')}"
+        assert (
+            sessions[0]["agent"] == "wee-qa"
+        ), f"Expected 'wee-qa', got {sessions[0].get('agent')}"
     finally:
         os.unlink(path)
 
@@ -84,8 +93,12 @@ def test_update_session_agent_returns_false_for_unknown_session():
     """update_session_agent() should return False if session not found."""
     mgr, path = _make_history_manager()
     try:
-        result = mgr.update_session_agent("telegram", "testuser", "nonexistent", "wee-dev")
-        assert result is False, "update_session_agent should return False for unknown session"
+        result = mgr.update_session_agent(
+            "telegram", "testuser", "nonexistent", "wee-dev"
+        )
+        assert (
+            result is False
+        ), "update_session_agent should return False for unknown session"
     finally:
         os.unlink(path)
 

--- a/tests/test_issue248_agent_name_in_session_list.py
+++ b/tests/test_issue248_agent_name_in_session_list.py
@@ -7,11 +7,12 @@ Tests verify that:
 3. update_session_agent() updates the agent field in history
 4. Sessions created without agent default to empty string
 """
-import sys
-import os
-import time
+
 import json
+import os
+import sys
 import tempfile
+import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/tests/test_issue248_agent_name_in_session_list.py
+++ b/tests/test_issue248_agent_name_in_session_list.py
@@ -1,0 +1,123 @@
+"""
+Regression tests for Issue #248: Display agent name in session list.
+
+Tests verify that:
+1. HistoryManager.create_session() stores the agent field
+2. get_sessions() returns the agent field
+3. update_session_agent() updates the agent field in history
+4. Sessions created without agent default to empty string
+"""
+import sys
+import os
+import time
+import json
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _make_history_manager():
+    """Create a HistoryManager with a temp file."""
+    import importlib
+    import agent_manager as am
+    mgr = am.HistoryManager.__new__(am.HistoryManager)
+    # Point to a temp file
+    tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+    json.dump({}, tmp)
+    tmp.close()
+    import threading
+    mgr._path = tmp.name
+    mgr._lock = threading.Lock()
+    return mgr, tmp.name
+
+
+def test_create_session_stores_agent():
+    """Session created with agent arg should have agent in history."""
+    mgr, path = _make_history_manager()
+    try:
+        mgr.create_session("telegram", "testuser", "sess001", agent="wee-dev")
+        sessions = mgr.get_sessions("telegram", "testuser")
+        assert len(sessions) == 1
+        assert sessions[0]["agent"] == "wee-dev", f"Expected 'wee-dev', got {sessions[0].get('agent')}"
+    finally:
+        os.unlink(path)
+
+
+def test_create_session_no_agent_defaults_empty():
+    """Session created without agent should have empty agent string."""
+    mgr, path = _make_history_manager()
+    try:
+        mgr.create_session("telegram", "testuser", "sess002")
+        sessions = mgr.get_sessions("telegram", "testuser")
+        assert len(sessions) == 1
+        assert sessions[0]["agent"] == "", f"Expected empty string, got {sessions[0].get('agent')}"
+    finally:
+        os.unlink(path)
+
+
+def test_get_sessions_returns_agent_field():
+    """get_sessions() must include agent in returned data."""
+    mgr, path = _make_history_manager()
+    try:
+        mgr.create_session("telegram", "testuser", "sess003", agent="orchestrator")
+        sessions = mgr.get_sessions("telegram", "testuser")
+        assert "agent" in sessions[0], "agent field missing from get_sessions() output"
+        assert sessions[0]["agent"] == "orchestrator"
+    finally:
+        os.unlink(path)
+
+
+def test_update_session_agent():
+    """update_session_agent() should update the agent on an existing session."""
+    mgr, path = _make_history_manager()
+    try:
+        mgr.create_session("telegram", "testuser", "sess004", agent="orchestrator")
+        result = mgr.update_session_agent("telegram", "testuser", "sess004", "wee-qa")
+        assert result is True, "update_session_agent should return True on success"
+        sessions = mgr.get_sessions("telegram", "testuser")
+        assert sessions[0]["agent"] == "wee-qa", f"Expected 'wee-qa', got {sessions[0].get('agent')}"
+    finally:
+        os.unlink(path)
+
+
+def test_update_session_agent_returns_false_for_unknown_session():
+    """update_session_agent() should return False if session not found."""
+    mgr, path = _make_history_manager()
+    try:
+        result = mgr.update_session_agent("telegram", "testuser", "nonexistent", "wee-dev")
+        assert result is False, "update_session_agent should return False for unknown session"
+    finally:
+        os.unlink(path)
+
+
+def test_multiple_agents_in_session_list():
+    """Multiple sessions with different agents should each show their agent."""
+    mgr, path = _make_history_manager()
+    try:
+        mgr.create_session("telegram", "testuser", "sess010", agent="wee-dev")
+        time.sleep(0.01)
+        mgr.create_session("telegram", "testuser", "sess011", agent="email-triage")
+        time.sleep(0.01)
+        mgr.create_session("telegram", "testuser", "sess012", agent="")
+        sessions = mgr.get_sessions("telegram", "testuser")
+        assert len(sessions) == 3
+        # Sessions are sorted newest-first
+        by_id = {s["session_id"]: s["agent"] for s in sessions}
+        assert by_id["sess010"] == "wee-dev"
+        assert by_id["sess011"] == "email-triage"
+        assert by_id["sess012"] == ""
+    finally:
+        os.unlink(path)
+
+
+def test_agent_field_not_in_messages_leak():
+    """get_sessions() should never include messages — agent must still be present."""
+    mgr, path = _make_history_manager()
+    try:
+        mgr.create_session("telegram", "testuser", "sess020", agent="research")
+        mgr.append_message("telegram", "testuser", "sess020", "user", "hello")
+        sessions = mgr.get_sessions("telegram", "testuser")
+        assert "messages" not in sessions[0], "messages must not leak into session list"
+        assert sessions[0]["agent"] == "research"
+    finally:
+        os.unlink(path)

--- a/webui/dist/app.css
+++ b/webui/dist/app.css
@@ -428,6 +428,33 @@ html, body {
 }
 .session-item:hover .session-rename-btn { visibility: visible; }
 .session-rename-btn:hover { background: rgba(62,207,142,0.3); }
+/* Agent badge in session list */
+.session-agent-badge {
+  display: inline-block;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-right: 4px;
+  vertical-align: middle;
+  line-height: 1.5;
+  opacity: 0.9;
+  color: #fff;
+  background: rgba(99,102,241,0.5);
+  border: 1px solid rgba(99,102,241,0.4);
+}
+/* Per-agent color coding */
+.session-agent-badge[data-agent="orchestrator"] { background: rgba(62,207,142,0.4); border-color: rgba(62,207,142,0.5); }
+.session-agent-badge[data-agent="wee-dev"]      { background: rgba(96,165,250,0.4); border-color: rgba(96,165,250,0.5); }
+.session-agent-badge[data-agent="wee-qa"]       { background: rgba(251,146,60,0.4); border-color: rgba(251,146,60,0.5); }
+.session-agent-badge[data-agent="email-triage"] { background: rgba(167,139,250,0.4); border-color: rgba(167,139,250,0.5); }
+.session-agent-badge[data-agent="research"]     { background: rgba(34,211,238,0.4); border-color: rgba(34,211,238,0.5); }
+.session-agent-badge[data-agent="devops"]       { background: rgba(251,191,36,0.4); border-color: rgba(251,191,36,0.5); color: #1a1a1a; }
+.session-agent-badge[data-agent="family-knowledge"] { background: rgba(244,114,182,0.4); border-color: rgba(244,114,182,0.5); }
+.session-agent-badge[data-agent="smarthome"]    { background: rgba(52,211,153,0.4); border-color: rgba(52,211,153,0.5); }
+.session-agent-badge[data-agent="wee-doc"]      { background: rgba(156,163,175,0.4); border-color: rgba(156,163,175,0.5); }
 
 /* Inline rename input */
 .session-rename-input {

--- a/webui/dist/app.js
+++ b/webui/dist/app.js
@@ -823,9 +823,13 @@ function renderSessionList() {
 
     const title   = s.title   || s.session_id;
     const preview = s.preview || '';
+    const agentName = s.agent || '';
+    const agentBadge = agentName
+      ? `<span class="session-agent-badge" data-agent="${escHtml(agentName)}" title="${escHtml(agentName)}">${escHtml(agentName)}</span>`
+      : '';
 
     item.innerHTML =
-      `<div class="session-title" title="Double-click to rename">${escHtml(title)}</div>` +
+      `<div class="session-title" title="Double-click to rename">${agentBadge}${escHtml(title)}</div>` +
       `<div class="session-preview">${escHtml(preview)}</div>` +
       `<button class="session-rename-btn" data-id="${escHtml(s.session_id)}" title="Rename">✏️</button>` +
       `<button class="session-delete-btn" data-id="${escHtml(s.session_id)}" title="Delete">✕</button>`;
@@ -865,15 +869,22 @@ function startInlineRename(item, sessionId, currentTitle) {
   input.value = currentTitle;
   input.maxLength = 120;
 
+  // Preserve the agent badge element before clearing title
+  const existingBadge = titleEl.querySelector('.session-agent-badge');
+  const badgeHtml = existingBadge ? existingBadge.outerHTML : '';
   titleEl.textContent = '';
   titleEl.appendChild(input);
   input.focus();
   input.select();
 
+  const _rebuildTitle = (text) => {
+    titleEl.innerHTML = badgeHtml + escHtml(text);
+  };
+
   const commitRename = async () => {
     const newTitle = input.value.trim();
     if (!newTitle || newTitle === currentTitle) {
-      titleEl.textContent = currentTitle;
+      _rebuildTitle(currentTitle);
       return;
     }
     try {
@@ -881,9 +892,9 @@ function startInlineRename(item, sessionId, currentTitle) {
       // Update local state
       const sess = STATE.sessions.find(s => s.session_id === sessionId);
       if (sess) sess.title = newTitle;
-      titleEl.textContent = newTitle;
+      _rebuildTitle(newTitle);
     } catch (err) {
-      titleEl.textContent = currentTitle;
+      _rebuildTitle(currentTitle);
       console.error('Rename failed:', err);
     }
   };

--- a/webui/dist/index.html
+++ b/webui/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" type="image/png" sizes="192x192" href="/static/icon-192.png" />
   <link rel="apple-touch-icon" href="/static/apple-touch-icon.png" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github-dark.min.css" />
-  <link rel="stylesheet" href="app.css?v=202604210051" />
-  <link rel="stylesheet" href="themes.css?v=202604210051" />
+  <link rel="stylesheet" href="app.css?v=202604270100" />
+  <link rel="stylesheet" href="themes.css?v=202604270100" />
 </head>
 <body>
   <!-- Auth overlay -->
@@ -757,7 +757,7 @@
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/highlight.min.js"></script>
-  <script src="app.js?v=202604210051" type="module"></script>
+  <script src="app.js?v=202604270100" type="module"></script>
 
     <!-- Skills slide-over panel (right side, below canvas) -->
     <aside id="skills-panel" class="skills-panel skills-hidden">


### PR DESCRIPTION
## Summary
- `HistoryManager.create_session()` now accepts and persists an `agent` parameter
- New `update_session_agent()` method keeps history in sync after `/agent set` commands
- Both `execute_session` and `stream_session` endpoints sync agent to history after each exchange
- Frontend `renderSessionList()` renders a color-coded badge (e.g. `[wee-dev]`) before each session title
- `startInlineRename()` preserves the agent badge during inline title editing
- 7 regression tests added (`tests/test_issue248_agent_name_in_session_list.py`)

## Agent color coding
- `orchestrator` → green
- `wee-dev` → blue
- `wee-qa` → orange
- `email-triage` → purple
- `research` → cyan
- `devops` → yellow
- `family-knowledge` → pink
- `smarthome` → teal
- `wee-doc` → gray
- unknown → indigo

## Test plan
- [ ] Open WebUI at https://192.168.1.100:8001
- [ ] Create a new session — confirm no agent badge shows (no agent set yet)
- [ ] Run `/agent set wee-dev` — send a message, reload session list — confirm `wee-dev` badge appears
- [ ] Run `/agent set orchestrator` — send a message — confirm badge updates to `orchestrator`
- [ ] Rename a session — confirm badge is preserved after rename
- [ ] Verify mobile viewport renders correctly
- [ ] All 7 regression tests pass: `python3 -m pytest tests/test_issue248_agent_name_in_session_list.py -v`

Closes #248