### PR TITLE
feat(#249): auto-apply agent runtime/model defaults on switch

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -28,20 +28,28 @@ SCRIPT_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 # ── Theme constants (F025) ──────────────────────────────────────────────
 _BUILTIN_THEMES = [
     {
-        "name": "emerald", "label": "Emerald",
-        "description": "Default glassmorphism", "builtin": True,
+        "name": "emerald",
+        "label": "Emerald",
+        "description": "Default glassmorphism",
+        "builtin": True,
     },
     {
-        "name": "midnight", "label": "Midnight",
-        "description": "Deep blue ocean", "builtin": True,
+        "name": "midnight",
+        "label": "Midnight",
+        "description": "Deep blue ocean",
+        "builtin": True,
     },
     {
-        "name": "sunrise", "label": "Sunrise",
-        "description": "Warm light mode", "builtin": True,
+        "name": "sunrise",
+        "label": "Sunrise",
+        "description": "Warm light mode",
+        "builtin": True,
     },
     {
-        "name": "cyberpunk", "label": "Cyberpunk",
-        "description": "Neon pink & cyan", "builtin": True,
+        "name": "cyberpunk",
+        "label": "Cyberpunk",
+        "description": "Neon pink & cyan",
+        "builtin": True,
     },
 ]
 _THEME_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$")
@@ -82,6 +90,7 @@ _CURL_USER_RE = re.compile(
     r"""(-u\s+)(\S+)""",
 )
 
+
 def _sanitize_command_for_display(text: str) -> str:
     """Redact sensitive headers and credentials from command strings for UI display.
 
@@ -109,6 +118,7 @@ def _sanitize_command_for_display(text: str) -> str:
     # curl -u user:password
     text = _CURL_USER_RE.sub(r"\1[REDACTED]", text)
     return text
+
 
 def _sanitize_tool_call_for_display(data: dict) -> dict:
     """Return a shallow copy of a tool_call event dict with sensitive
@@ -181,6 +191,7 @@ class RateLimiter:
                         del self.records[ip][ep]
                 if not self.records[ip]:
                     del self.records[ip]
+
 
 class AuthManager:
     """Manages pairing codes, session tokens, and shared key validation."""
@@ -329,13 +340,25 @@ class AuthManager:
                     del self.session_tokens[token]
         self._save_sessions()
 
+
 _FALLBACK_PATTERNS = [
-    r"429", r"rate.?limit", r"quota.?exceeded",
-    r"401", r"unauthorized", r"missing.?authentication",
+    r"429",
+    r"rate.?limit",
+    r"quota.?exceeded",
+    r"401",
+    r"unauthorized",
+    r"missing.?authentication",
     r"api[_\-]?key.?(invalid|expired|missing)",
-    r"503", r"service.?unavailable", r"502", r"bad.?gateway",
-    r"connection.?refused", r"timed?.?out", r"etimedout", r"overloaded",
+    r"503",
+    r"service.?unavailable",
+    r"502",
+    r"bad.?gateway",
+    r"connection.?refused",
+    r"timed?.?out",
+    r"etimedout",
+    r"overloaded",
 ]
+
 
 class BackgroundTaskManager:
     """Manages background task lifecycle: creation, tracking, output capture, cleanup."""
@@ -499,9 +522,7 @@ class BackgroundTaskManager:
         if not origin_session_id:
             return
         with self._bg_events_lock:
-            self._bg_events.setdefault(
-                origin_session_id, []
-            ).append(event)
+            self._bg_events.setdefault(origin_session_id, []).append(event)
 
     def pop_bg_events(self, session_id):
         """Return and clear pending bg-task events."""
@@ -558,7 +579,9 @@ class BackgroundTaskManager:
                     break
             self._save(tasks)
 
-    def mark_fallback_used(self, task_id: str, fallback_runtime: str, fallback_model: str):
+    def mark_fallback_used(
+        self, task_id: str, fallback_runtime: str, fallback_model: str
+    ):
         """Record that a task retried on a fallback runtime."""
         self.update_task(
             task_id,
@@ -644,7 +667,6 @@ class BackgroundTaskManager:
             if len(kept) < len(tasks):
                 self._save(kept)
 
-
     def reconcile_stale_tasks(self) -> dict:
         """Reconcile orphaned tasks after a service restart.
 
@@ -720,6 +742,7 @@ class BackgroundTaskManager:
         except OSError:
             pass
 
+
 # Executable resolution
 def find_executable(name: str) -> Optional[str]:
     """Find executable in multiple common locations
@@ -755,64 +778,68 @@ def find_executable(name: str) -> Optional[str]:
 
     return None
 
+
 # Environment-based configuration
 def get_default_agent() -> str:
     """Get default agent from environment or use orchestrator"""
     return os.environ.get("COPILOT_DEFAULT_AGENT", "orchestrator")
 
+
 def get_default_model() -> str:
     """Get default model from environment or use gpt-5-mini"""
     return os.environ.get("COPILOT_DEFAULT_MODEL", "gpt-5-mini")
+
 
 def get_default_runtime() -> str:
     """Get default runtime from environment or use copilot"""
     return os.environ.get("COPILOT_DEFAULT_RUNTIME", "copilot")
 
+
 def check_runtime_available(runtime: str) -> bool:
     """Check if a runtime is available on the system.
-    
+
     Args:
         runtime: Runtime ID (e.g., 'copilot', 'claude', 'copilot-sdk')
-    
+
     Returns:
         True if the runtime is available, False otherwise
     """
     # Map runtime IDs to their executable/module names
     runtime_map = {
-        'copilot': 'copilot',
-        'copilot-sdk': 'copilot',  # Python package
-        'claude': 'claude',
-        'claude-sdk': 'claude-sdk',  # Python package
-        'gemini': 'gemini',
-        'codex': 'codex',
-        'devin': 'devin',
-        'cursor': 'agent',  # Cursor uses 'agent' binary
-        'opencode': 'opencode',
-        'wee': 'openai',  # OpenAI-compatible API (no binary needed),
+        "copilot": "copilot",
+        "copilot-sdk": "copilot",  # Python package
+        "claude": "claude",
+        "claude-sdk": "claude-sdk",  # Python package
+        "gemini": "gemini",
+        "codex": "codex",
+        "devin": "devin",
+        "cursor": "agent",  # Cursor uses 'agent' binary
+        "opencode": "opencode",
+        "wee": "openai",  # OpenAI-compatible API (no binary needed),
     }
-    
+
     executable_name = runtime_map.get(runtime)
     if not executable_name:
         return False
-    
+
     # For Python packages (SDK runtimes), try importing
-    if runtime in ('copilot-sdk', 'claude-sdk', 'wee'):
+    if runtime in ("copilot-sdk", "claude-sdk", "wee"):
         try:
-            if runtime == 'claude-sdk':
+            if runtime == "claude-sdk":
                 # Package is installed as claude_agent_sdk
-                __import__('claude_agent_sdk')
+                __import__("claude_agent_sdk")
             else:
-                module_name = executable_name.replace('-', '_')
+                module_name = executable_name.replace("-", "_")
                 __import__(module_name)
             return True
         except ImportError:
             return False
-    
+
     # For CLI runtimes, check if executable exists
     # First try system PATH
     if shutil.which(executable_name):
         return True
-    
+
     # Search additional common locations
     search_paths = [
         Path.home() / ".local" / "bin" / executable_name,
@@ -820,16 +847,17 @@ def check_runtime_available(runtime: str) -> bool:
         Path("/usr/local/bin") / executable_name,
         Path("/usr/bin") / executable_name,
     ]
-    
+
     for path in search_paths:
         if path.exists() and path.is_file():
             return True
-    
+
     return False
+
 
 def get_available_runtimes() -> List[Dict[str, str]]:
     """Get list of available runtimes on this system.
-    
+
     Returns:
         List of runtime dicts with 'id' and 'label' keys
     """
@@ -845,9 +873,10 @@ def get_available_runtimes() -> List[Dict[str, str]]:
         {"id": "cursor", "label": "cursor", "icon": "🖱️"},
         {"id": "wee", "label": "wee", "icon": "🌿"},
     ]
-    
-    available = [rt for rt in all_runtimes if check_runtime_available(rt['id'])]
+
+    available = [rt for rt in all_runtimes if check_runtime_available(rt["id"])]
     return available
+
 
 def get_command_timeout() -> int:
     """Get command execution timeout from environment or use default 300 seconds"""
@@ -868,6 +897,7 @@ def get_command_timeout() -> int:
             file=sys.stderr,
         )
 
+
 def get_bg_command_timeout() -> int:
     """Get background task timeout from environment or use default 900 seconds (15 minutes)"""
     try:
@@ -878,6 +908,7 @@ def get_bg_command_timeout() -> int:
         return timeout
     except ValueError:
         return 900
+
 
 def estimate_background_timeout(prompt: str, default: int = 900) -> int:
     """Estimate an appropriate timeout for a background task based on the prompt.
@@ -958,6 +989,7 @@ def estimate_background_timeout(prompt: str, default: int = 900) -> int:
             return 120  # 2 min
 
     return default
+
 
 class HistoryManager:
     """Persists per-user chat history in ~/.copilot/chat-history.json."""
@@ -1311,6 +1343,7 @@ class RuntimeUsageTracker:
             "period": month,
             "source": "unavailable",
         }
+
 
 class SessionManager:
     """Manages AI CLI sessions (Copilot & OpenCode) for N8N integration"""
@@ -1677,23 +1710,45 @@ class SessionManager:
         register it below.
         """
         self._register_slash("/help", self._slash_help, "Show available commands")
-        self._register_slash("/status", self._slash_status, "Check status of running query")
-        self._register_slash("/cancel", self._slash_cancel, "Cancel running query")
-        self._register_slash("/capabilities", self._slash_capabilities, "Show agent capabilities")
-        self._register_slash("/runtime", self._slash_runtime, "Manage runtime (list/set/current)")
-        self._register_slash("/agent", self._slash_agent, "Manage agent (list/set/current/invoke)")
-        self._register_slash("/model", self._slash_model, "Manage model (list/set/current)")
-        self._register_slash("/session", self._slash_session, "Manage session (list/reset/info)")
-        self._register_slash("/timeout", self._slash_timeout, "Get/set execution timeout")
-        self._register_slash("/render", self._slash_render, "Get/set output render format")
-        self._register_slash("/notifications", self._slash_notifications, "Toggle background notifications")
-        self._register_slash("/silent", self._slash_silent, "Toggle silent mode (hide tool calls)")
         self._register_slash(
-            "/verbose", self._slash_verbose, "Toggle verbose mode"
+            "/status", self._slash_status, "Check status of running query"
         )
+        self._register_slash("/cancel", self._slash_cancel, "Cancel running query")
+        self._register_slash(
+            "/capabilities", self._slash_capabilities, "Show agent capabilities"
+        )
+        self._register_slash(
+            "/runtime", self._slash_runtime, "Manage runtime (list/set/current)"
+        )
+        self._register_slash(
+            "/agent", self._slash_agent, "Manage agent (list/set/current/invoke)"
+        )
+        self._register_slash(
+            "/model", self._slash_model, "Manage model (list/set/current)"
+        )
+        self._register_slash(
+            "/session", self._slash_session, "Manage session (list/reset/info)"
+        )
+        self._register_slash(
+            "/timeout", self._slash_timeout, "Get/set execution timeout"
+        )
+        self._register_slash(
+            "/render", self._slash_render, "Get/set output render format"
+        )
+        self._register_slash(
+            "/notifications",
+            self._slash_notifications,
+            "Toggle background notifications",
+        )
+        self._register_slash(
+            "/silent", self._slash_silent, "Toggle silent mode (hide tool calls)"
+        )
+        self._register_slash("/verbose", self._slash_verbose, "Toggle verbose mode")
         self._register_slash("/mode", self._slash_mode, "Set permission mode")
         self._register_slash("/schedule", self._slash_schedule, "Manage scheduled jobs")
-        self._register_slash("/background", self._slash_background, "Manage background tasks")
+        self._register_slash(
+            "/background", self._slash_background, "Manage background tasks"
+        )
         self._register_slash("/update", self._slash_update, "Pull latest and restart")
         self._register_slash("/upgrade", self._slash_update, "Pull latest and restart")
         self._register_slash("/pull", self._slash_update, "Pull latest and restart")
@@ -1760,13 +1815,9 @@ class SessionManager:
                 return "\U0001f510 **Secrets:** (none)"
             try:
                 data = json.loads(output)
-                names = (
-                    data if isinstance(data, list) else data.get("names", [])
-                )
+                names = data if isinstance(data, list) else data.get("names", [])
             except json.JSONDecodeError:
-                names = [
-                    ln.strip() for ln in output.splitlines() if ln.strip()
-                ]
+                names = [ln.strip() for ln in output.splitlines() if ln.strip()]
             if not names:
                 return "\U0001f510 **Secrets:** (none)"
             lines = ["\U0001f510 **Stored Secrets:**\n"]
@@ -2208,9 +2259,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             return out
 
         elif argument == "current":
-            return (
-                f"Current Model: `{session_data.get('model')}` ({current_runtime})"
-            )
+            return f"Current Model: `{session_data.get('model')}` ({current_runtime})"
         elif argument.startswith("set "):
             model_name = argument[4:].strip().strip('"')
             model_id = self.get_model_from_name(model_name, effective_rt)
@@ -2293,9 +2342,7 @@ You can mention an agent in your prompt and it will auto-delegate:
                 self.update_session_field(
                     n8n_session_id, "timeout", str(timeout_seconds)
                 )
-                return (
-                    f"✓ Timeout set to `{timeout_seconds}` seconds for this session"
-                )
+                return f"✓ Timeout set to `{timeout_seconds}` seconds for this session"
             except ValueError:
                 return f"❌ Invalid timeout value '{timeout_str}'. Please provide a number (30-600 seconds)"
         else:
@@ -2353,9 +2400,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             return f"🔔 **Background Notifications:** `{status}`"
 
         elif argument in ["on", "all"]:
-            self.update_session_field(
-                n8n_session_id, "notification_preference", "all"
-            )
+            self.update_session_field(n8n_session_id, "notification_preference", "all")
             if self._notification_mgr:
                 # Store under specific identity if available
                 if _notif_identity:
@@ -2363,25 +2408,21 @@ You can mention an agent in your prompt and it will auto-delegate:
                         _notif_identity, _notif_channel, "all"
                     )
                 # Always store global preference so it applies across all channels
-                self._notification_mgr.set_user_pref(
-                    "_global", _notif_channel, "all"
-                )
+                self._notification_mgr.set_user_pref("_global", _notif_channel, "all")
             return "✓ Background task notifications enabled for Telegram/WebEx."
 
         elif argument in ["off", "mute"]:
-            self.update_session_field(
-                n8n_session_id, "notification_preference", "off"
-            )
+            self.update_session_field(n8n_session_id, "notification_preference", "off")
             if self._notification_mgr:
                 if _notif_identity:
                     self._notification_mgr.set_user_pref(
                         _notif_identity, _notif_channel, "off"
                     )
                 # Always store global preference so it applies across all channels
-                self._notification_mgr.set_user_pref(
-                    "_global", _notif_channel, "off"
-                )
-            return "✓ Background task notifications muted for Telegram/WebEx (WebUI only)."
+                self._notification_mgr.set_user_pref("_global", _notif_channel, "off")
+            return (
+                "✓ Background task notifications muted for Telegram/WebEx (WebUI only)."
+            )
         else:
             return "Usage: `/notifications [on|off]` to toggle background task notifications."
 
@@ -2482,9 +2523,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             _cur_perms["mode"] = "restricted"
             self.update_session_field(n8n_session_id, "permissions", _cur_perms)
             self.update_session_field(n8n_session_id, "yolo_mode", "restricted")
-            return (
-                "\u2713 Restricted mode enabled \U0001f512 - normal prompts enabled"
-            )
+            return "\u2713 Restricted mode enabled \U0001f512 - normal prompts enabled"
 
         elif argument == "sandboxed":
             _cur_perms = session_data.get("permissions", {})
@@ -2853,7 +2892,9 @@ You can mention an agent in your prompt and it will auto-delegate:
             try:
                 with open(_log_path) as f:
                     tail = f.readlines()[-30:]
-                return f"📋 **Last update log** (`{_log_path}`):\n```\n{''.join(tail)}```"
+                return (
+                    f"📋 **Last update log** (`{_log_path}`):\n```\n{''.join(tail)}```"
+                )
             except FileNotFoundError:
                 return "ℹ️ No update log found. No update has been run yet."
             except Exception as e:
@@ -3349,7 +3390,6 @@ You can mention an agent in your prompt and it will auto-delegate:
             print(f"Error fetching opencode models: {e}", file=sys.stderr)
             return self._static_models_to_dict(self.OPENCODE_MODELS)
 
-
     # Curated popular OpenRouter model IDs for auto-discovery filtering
     OPENROUTER_POPULAR_MODELS = {
         "meta-llama/llama-4-maverick",
@@ -3376,23 +3416,71 @@ You can mention an agent in your prompt and it will auto-delegate:
         "Wee Native (Ollama)": [
             ("ollama/gemma4:e4b", "Ollama Gemma 4 E4B (local)", ["gemma4", "gemma"]),
             ("ollama/qwen3", "Ollama Qwen 3 (local)", ["qwen3", "qwen"]),
-            ("ollama/granite3.3-tuned", "Ollama Granite 3.3 Tuned (local)", ["granite", "granite3.3"]),
+            (
+                "ollama/granite3.3-tuned",
+                "Ollama Granite 3.3 Tuned (local)",
+                ["granite", "granite3.3"],
+            ),
         ],
         "Wee Native (OpenRouter)": [
-            ("openrouter/meta-llama/llama-4-maverick", "Llama 4 Maverick via OpenRouter", ["llama-4-maverick", "maverick"]),
-            ("openrouter/meta-llama/llama-4-scout", "Llama 4 Scout via OpenRouter", ["llama-4-scout", "scout"]),
-            ("openrouter/anthropic/claude-sonnet-4.6", "Claude Sonnet 4.6 via OpenRouter", ["or-claude-sonnet"]),
-            ("openrouter/google/gemini-3.1-flash-lite-preview", "Gemini 3.1 Flash Lite via OpenRouter", ["or-gemini-flash"]),
+            (
+                "openrouter/meta-llama/llama-4-maverick",
+                "Llama 4 Maverick via OpenRouter",
+                ["llama-4-maverick", "maverick"],
+            ),
+            (
+                "openrouter/meta-llama/llama-4-scout",
+                "Llama 4 Scout via OpenRouter",
+                ["llama-4-scout", "scout"],
+            ),
+            (
+                "openrouter/anthropic/claude-sonnet-4.6",
+                "Claude Sonnet 4.6 via OpenRouter",
+                ["or-claude-sonnet"],
+            ),
+            (
+                "openrouter/google/gemini-3.1-flash-lite-preview",
+                "Gemini 3.1 Flash Lite via OpenRouter",
+                ["or-gemini-flash"],
+            ),
             ("openrouter/openai/gpt-4.1", "GPT-4.1 via OpenRouter", ["or-gpt-4.1"]),
-            ("openrouter/deepseek/deepseek-v3.2", "DeepSeek V3.2 via OpenRouter", ["or-deepseek"]),
+            (
+                "openrouter/deepseek/deepseek-v3.2",
+                "DeepSeek V3.2 via OpenRouter",
+                ["or-deepseek"],
+            ),
         ],
         "Wee Native (OpenRouter Free)": [
-            ("openrouter/google/gemma-3-27b-it:free", "Gemma 3 27B FREE via OpenRouter", ["gemma-3-free", "gemma-free"]),
-            ("openrouter/google/gemma-4-31b-it:free", "Gemma 4 31B FREE via OpenRouter", ["gemma-4-free"]),
-            ("openrouter/meta-llama/llama-3.3-70b-instruct:free", "Llama 3.3 70B FREE via OpenRouter", ["llama-free"]),
-            ("openrouter/nvidia/nemotron-3-super-120b-a12b:free", "Nemotron 3 Super 120B FREE via OpenRouter", ["nemotron-free"]),
-            ("openrouter/nvidia/nemotron-nano-9b-v2:free", "Nemotron Nano 9B FREE via OpenRouter", ["nemotron-nano-free"]),
-            ("openrouter/qwen/qwen3-coder:free", "Qwen3 Coder FREE via OpenRouter", ["qwen3-free", "qwen-free"]),
+            (
+                "openrouter/google/gemma-3-27b-it:free",
+                "Gemma 3 27B FREE via OpenRouter",
+                ["gemma-3-free", "gemma-free"],
+            ),
+            (
+                "openrouter/google/gemma-4-31b-it:free",
+                "Gemma 4 31B FREE via OpenRouter",
+                ["gemma-4-free"],
+            ),
+            (
+                "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+                "Llama 3.3 70B FREE via OpenRouter",
+                ["llama-free"],
+            ),
+            (
+                "openrouter/nvidia/nemotron-3-super-120b-a12b:free",
+                "Nemotron 3 Super 120B FREE via OpenRouter",
+                ["nemotron-free"],
+            ),
+            (
+                "openrouter/nvidia/nemotron-nano-9b-v2:free",
+                "Nemotron Nano 9B FREE via OpenRouter",
+                ["nemotron-nano-free"],
+            ),
+            (
+                "openrouter/qwen/qwen3-coder:free",
+                "Qwen3 Coder FREE via OpenRouter",
+                ["qwen3-free", "qwen-free"],
+            ),
         ],
     }
 
@@ -3620,7 +3708,6 @@ You can mention an agent in your prompt and it will auto-delegate:
 
         return self._static_models_to_dict(self.CURSOR_MODELS)
 
-
     def fetch_wee_models(self) -> Dict:
         """Return available wee models: local Ollama + OpenRouter cloud models.
 
@@ -3649,6 +3736,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             api_key = None
             try:
                 import keyring
+
                 api_key = keyring.get_password("openrouter", "api_key")
             except Exception:
                 pass
@@ -3656,10 +3744,13 @@ You can mention an agent in your prompt and it will auto-delegate:
                 api_key = os.environ.get("OPENROUTER_API_KEY")
 
             if not api_key:
-                print("[wee] No OpenRouter API key -- using static list", file=sys.stderr)
+                print(
+                    "[wee] No OpenRouter API key -- using static list", file=sys.stderr
+                )
                 return self._static_models_to_dict(self.WEE_MODELS)
 
             import urllib.request
+
             req = urllib.request.Request(
                 "https://openrouter.ai/api/v1/models",
                 headers={"Authorization": "Bearer " + api_key},
@@ -3883,11 +3974,23 @@ You can mention an agent in your prompt and it will auto-delegate:
                     merged["model"] = os.getenv("CURSOR_DEFAULT_MODEL", "auto")
             elif runtime == "wee":
                 if not merged.get("model"):
-                    merged["model"] = os.getenv("WEE_DEFAULT_MODEL", "ollama/gemma4:e4b")
+                    merged["model"] = os.getenv(
+                        "WEE_DEFAULT_MODEL", "ollama/gemma4:e4b"
+                    )
 
             # Validate and fix session_id if corrupted
             session_id = merged.get("session_id", "")
-            if runtime in ["claude", "claude-sdk", "gemini", "codex", "copilot", "copilot-sdk", "devin", "cursor", "wee"]:
+            if runtime in [
+                "claude",
+                "claude-sdk",
+                "gemini",
+                "codex",
+                "copilot",
+                "copilot-sdk",
+                "devin",
+                "cursor",
+                "wee",
+            ]:
                 if not session_id or not (len(session_id) == 36 and "-" in session_id):
                     merged["session_id"] = str(uuid4())
             elif runtime == "opencode":
@@ -4118,7 +4221,6 @@ You can mention an agent in your prompt and it will auto-delegate:
             available = ", ".join(self.AGENTS.keys())
             return f"Unknown agent: '{agent}'. Available agents: {available}"
 
-
         # Get agent's primary runtime/model defaults (issue #249)
         agent_config = self.AGENTS[agent]
         primary_runtime = agent_config.get("primary_runtime") or "copilot"
@@ -4329,7 +4431,9 @@ You can mention an agent in your prompt and it will auto-delegate:
         """
         if prompt_mode != "restricted":
             return prompt_mode
-        perms = session_data.get("permissions") or {}  # Handle None from session template
+        perms = (
+            session_data.get("permissions") or {}
+        )  # Handle None from session template
         if isinstance(perms, dict) and perms.get("mode") in (
             "elevated",
             "restricted",
@@ -5493,17 +5597,14 @@ Do NOT emit status updates for quick operations (< 15 seconds)."""
             _session_data = self.load_session_data(n8n_session_id)
             if not (_session_data or {}).get("memory_injected"):
                 from memory.inject import get_memory_context
+
                 agent_info_mem = self.AGENTS.get(
                     agent, self.AGENTS.get("orchestrator", {})
                 )
-                _mem_ctx = get_memory_context(
-                    agent_path=agent_info_mem.get("path", "")
-                )
+                _mem_ctx = get_memory_context(agent_path=agent_info_mem.get("path", ""))
                 if _mem_ctx:
                     memory_section = f"\n\n{_mem_ctx}\n"
-                    self.update_session_field(
-                        n8n_session_id, "memory_injected", True
-                    )
+                    self.update_session_field(n8n_session_id, "memory_injected", True)
                     print(
                         f"[Memory] Injected {len(_mem_ctx)} chars for "
                         f"session={n8n_session_id} agent={agent}",
@@ -5511,9 +5612,7 @@ Do NOT emit status updates for quick operations (< 15 seconds)."""
                     )
                 else:
                     # No memory files — still mark as injected
-                    self.update_session_field(
-                        n8n_session_id, "memory_injected", True
-                    )
+                    self.update_session_field(n8n_session_id, "memory_injected", True)
         except Exception as _mem_exc:
             print(
                 f"[Memory] Injection skipped: {_mem_exc}",
@@ -6117,7 +6216,12 @@ User Request:
                                                 "name": "shell",
                                                 "input": _oc_run.group(1).strip(),
                                             }
-                                elif runtime in ("copilot", "copilot-sdk", "claude-sdk", "wee"):
+                                elif runtime in (
+                                    "copilot",
+                                    "copilot-sdk",
+                                    "claude-sdk",
+                                    "wee",
+                                ):
                                     # Copilot shows tool calls as "● Description" and shell cmds as "  $ cmd"
                                     import re as _re_tc
 
@@ -6550,7 +6654,7 @@ User Request:
 
         # Expand home path for MCP config file
         mcp_config_path = os.path.expanduser("~/.copilot/mcp-config.json")
-        
+
         cmd = [
             self.copilot_bin,
             "-p",
@@ -6696,7 +6800,9 @@ User Request:
         async def _run_sdk() -> str:
             collected_messages: list = []
 
-            _sdk_config = SubprocessConfig(cli_args=sdk_cli_args) if sdk_cli_args else None
+            _sdk_config = (
+                SubprocessConfig(cli_args=sdk_cli_args) if sdk_cli_args else None
+            )
             _client = CopilotClient(_sdk_config) if _sdk_config else CopilotClient()
             async with _client as client:
                 # Event handler — streams chunks and detects tool calls
@@ -6730,15 +6836,25 @@ User Request:
                         tool_name = "tool"
                         tool_input = ""
                         if hasattr(event, "data"):
-                            tool_name = getattr(event.data, "name", None) or getattr(event.data, "tool_name", None) or "tool"
-                            tool_input = str(getattr(event.data, "input", "") or getattr(event.data, "arguments", "") or "")
+                            tool_name = (
+                                getattr(event.data, "name", None)
+                                or getattr(event.data, "tool_name", None)
+                                or "tool"
+                            )
+                            tool_input = str(
+                                getattr(event.data, "input", "")
+                                or getattr(event.data, "arguments", "")
+                                or ""
+                            )
                         tc_evt = {
                             "event": "started",
                             "id": f"tc_copilot-sdk_{_tool_call_counter[0]}",
                             "name": str(tool_name),
                             "input": tool_input[:200],
                             "runtime": "copilot-sdk",
-                            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                            "timestamp": time.strftime(
+                                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                            ),
                         }
                         if stream_buffer:
                             stream_buffer.push("tool_call", tc_evt)
@@ -6746,14 +6862,20 @@ User Request:
                     elif event.type == SessionEventType.TOOL_EXECUTION_COMPLETE:
                         tool_name = "tool"
                         if hasattr(event, "data"):
-                            tool_name = getattr(event.data, "name", None) or getattr(event.data, "tool_name", None) or "tool"
+                            tool_name = (
+                                getattr(event.data, "name", None)
+                                or getattr(event.data, "tool_name", None)
+                                or "tool"
+                            )
                         tc_evt = {
                             "event": "completed",
                             "id": f"tc_copilot-sdk_{_tool_call_counter[0]}",
                             "name": str(tool_name),
                             "input": "",
                             "runtime": "copilot-sdk",
-                            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                            "timestamp": time.strftime(
+                                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                            ),
                         }
                         if stream_buffer:
                             stream_buffer.push("tool_call", tc_evt)
@@ -6762,14 +6884,20 @@ User Request:
                         _tool_call_counter[0] += 1
                         cmd_text = ""
                         if hasattr(event, "data"):
-                            cmd_text = str(getattr(event.data, "command", "") or getattr(event.data, "text", "") or event.data)
+                            cmd_text = str(
+                                getattr(event.data, "command", "")
+                                or getattr(event.data, "text", "")
+                                or event.data
+                            )
                         tc_evt = {
                             "event": "detected",
                             "id": f"tc_copilot-sdk_{_tool_call_counter[0]}",
                             "name": "shell",
                             "input": cmd_text[:200],
                             "runtime": "copilot-sdk",
-                            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                            "timestamp": time.strftime(
+                                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                            ),
                         }
                         if stream_buffer:
                             stream_buffer.push("tool_call", tc_evt)
@@ -6905,24 +7033,21 @@ User Request:
         """
         try:
             from claude_agent_sdk import (
-                query as claude_sdk_query,
-                ClaudeAgentOptions,
                 AssistantMessage,
-                TextBlock,
+                ClaudeAgentOptions,
                 ResultMessage,
-                ToolUseBlock,
+                TextBlock,
                 ToolResultBlock,
+                ToolUseBlock,
             )
+            from claude_agent_sdk import query as claude_sdk_query
         except ImportError:
-            return (
-                "Error: claude-sdk not installed. "
-                "Run: pip install claude-sdk"
-            )
+            return "Error: claude-sdk not installed. " "Run: pip install claude-sdk"
 
         import asyncio
-
         import io
         import sys
+
         # Parse mode
         if mode is None:
             prompt_parsed, mode = self._parse_mode_command(prompt)
@@ -7019,29 +7144,43 @@ User Request:
                                 _tool_call_counter[0] += 1
                                 tc_evt = {
                                     "event": "detected",
-                                    "id": block.id or f"tc_claude-sdk_{_tool_call_counter[0]}",
+                                    "id": block.id
+                                    or f"tc_claude-sdk_{_tool_call_counter[0]}",
                                     "name": block.name or "tool",
-                                    "input": str(block.input)[:200] if block.input else "",
+                                    "input": (
+                                        str(block.input)[:200] if block.input else ""
+                                    ),
                                     "runtime": "claude-sdk",
-                                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                                    "timestamp": time.strftime(
+                                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                                    ),
                                 }
                                 if stream_buffer:
                                     stream_buffer.push("tool_call", tc_evt)
                             elif isinstance(block, ToolResultBlock):
                                 tc_evt = {
                                     "event": "completed",
-                                    "id": block.tool_use_id or f"tc_claude-sdk_{_tool_call_counter[0]}",
+                                    "id": block.tool_use_id
+                                    or f"tc_claude-sdk_{_tool_call_counter[0]}",
                                     "name": "tool",
-                                    "input": str(block.content)[:200] if block.content else "",
+                                    "input": (
+                                        str(block.content)[:200]
+                                        if block.content
+                                        else ""
+                                    ),
                                     "is_error": getattr(block, "is_error", False),
                                     "runtime": "claude-sdk",
-                                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                                    "timestamp": time.strftime(
+                                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                                    ),
                                 }
                                 if stream_buffer:
                                     stream_buffer.push("tool_call", tc_evt)
                     elif isinstance(message, ResultMessage):
                         if message.session_id:
-                            self.update_session_field(n8n_session_id, "session_id", message.session_id)
+                            self.update_session_field(
+                                n8n_session_id, "session_id", message.session_id
+                            )
                     elif hasattr(message, "content"):
                         for block in getattr(message, "content", []):
                             if hasattr(block, "text"):
@@ -7087,10 +7226,11 @@ User Request:
 
             if loop and loop.is_running():
                 import concurrent.futures
+
                 with concurrent.futures.ThreadPoolExecutor() as pool:
-                    output = pool.submit(
-                        asyncio.run, _run_sdk()
-                    ).result(timeout=effective_timeout)
+                    output = pool.submit(asyncio.run, _run_sdk()).result(
+                        timeout=effective_timeout
+                    )
             else:
                 output = asyncio.run(_run_sdk())
         except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
@@ -7788,10 +7928,7 @@ User Request:
         try:
             from openai import OpenAI
         except ImportError:
-            return (
-                "Error: openai package not installed. "
-                "Run: pip install openai"
-            )
+            return "Error: openai package not installed. " "Run: pip install openai"
 
         session_data = self.get_or_create_session_data(n8n_session_id)
         agent_dir = self.AGENTS.get(agent, self.AGENTS["orchestrator"])["path"]
@@ -7799,12 +7936,8 @@ User Request:
         channel = session_data.get("channel", "webui")
 
         # -- Resolve model, endpoint, and API key --
-        api_base = session_data.get("api_base") or os.environ.get(
-            "WEE_API_BASE"
-        )
-        api_key = session_data.get("api_key") or os.environ.get(
-            "WEE_API_KEY"
-        )
+        api_base = session_data.get("api_base") or os.environ.get("WEE_API_BASE")
+        api_key = session_data.get("api_key") or os.environ.get("WEE_API_KEY")
 
         # Provider presets
         _PRESETS = {
@@ -7816,7 +7949,7 @@ User Request:
         resolved_model = model
         for prefix, (preset_base, preset_key) in _PRESETS.items():
             if model.lower().startswith(f"{prefix}/"):
-                resolved_model = model[len(prefix) + 1:]
+                resolved_model = model[len(prefix) + 1 :]
                 if not api_base:
                     api_base = preset_base
                 if not api_key and preset_key:
@@ -7830,6 +7963,7 @@ User Request:
             if "openrouter" in api_base.lower():
                 try:
                     import keyring
+
                     api_key = keyring.get_password("openrouter", "api_key")
                 except Exception:
                     pass
@@ -7858,7 +7992,6 @@ User Request:
         # Issue #111: Augment system prompt with explicit tool capability section
         # so models that ignore JSON schemas still know tools are available.
         context_prompt = self._wee_augment_system_prompt_with_tools(base_context_prompt)
-
 
         # -- Streaming infrastructure --
         stream_buffer = getattr(self, "_stream_buffers", {}).get(n8n_session_id)
@@ -7964,11 +8097,14 @@ User Request:
                             if idx not in tool_calls_acc:
                                 _tool_call_counter += 1
                                 tool_calls_acc[idx] = {
-                                    "id": getattr(tc_delta, "id", None) or f"tc_wee_{_tool_call_counter}",
+                                    "id": getattr(tc_delta, "id", None)
+                                    or f"tc_wee_{_tool_call_counter}",
                                     "name": "",
                                     "arguments": "",
                                 }
-                            if tc_delta.id and not tool_calls_acc[idx]["id"].startswith("tc_wee_"):
+                            if tc_delta.id and not tool_calls_acc[idx]["id"].startswith(
+                                "tc_wee_"
+                            ):
                                 pass  # keep first real id
                             elif tc_delta.id:
                                 tool_calls_acc[idx]["id"] = tc_delta.id
@@ -7976,7 +8112,9 @@ User Request:
                                 if tc_delta.function.name:
                                     tool_calls_acc[idx]["name"] = tc_delta.function.name
                                 if tc_delta.function.arguments:
-                                    tool_calls_acc[idx]["arguments"] += tc_delta.function.arguments
+                                    tool_calls_acc[idx][
+                                        "arguments"
+                                    ] += tc_delta.function.arguments
 
                 content_text = "".join(round_content)
 
@@ -7996,14 +8134,16 @@ User Request:
                 assistant_tool_calls = []
                 for idx in sorted(tool_calls_acc.keys()):
                     tc = tool_calls_acc[idx]
-                    assistant_tool_calls.append({
-                        "id": tc["id"],
-                        "type": "function",
-                        "function": {
-                            "name": tc["name"],
-                            "arguments": tc["arguments"],
-                        },
-                    })
+                    assistant_tool_calls.append(
+                        {
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                    )
 
                 assistant_msg = {
                     "role": "assistant",
@@ -8054,21 +8194,28 @@ User Request:
                         stream_buffer.push("tool_call", tc_done_event)
 
                     # Append tool result to conversation for next round
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tc_id,
-                        "content": tool_result or "No output",
-                    })
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc_id,
+                            "content": tool_result or "No output",
+                        }
+                    )
 
             else:
                 # All MAX_TOOL_ROUNDS had tool calls with no final text
-                last_tool_results = [m["content"] for m in messages if m.get("role") == "tool"]
+                last_tool_results = [
+                    m["content"] for m in messages if m.get("role") == "tool"
+                ]
                 if last_tool_results:
                     collected_output.append(
-                        "Tool execution completed. Last result:\n" + last_tool_results[-1][:2000]
+                        "Tool execution completed. Last result:\n"
+                        + last_tool_results[-1][:2000]
                     )
                 else:
-                    collected_output.append("Max tool rounds reached without final response.")
+                    collected_output.append(
+                        "Max tool rounds reached without final response."
+                    )
 
             output = "".join(collected_output)
 
@@ -8141,7 +8288,10 @@ User Request:
                 if len(messages) > MAX_WEE_MESSAGES:
                     system_msgs = [m for m in messages if m.get("role") == "system"]
                     non_system = [m for m in messages if m.get("role") != "system"]
-                    saved = system_msgs + non_system[-(MAX_WEE_MESSAGES - len(system_msgs)):]
+                    saved = (
+                        system_msgs
+                        + non_system[-(MAX_WEE_MESSAGES - len(system_msgs)) :]
+                    )
                 else:
                     saved = list(messages)
                 # Strip tool_calls from assistant messages for JSON serialization
@@ -8151,15 +8301,29 @@ User Request:
                         mc = dict(m)
                         mc["tool_calls"] = [
                             {
-                                "id": tc.get("id", "") if isinstance(tc, dict) else getattr(tc, "id", ""),
+                                "id": (
+                                    tc.get("id", "")
+                                    if isinstance(tc, dict)
+                                    else getattr(tc, "id", "")
+                                ),
                                 "type": "function",
                                 "function": {
-                                    "name": (tc.get("function", {}).get("name", "")
-                                             if isinstance(tc, dict)
-                                             else getattr(getattr(tc, "function", None), "name", "")),
-                                    "arguments": (tc.get("function", {}).get("arguments", "")
-                                                  if isinstance(tc, dict)
-                                                  else getattr(getattr(tc, "function", None), "arguments", "")),
+                                    "name": (
+                                        tc.get("function", {}).get("name", "")
+                                        if isinstance(tc, dict)
+                                        else getattr(
+                                            getattr(tc, "function", None), "name", ""
+                                        )
+                                    ),
+                                    "arguments": (
+                                        tc.get("function", {}).get("arguments", "")
+                                        if isinstance(tc, dict)
+                                        else getattr(
+                                            getattr(tc, "function", None),
+                                            "arguments",
+                                            "",
+                                        )
+                                    ),
                                 },
                             }
                             for tc in m["tool_calls"]
@@ -8183,11 +8347,11 @@ User Request:
             "perform any action -- do NOT say you cannot do something that these tools enable.\n"
             "\n"
             "**bash** -- Execute a bash shell command and return its output.\n"
-            "  Call: bash tool with {\"command\": \"your shell command here\"}\n"
+            '  Call: bash tool with {"command": "your shell command here"}\n'
             "  Use for: running commands, SSH, file operations, checking system state\n"
             "\n"
             "**python** -- Execute Python 3 code and return its output.\n"
-            "  Call: python tool with {\"code\": \"your python code here\"}\n"
+            '  Call: python tool with {"code": "your python code here"}\n'
             "  Use for: data processing, calculations, scripting, file parsing\n"
             "\n"
             "CRITICAL: When asked to run a command, SSH somewhere, check system status,\n"
@@ -8528,11 +8692,7 @@ User Request:
             if self._bg_task_mgr:
                 self._bg_task_mgr.complete_task(task_id, result)
                 task_rec = self._bg_task_mgr.get_task(task_id)
-                o_sid = (
-                    task_rec.get("origin_session_id")
-                    if task_rec
-                    else None
-                )
+                o_sid = task_rec.get("origin_session_id") if task_rec else None
                 if o_sid:
                     self._bg_task_mgr.push_bg_event(
                         o_sid,
@@ -8552,11 +8712,7 @@ User Request:
             if self._bg_task_mgr:
                 self._bg_task_mgr.fail_task(task_id, str(exc))
                 task_rec = self._bg_task_mgr.get_task(task_id)
-                o_sid = (
-                    task_rec.get("origin_session_id")
-                    if task_rec
-                    else None
-                )
+                o_sid = task_rec.get("origin_session_id") if task_rec else None
                 if o_sid:
                     self._bg_task_mgr.push_bg_event(
                         o_sid,
@@ -8768,7 +8924,9 @@ User Request:
         effective_timeout = self.get_effective_timeout(session_data)
         render_type = self.get_render_type(session_data)
         # Get permission mode from session (backward compat with yolo_mode)
-        _perms = session_data.get("permissions") or {}  # Handle None from session template
+        _perms = (
+            session_data.get("permissions") or {}
+        )  # Handle None from session template
         if isinstance(_perms, dict) and _perms.get("mode") in (
             "elevated",
             "restricted",
@@ -8880,6 +9038,7 @@ User Request:
 
         return output
 
+
 def _check_command_result(result: str, error_keywords: List[str]) -> None:
     """Helper function to check command results and exit on error
 
@@ -8895,11 +9054,13 @@ def _check_command_result(result: str, error_keywords: List[str]) -> None:
             print(result, file=sys.stderr)
             sys.exit(1)
 
+
 # ---------------------------------------------------------------------------
 # FastAPI Application
 # ---------------------------------------------------------------------------
 
 _api_auth_manager: Optional["AuthManager"] = None
+
 
 def _send_pairing_code(channel: str, identity: str, code: str) -> bool:
     """Deliver a pairing code. Returns True on success, False on failure."""
@@ -8923,10 +9084,16 @@ def _send_pairing_code(channel: str, identity: str, code: str) -> bool:
                     return True
                 except Exception as _exc:
                     last_exc = _exc
-                    print(f"[API] Telegram send attempt {attempt}/3 failed: {_exc}", file=sys.stderr)
+                    print(
+                        f"[API] Telegram send attempt {attempt}/3 failed: {_exc}",
+                        file=sys.stderr,
+                    )
                     if attempt < 3:
                         time.sleep(2)
-            print(f"[API] All 3 Telegram send attempts failed: {last_exc}", file=sys.stderr)
+            print(
+                f"[API] All 3 Telegram send attempts failed: {last_exc}",
+                file=sys.stderr,
+            )
             return False
         elif channel == "webex":
             config_path = os.path.join(script_dir, "webex_config.json")
@@ -8966,6 +9133,7 @@ def _send_pairing_code(channel: str, identity: str, code: str) -> bool:
     except Exception as exc:  # noqa: BLE001
         print(f"[API] Warning: could not send pairing code via {channel}: {exc}")
 
+
 def _get_telegram_username(user_id: str):
     """Look up @username for a numeric Telegram user_id in telegram_config.json.
     Returns the username string (without @), or None if not found."""
@@ -8979,6 +9147,7 @@ def _get_telegram_username(user_id: str):
         return username.lstrip("@") if username else None
     except Exception:
         return None
+
 
 def _ddg_image_search(query: str, max_results: int = 4) -> list:
     """Fetch image results from DuckDuckGo without an API key.
@@ -9036,6 +9205,7 @@ def _ddg_image_search(query: str, max_results: int = 4) -> list:
     except Exception:
         return []
 
+
 def _resolve_telegram_identity(username: str):
     """Reverse-lookup @username in telegram_config.json user_pairings.
     Returns numeric user_id string, or None if not found (user must message bot first).
@@ -9051,6 +9221,7 @@ def _resolve_telegram_identity(username: str):
         return None
     except Exception:
         return None
+
 
 def _compute_bg_task_defaults(session_map, identity, channel):
     """Compute inheritable defaults from existing sessions for a new background task.
@@ -9116,7 +9287,10 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
     )
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import (
-        FileResponse, JSONResponse, Response, StreamingResponse
+        FileResponse,
+        JSONResponse,
+        Response,
+        StreamingResponse,
     )
     from fastapi.staticfiles import StaticFiles
     from pydantic import BaseModel, field_validator
@@ -9168,6 +9342,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
     session_mgr._bg_task_mgr = bg_task_mgr
     # Expose for testing/introspection (read-only reference)
     import sys as _sys
+
     _sys.modules[__name__]._session_mgr = session_mgr
     usage_tracker = RuntimeUsageTracker()
 
@@ -9389,9 +9564,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 raise ValueError("Query must be 10,000 characters or less")
             return v
 
-
     class QueryRequest(BaseModel):
         """One-shot query without session management."""
+
         prompt: str
         runtime: Optional[str] = None
         model: Optional[str] = None
@@ -9404,6 +9579,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             if len(v) > 10000:
                 raise ValueError("Prompt must be 10,000 characters or less")
             return v
+
     # ---- authentication dependency ----
     async def authenticate(
         request: Request,
@@ -9674,7 +9850,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         for name, svc in services.items():
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    "systemctl", "is-active", svc,
+                    "systemctl",
+                    "is-active",
+                    svc,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -9725,7 +9903,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
     @app.get("/api/v1/runtimes")
     async def get_runtimes():
         """Return list of available runtimes on this system.
-        
+
         Only runtimes that are actually installed/available are returned.
         This prevents the WebUI from showing runtimes that cannot be used.
         """
@@ -10046,9 +10224,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
         # Strip ANSI escape codes from runtime output (#68)
         _ansi_re = re.compile(
-            r"\x1b\[[0-9;]*[a-zA-Z]"
-            r"|\x1b\][^\x07]*\x07"
-            r"|\x1b\([A-Z0-9]"
+            r"\x1b\[[0-9;]*[a-zA-Z]" r"|\x1b\][^\x07]*\x07" r"|\x1b\([A-Z0-9]"
         )
         if result and isinstance(result, str):
             result = _ansi_re.sub("", result)
@@ -11112,15 +11288,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         description: Optional[str] = (
             None  # human-readable task name shown in Agents panel
         )
-        origin_session_id: Optional[str] = (
-            None  # chat session that initiated this task
-        )
-        fallback_runtime: Optional[str] = (
-            None  # runtime to retry with if primary fails
-        )
-        fallback_model: Optional[str] = (
-            None  # model to use with fallback runtime
-        )
+        origin_session_id: Optional[str] = None  # chat session that initiated this task
+        fallback_runtime: Optional[str] = None  # runtime to retry with if primary fails
+        fallback_model: Optional[str] = None  # model to use with fallback runtime
 
         @field_validator("prompt")
         @classmethod
@@ -11165,9 +11335,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             )
             # Push in-thread event to originating session
             task = bg_task_mgr.get_task(task_id)
-            origin_sid = (
-                task.get("origin_session_id") if task else None
-            )
+            origin_sid = task.get("origin_session_id") if task else None
             if origin_sid:
                 bg_task_mgr.push_bg_event(
                     origin_sid,
@@ -11175,11 +11343,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         "task_id": task_id,
                         "summary": prompt[:80],
                         "status": status,
-                        "agent": (
-                            task.get("agent", "")
-                            if task
-                            else ""
-                        ),
+                        "agent": (task.get("agent", "") if task else ""),
                         "timestamp": time.strftime(
                             "%Y-%m-%dT%H:%M:%SZ",
                             time.gmtime(),
@@ -11240,17 +11404,13 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                     f"[Command Mode] Run Now job {job_id} failed: exit code {result.returncode}"
                 )
         except _sp.TimeoutExpired:
-            bg_task_mgr.fail_task(
-                task_id, f"Command timed out after {timeout}s"
-            )
+            bg_task_mgr.fail_task(task_id, f"Command timed out after {timeout}s")
             logger.error(
                 f"[Command Mode] Run Now job {job_id} timed out after {timeout}s"
             )
         except Exception as e:
             bg_task_mgr.fail_task(task_id, str(e))
-            logger.error(
-                f"[Command Mode] Run Now job {job_id} exception: {e}"
-            )
+            logger.error(f"[Command Mode] Run Now job {job_id} exception: {e}")
 
         # Save result to scheduler logs/results for consistency
         try:
@@ -11265,9 +11425,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 error=(task_rec or {}).get("error", ""),
             )
             status_label = "succeeded" if success else "failed"
-            sched._log_job(
-                job_id, f"Run Now (command mode) {status_label}"
-            )
+            sched._log_job(job_id, f"Run Now (command mode) {status_label}")
         except Exception as exc:
             logger.warning(
                 f"[Command Mode] Could not save scheduler result for {job_id}: {exc}"
@@ -11608,7 +11766,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         _cmd.extend(["-m", eff_model])
                     _cmd.append(context_prompt)
                 elif eff_runtime == "claude":
-                    _claude_bin = session_mgr.claude_bin or _which_bin("claude") or "claude"
+                    _claude_bin = (
+                        session_mgr.claude_bin or _which_bin("claude") or "claude"
+                    )
                     _claude_perm = {
                         "elevated": "bypassPermissions",
                         "sandboxed": "plan",
@@ -11630,7 +11790,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         if hasattr(session_mgr, "devin_bin") and session_mgr.devin_bin
                         else (_which_bin("devin") or "devin")
                     )
-                    _devin_perm = "dangerous" if permission_mode == "elevated" else "auto"
+                    _devin_perm = (
+                        "dangerous" if permission_mode == "elevated" else "auto"
+                    )
                     _cmd = [_devin_bin, "-p", "--permission-mode", _devin_perm]
                     if eff_model:
                         _cmd.extend(["--model", eff_model])
@@ -11658,9 +11820,12 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         "wee_runtime.py",
                     )
                     _cmd = [
-                        sys.executable, _wee_script,
-                        "--model", eff_model,
-                        "--timeout", str(timeout or 300),
+                        sys.executable,
+                        _wee_script,
+                        "--model",
+                        eff_model,
+                        "--timeout",
+                        str(timeout or 300),
                     ]
                     _wee_api_base = os.environ.get("WEE_API_BASE", "")
                     _wee_api_key = os.environ.get("WEE_API_KEY", "")
@@ -11860,16 +12025,26 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                     notify=notify,
                 )
             else:
-                primary_error_msg = f"Task failed with code {process.returncode}: {output}"
+                primary_error_msg = (
+                    f"Task failed with code {process.returncode}: {output}"
+                )
 
                 # --- Fallback retry logic (Issue #243) ---
                 _is_infra_error = any(
                     re.search(p, output, re.IGNORECASE) for p in _FALLBACK_PATTERNS
                 )
                 _task_rec = bg_task_mgr.get_task(task_id)
-                _fb_runtime = (_task_rec or {}).get("fallback_runtime") if _task_rec else None
-                _fb_model = (_task_rec or {}).get("fallback_model") if _task_rec else None
-                _already_fb = (_task_rec or {}).get("used_fallback", False) if _task_rec else False
+                _fb_runtime = (
+                    (_task_rec or {}).get("fallback_runtime") if _task_rec else None
+                )
+                _fb_model = (
+                    (_task_rec or {}).get("fallback_model") if _task_rec else None
+                )
+                _already_fb = (
+                    (_task_rec or {}).get("used_fallback", False)
+                    if _task_rec
+                    else False
+                )
 
                 if _is_infra_error and (_fb_runtime or _fb_model) and not _already_fb:
                     _eff_fb_runtime = _fb_runtime or runtime
@@ -11878,7 +12053,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         task_id,
                         f"[Fallback] Primary failed ({primary_error_msg[:120]}), retrying with runtime={_eff_fb_runtime}, model={_eff_fb_model}",
                     )
-                    bg_task_mgr.mark_fallback_used(task_id, _eff_fb_runtime, _eff_fb_model)
+                    bg_task_mgr.mark_fallback_used(
+                        task_id, _eff_fb_runtime, _eff_fb_model
+                    )
 
                     _fb_cmd = _build_bg_cmd(_eff_fb_runtime, _eff_fb_model)
                     _fb_env = {**env, "COPILOT_RUNTIME": _eff_fb_runtime}
@@ -11904,7 +12081,10 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                             pass
 
                     import threading as _fb_threading
-                    _fb_stderr_thread = _fb_threading.Thread(target=_drain_fb_stderr, daemon=True)
+
+                    _fb_stderr_thread = _fb_threading.Thread(
+                        target=_drain_fb_stderr, daemon=True
+                    )
                     _fb_stderr_thread.start()
                     _fb_start = time.time()
 
@@ -11936,7 +12116,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                             else "Task completed via fallback runtime"
                         )
                         if not _fb_final.strip():
-                            _fb_final = _fb_output or "Task completed via fallback runtime"
+                            _fb_final = (
+                                _fb_output or "Task completed via fallback runtime"
+                            )
                         session_mgr.clear_live_status(session_id)
                         bg_task_mgr.complete_task(task_id, _fb_final)
                         _emit_bg_notification(
@@ -11975,7 +12157,11 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                             job = sched.get_job(job_id).get("result")
                             if job:
                                 sched.save_result(
-                                    job_id, job.get("name", job_id), False, "", error_msg
+                                    job_id,
+                                    job.get("name", job_id),
+                                    False,
+                                    "",
+                                    error_msg,
                                 )
                         except Exception:
                             pass
@@ -12190,19 +12376,13 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         }
 
     @app.get("/api/v1/sessions/{session_id}/bg-events")
-    async def get_session_bg_events(
-        session_id: str, request: Request
-    ):
+    async def get_session_bg_events(session_id: str, request: Request):
         """Return and clear pending BG task completion events."""
         await authenticate(
             request,
             authorization=request.headers.get("authorization"),
-            x_user_identity=request.headers.get(
-                "x-user-identity"
-            ),
-            x_auth_channel=request.headers.get(
-                "x-auth-channel"
-            ),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
         )
         events = bg_task_mgr.pop_bg_events(session_id)
         return {"events": events}
@@ -12216,7 +12396,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             x_auth_channel=request.headers.get("x-auth-channel"),
         )
         client_ip = request.client.host if request.client else "unknown"
-        if not rate_limiter.check(client_ip, "bg_tasks_list", max_requests=120, window=60):
+        if not rate_limiter.check(
+            client_ip, "bg_tasks_list", max_requests=120, window=60
+        ):
             raise HTTPException(status_code=429, detail="Rate limit exceeded")
         tasks = bg_task_mgr.list_all_tasks()
         # Check if running tasks are still alive
@@ -12424,7 +12606,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 detail=f"Task is {task['status']}, not running -- cannot steer",
             )
         path = bg_task_mgr.write_steering(task_id, body.instruction)
-        logger.info("[STEER] Steering written for task %s: %s", task_id, body.instruction[:80])
+        logger.info(
+            "[STEER] Steering written for task %s: %s", task_id, body.instruction[:80]
+        )
         return {
             "task_id": task_id,
             "status": "steering_written",
@@ -13353,17 +13537,13 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
                 # Update DUE: header if new_due provided
                 if new_due is not None:
-                    header_lines = [
-                        h for h in header_lines if not h.startswith("DUE:")
-                    ]
+                    header_lines = [h for h in header_lines if not h.startswith("DUE:")]
                     if new_due.strip():
                         header_lines.insert(0, f"DUE: {new_due.strip()}")
 
                 # Update details body if provided
                 if details is not None:
-                    body_lines = (
-                        ["", details.strip()] if details.strip() else []
-                    )
+                    body_lines = ["", details.strip()] if details.strip() else []
 
                 new_content = "\n".join(header_lines)
                 if body_lines:
@@ -13402,8 +13582,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                     if not resolved.is_relative_to(parent):
                         return {
                             "success": False,
-                            "error": "Invalid label:"
-                            " path traversal detected",
+                            "error": "Invalid label:" " path traversal detected",
                         }
                     if clean == match.name:
                         pass  # no rename needed
@@ -13411,8 +13590,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         lbl = clean
                         return {
                             "success": False,
-                            "error": f"A TODO named"
-                            f" {lbl!r} already exists",
+                            "error": f"A TODO named" f" {lbl!r} already exists",
                         }
                     else:
                         match.rename(new_path)
@@ -14036,13 +14214,21 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         )
         try:
             proc = await asyncio.create_subprocess_exec(
-                sys.executable, _SECRET_TOOL_PATH, "list", "--backend", "file",
+                sys.executable,
+                _SECRET_TOOL_PATH,
+                "list",
+                "--backend",
+                "file",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await proc.communicate()
             if proc.returncode != 0:
-                detail = stdout.decode().strip() or stderr.decode().strip() or "secret-tool list failed"
+                detail = (
+                    stdout.decode().strip()
+                    or stderr.decode().strip()
+                    or "secret-tool list failed"
+                )
                 try:
                     err = json.loads(detail)
                     detail = err.get("message", detail)
@@ -14082,22 +14268,32 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             raise HTTPException(status_code=400, detail="Secret value is required")
         # Validate name: alphanumeric, hyphens, underscores, dots only
 
-        if not re.match(r'^[A-Za-z0-9._-]+$', name):
+        if not re.match(r"^[A-Za-z0-9._-]+$", name):
             raise HTTPException(
                 status_code=400,
                 detail="Secret name may only contain letters, digits, hyphens, underscores, and dots",
             )
         try:
             proc = await asyncio.create_subprocess_exec(
-                sys.executable, _SECRET_TOOL_PATH, "set",
-                "--name", name, "--value-stdin", "--backend", "file",
+                sys.executable,
+                _SECRET_TOOL_PATH,
+                "set",
+                "--name",
+                name,
+                "--value-stdin",
+                "--backend",
+                "file",
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await proc.communicate(input=f"{value}\n".encode())
             if proc.returncode != 0:
-                detail = stdout.decode().strip() or stderr.decode().strip() or "secret-tool set failed"
+                detail = (
+                    stdout.decode().strip()
+                    or stderr.decode().strip()
+                    or "secret-tool set failed"
+                )
                 try:
                     err = json.loads(detail)
                     detail = err.get("message", detail)
@@ -14132,15 +14328,22 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             )
         try:
             proc = await asyncio.create_subprocess_exec(
-                sys.executable, _SECRET_TOOL_PATH, "delete",
-                "--name", name, "--backend", "file",
+                sys.executable,
+                _SECRET_TOOL_PATH,
+                "delete",
+                "--name",
+                name,
+                "--backend",
+                "file",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await proc.communicate()
             output = stdout.decode().strip()
             if proc.returncode != 0:
-                detail = output or stderr.decode().strip() or "secret-tool delete failed"
+                detail = (
+                    output or stderr.decode().strip() or "secret-tool delete failed"
+                )
                 try:
                     err = json.loads(detail)
                     detail = err.get("message", detail)
@@ -14171,7 +14374,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         )
         try:
             proc = await asyncio.create_subprocess_exec(
-                sys.executable, _SECRET_TOOL_PATH, "status",
+                sys.executable,
+                _SECRET_TOOL_PATH,
+                "status",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -14182,8 +14387,10 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                     return json.loads(output)
                 except json.JSONDecodeError:
                     pass
-            return {"status": "unavailable",
-                    "message": output or stderr.decode().strip() or "Unknown error"}
+            return {
+                "status": "unavailable",
+                "message": output or stderr.decode().strip() or "Unknown error",
+            }
         except Exception as e:
             return {"status": "error", "message": str(e)}
 
@@ -14206,14 +14413,14 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             raise HTTPException(status_code=400, detail="password is required")
         try:
             proc = await asyncio.create_subprocess_exec(
-                sys.executable, _SECRET_TOOL_PATH, "unlock",
+                sys.executable,
+                _SECRET_TOOL_PATH,
+                "unlock",
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, stderr = await proc.communicate(
-                input=f"{password}\n".encode()
-            )
+            stdout, stderr = await proc.communicate(input=f"{password}\n".encode())
             output = stdout.decode().strip()
             if proc.returncode == 0 and output:
                 try:
@@ -14236,9 +14443,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
     # --- Session Permissions API ---
     @app.patch("/api/v1/sessions/{session_id}/settings")
-    async def update_session_settings(
-        session_id: str, request: Request
-    ):
+    async def update_session_settings(session_id: str, request: Request):
         """F027: Update session settings (e.g. silent_mode toggle)."""
         user = await authenticate(
             request,
@@ -14249,9 +14454,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
         data = session_mgr.load_session_data(session_id)
         if not data:
-            raise HTTPException(
-                status_code=404, detail="Session not found"
-            )
+            raise HTTPException(status_code=404, detail="Session not found")
 
         body = await request.json()
         _allowed = {"silent_mode"}
@@ -14264,9 +14467,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         status_code=422,
                         detail="silent_mode must be boolean",
                     )
-                session_mgr.update_session_field(
-                    session_id, field, val
-                )
+                session_mgr.update_session_field(session_id, field, val)
                 updated[field] = val
 
         if not updated:
@@ -14916,7 +15117,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
     # --- Memory Promotion ─────────────────────────────────────────────────────
 
-    MEMORY_PROMOTER_SCRIPT = Path("/opt/foster-skills/memory-promoter/memory_promoter.py")
+    MEMORY_PROMOTER_SCRIPT = Path(
+        "/opt/foster-skills/memory-promoter/memory_promoter.py"
+    )
 
     class PromoteMemoryRequest(BaseModel):
         agent: Optional[str] = None
@@ -15033,27 +15236,33 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         env=env,
                     ),
                 )
-                results.append({
-                    "agent": agent_name,
-                    "agent_path": agent_path,
-                    "status": "ok" if result.returncode == 0 else "error",
-                    "returncode": result.returncode,
-                    "stdout": result.stdout[-500:] if result.stdout else "",
-                    "stderr": result.stderr[-500:] if result.stderr else "",
-                })
+                results.append(
+                    {
+                        "agent": agent_name,
+                        "agent_path": agent_path,
+                        "status": "ok" if result.returncode == 0 else "error",
+                        "returncode": result.returncode,
+                        "stdout": result.stdout[-500:] if result.stdout else "",
+                        "stderr": result.stderr[-500:] if result.stderr else "",
+                    }
+                )
             except subprocess.TimeoutExpired:
-                results.append({
-                    "agent": agent_name,
-                    "agent_path": agent_path,
-                    "status": "timeout",
-                })
+                results.append(
+                    {
+                        "agent": agent_name,
+                        "agent_path": agent_path,
+                        "status": "timeout",
+                    }
+                )
             except Exception as exc:
-                results.append({
-                    "agent": agent_name,
-                    "agent_path": agent_path,
-                    "status": "error",
-                    "error": str(exc),
-                })
+                results.append(
+                    {
+                        "agent": agent_name,
+                        "agent_path": agent_path,
+                        "status": "error",
+                        "error": str(exc),
+                    }
+                )
 
         ok_count = sum(1 for r in results if r["status"] == "ok")
         return {
@@ -15063,8 +15272,6 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             "failed": len(results) - ok_count,
             "results": results,
         }
-
-
 
     # ── Themes API (F025) ─────────────────────────────────────────────
 
@@ -15085,18 +15292,19 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                     continue
                 if any(t["name"] == name for t in themes):
                     continue
-                themes.append({
-                    "name": name,
-                    "label": name.replace("-", " ").replace("_", " ").title(),
-                    "description": "Custom theme",
-                    "builtin": False,
-                    "css": css_file.read_text(encoding="utf-8"),
-                })
+                themes.append(
+                    {
+                        "name": name,
+                        "label": name.replace("-", " ").replace("_", " ").title(),
+                        "description": "Custom theme",
+                        "builtin": False,
+                        "css": css_file.read_text(encoding="utf-8"),
+                    }
+                )
         return {"themes": themes, "count": len(themes)}
 
-
-
         # --- AI Media ─────────────────────────────────────────────────────────────
+
     _ai_media_dir = Path("/tmp/webui_ai_media")
     _ai_media_dir.mkdir(parents=True, exist_ok=True)
     app.mount("/ai-media", StaticFiles(directory=str(_ai_media_dir)), name="ai_media")
@@ -15113,6 +15321,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         app.mount("/static", StaticFiles(directory=str(_static_dir)), name="static")
 
     return app
+
 
 def start_api_server():
     """Load dotenv, create the FastAPI app, and run uvicorn."""
@@ -15177,6 +15386,7 @@ def start_api_server():
     else:
         print(f"[API] Listening on {proto}://{host}:{port}", file=sys.stderr)
         uvicorn.run(app, host=host, port=port, **ssl_kwargs)
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -15269,7 +15479,17 @@ Examples:
     runtime_group.add_argument(
         "--runtime",
         metavar="NAME",
-        choices=["copilot", "copilot-sdk", "opencode", "claude", "claude-sdk", "gemini", "codex", "devin", "cursor"],
+        choices=[
+            "copilot",
+            "copilot-sdk",
+            "opencode",
+            "claude",
+            "claude-sdk",
+            "gemini",
+            "codex",
+            "devin",
+            "cursor",
+        ],
         help="Set the runtime to use (choices: copilot, copilot-sdk, opencode, claude, claude-sdk, gemini, codex, devin, cursor)",
     )
     runtime_group.add_argument(
@@ -15340,6 +15560,7 @@ Examples:
     # Execute the main prompt
     output = manager.execute(args.prompt, args.session_id)
     print(output)
+
 
 if __name__ == "__main__":
     if "--api" in sys.argv:

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -2936,6 +2936,10 @@ You can mention an agent in your prompt and it will auto-delegate:
                         "max_concurrent": agent.get("max_concurrent", 1),
                         "runtime": agent.get("runtime", "copilot"),
                         "model": agent.get("model", ""),
+                        "primary_runtime": agent.get("primary_runtime"),
+                        "primary_model": agent.get("primary_model"),
+                        "fallback_runtime": agent.get("fallback_runtime"),
+                        "fallback_model": agent.get("fallback_model"),
                     }
                 return agents
         except json.JSONDecodeError as e:
@@ -4114,6 +4118,12 @@ You can mention an agent in your prompt and it will auto-delegate:
             available = ", ".join(self.AGENTS.keys())
             return f"Unknown agent: '{agent}'. Available agents: {available}"
 
+
+        # Get agent's primary runtime/model defaults (issue #249)
+        agent_config = self.AGENTS[agent]
+        primary_runtime = agent_config.get("primary_runtime") or "copilot"
+        primary_model = agent_config.get("primary_model") or "gpt-5-mini"
+
         with self._session_map_lock:
             session_map = self.load_session_map()
 
@@ -4123,21 +4133,23 @@ You can mention an agent in your prompt and it will auto-delegate:
             if n8n_session_id not in session_map:
                 session_map[n8n_session_id] = {
                     "session_id": new_backend_session_id,
-                    "model": "gpt-5-mini",
+                    "model": primary_model,
                     "agent": agent,
-                    "runtime": "copilot",
+                    "runtime": primary_runtime,
                 }
             else:
                 if isinstance(session_map[n8n_session_id], dict):
                     session_map[n8n_session_id]["agent"] = agent
                     session_map[n8n_session_id]["session_id"] = new_backend_session_id
+                    session_map[n8n_session_id]["runtime"] = primary_runtime
+                    session_map[n8n_session_id]["model"] = primary_model
                 else:
                     # Convert old format
                     session_map[n8n_session_id] = {
                         "session_id": new_backend_session_id,
-                        "model": "gpt-5-mini",
+                        "model": primary_model,
                         "agent": agent,
-                        "runtime": "copilot",
+                        "runtime": primary_runtime,
                     }
 
             self.save_session_map(session_map)
@@ -9626,6 +9638,8 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                         "name": name,
                         "description": info.get("description", ""),
                         "path": info.get("path", ""),
+                        "primary_runtime": info.get("primary_runtime"),
+                        "primary_model": info.get("primary_model"),
                     }
                 )
             return {"agents": agents}

--- a/memory/inject.py
+++ b/memory/inject.py
@@ -123,6 +123,7 @@ def build_executor_context(session_id: str = "", mode: str = "interactive") -> s
     Returns a markdown section agents can reference to use wee_executor.py.
     """
     import subprocess as _sp
+
     script = Path(__file__).resolve().parent.parent / "scripts" / "wee_executor.py"
     if not script.exists():
         return ""
@@ -132,11 +133,14 @@ def build_executor_context(session_id: str = "", mode: str = "interactive") -> s
     try:
         result = _sp.run(
             ["python3", str(script), "--list-capabilities", "--json"],
-            capture_output=True, text=True, timeout=5,
-            env={**__import__("os").environ, "WEE_SESSION_ID": session_id or "ctx"}
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**__import__("os").environ, "WEE_SESSION_ID": session_id or "ctx"},
         )
         if result.returncode == 0:
             import json as _json
+
             caps = _json.loads(result.stdout)
             for cap in caps:
                 req = ", ".join(cap.get("required_args", []))
@@ -161,11 +165,12 @@ def build_executor_context(session_id: str = "", mode: str = "interactive") -> s
         "```bash\n"
         "python3 /opt/n8n-copilot-shim-dev/scripts/wee_executor.py "
         "--capability create_background_task "
-        "--args '{\"agent\": \"research\", \"prompt\": \"look up X\"}'\n"
+        '--args \'{"agent": "research", "prompt": "look up X"}\'\n'
         "```\n"
         "\n"
         "**Security:** Bearer token is hidden. WEE_SESSION_ID is set automatically.\n"
     )
+
 
 def detect_compaction(last_response: str) -> bool:
     """Return True if the response suggests context compaction occurred."""

--- a/scheduler/executor.py
+++ b/scheduler/executor.py
@@ -82,6 +82,7 @@ def _split_command_args(command: str) -> list[str]:
     try:
         # Explicit check that shlex is available
         import shlex as shlex_module
+
         argv = shlex_module.split(command, posix=True)
     except ValueError as exc:
         raise ValueError(f"Invalid command syntax: {exc}") from exc
@@ -515,8 +516,12 @@ class TaskSchedulerExecutor:
 
         Returns (fallback_runtime, fallback_model) or (None, None).
         """
-        fb_rt = job.get("fallback_runtime") or os.environ.get("SCHEDULER_FALLBACK_RUNTIME")
-        fb_model = job.get("fallback_model") or os.environ.get("SCHEDULER_FALLBACK_MODEL")
+        fb_rt = job.get("fallback_runtime") or os.environ.get(
+            "SCHEDULER_FALLBACK_RUNTIME"
+        )
+        fb_model = job.get("fallback_model") or os.environ.get(
+            "SCHEDULER_FALLBACK_MODEL"
+        )
         if fb_rt == job.get("runtime") and fb_model == job.get("model"):
             return None, None
         if not fb_rt and not fb_model:
@@ -562,7 +567,9 @@ class TaskSchedulerExecutor:
                     if notify:
                         self._notify_creator(
                             job,
-                            _brief_notification("\u2705", job["name"], "done (fallback)"),
+                            _brief_notification(
+                                "\u2705", job["name"], "done (fallback)"
+                            ),
                         )
                     return fb_result
 
@@ -572,11 +579,15 @@ class TaskSchedulerExecutor:
                 if notify:
                     self._notify_creator(
                         job,
-                        _brief_notification("\u274c", job["name"], "failed (primary + fallback)"),
+                        _brief_notification(
+                            "\u274c", job["name"], "failed (primary + fallback)"
+                        ),
                     )
                 return None
             else:
-                logger.info(f"[Fallback] Job {job_id}: eligible error but no fallback configured")
+                logger.info(
+                    f"[Fallback] Job {job_id}: eligible error but no fallback configured"
+                )
 
         # No fallback or not eligible
         self._save_result(job_id, job["name"], success=False, error=error_text)
@@ -588,7 +599,10 @@ class TaskSchedulerExecutor:
         return None
 
     def _run_ai_attempt(
-        self, job: Dict, runtime_override: Optional[str] = None, model_override: Optional[str] = None
+        self,
+        job: Dict,
+        runtime_override: Optional[str] = None,
+        model_override: Optional[str] = None,
     ) -> tuple:
         """Run a single AI execution attempt.
 
@@ -596,7 +610,9 @@ class TaskSchedulerExecutor:
         """
         job_id = job["id"]
         agent = job.get("agent", os.getenv("SCHEDULER_DEFAULT_AGENT", "orchestrator"))
-        runtime = runtime_override or job.get("runtime", os.getenv("SCHEDULER_DEFAULT_RUNTIME", "claude"))
+        runtime = runtime_override or job.get(
+            "runtime", os.getenv("SCHEDULER_DEFAULT_RUNTIME", "claude")
+        )
         task = job.get("task", "")
         timeout = int(
             job.get("timeout") or os.getenv("SCHEDULER_DEFAULT_TIMEOUT", "300")
@@ -610,7 +626,9 @@ class TaskSchedulerExecutor:
             "gemini": "gemini-1.5-pro",
             "opencode": "gpt-4o",
         }
-        model = model_override or job.get("model") or _default_models.get(runtime, "sonnet")
+        model = (
+            model_override or job.get("model") or _default_models.get(runtime, "sonnet")
+        )
 
         agent_manager_path = self.repo_root / "agent_manager.py"
         perm_mode = job.get("permission_mode", "restricted")
@@ -657,7 +675,9 @@ class TaskSchedulerExecutor:
                 logger.info(f"Job {job_id} completed successfully")
                 return output, None
             else:
-                error_msg = result.stderr or result.stdout or f"exit code {result.returncode}"
+                error_msg = (
+                    result.stderr or result.stdout or f"exit code {result.returncode}"
+                )
                 self._log_job(job_id, f"Execution failed: {error_msg[:200]}")
                 logger.error(f"Job {job_id} failed with code {result.returncode}")
                 return None, error_msg
@@ -676,7 +696,6 @@ class TaskSchedulerExecutor:
             return None, error_str
         finally:
             self._clear_checkpoint(job_id)
-
 
     def _execute_command_mode(self, job: Dict) -> Optional[str]:
         """Execute job as direct shell/python command (no LLM)."""

--- a/scheduler/management.py
+++ b/scheduler/management.py
@@ -729,9 +729,7 @@ class TaskScheduler:
             return {"success": False, "message": workdir_error}
 
         jobs = self._load_jobs()
-        job_id, job_id_error = self._build_job_id(
-            name, {j["id"] for j in jobs["jobs"]}
-        )
+        job_id, job_id_error = self._build_job_id(name, {j["id"] for j in jobs["jobs"]})
         if not job_id:
             return {"success": False, "message": job_id_error}
 
@@ -1083,7 +1081,9 @@ class TaskScheduler:
         try:
             log_file = self._log_file_for_job(job_id)
         except ValueError:
-            logger.warning("Refused to write scheduler log for invalid job_id=%r", job_id)
+            logger.warning(
+                "Refused to write scheduler log for invalid job_id=%r", job_id
+            )
             return
         timestamp = datetime.utcnow().isoformat() + "Z"
         with open(log_file, "a") as f:

--- a/secret_tool/secret_tool.py
+++ b/secret_tool/secret_tool.py
@@ -138,7 +138,9 @@ class PassBackend:
                 f"Initialise it with: PASSWORD_STORE_DIR={self.store_dir} pass init <GPG_KEY_ID>"
             )
 
-    def _run_pass(self, *args, input_data: str | None = None) -> subprocess.CompletedProcess:
+    def _run_pass(
+        self, *args, input_data: str | None = None
+    ) -> subprocess.CompletedProcess:
         env = {**os.environ, "PASSWORD_STORE_DIR": self.store_dir}
         return subprocess.run(
             ["pass", *args],
@@ -158,7 +160,10 @@ class PassBackend:
     def set(self, name: str, value: str) -> dict:
         existed = self.exists(name)
         result = self._run_pass(
-            "insert", "--force", "--multiline", self._pass_path(name),
+            "insert",
+            "--force",
+            "--multiline",
+            self._pass_path(name),
             input_data=value,
         )
         if result.returncode != 0:
@@ -215,11 +220,15 @@ class FileBackend:
             )
 
     def _get_or_create_key(self) -> bytes:
-        key = self._keyring.get_password("secret-tool-file-key", os.environ.get("USER", "root"))
+        key = self._keyring.get_password(
+            "secret-tool-file-key", os.environ.get("USER", "root")
+        )
         if key:
             return key.encode()
         k = self._Fernet.generate_key()
-        self._keyring.set_password("secret-tool-file-key", os.environ.get("USER", "root"), k.decode())
+        self._keyring.set_password(
+            "secret-tool-file-key", os.environ.get("USER", "root"), k.decode()
+        )
         return k
 
     def _load_store(self, fernet: object) -> dict:
@@ -325,7 +334,9 @@ def parse_args(argv=None):
     p_get.add_argument("--backend", choices=["pass", "keyring", "file"], default="pass")
 
     p_list = sub.add_parser("list", help="List stored secret names (no values)")
-    p_list.add_argument("--backend", choices=["pass", "keyring", "file"], default="pass")
+    p_list.add_argument(
+        "--backend", choices=["pass", "keyring", "file"], default="pass"
+    )
     p_list.add_argument(
         "--json",
         action="store_true",
@@ -357,17 +368,20 @@ def _resolve_value(args) -> str:
     return args.value
 
 
-
 def _check_keyring_status() -> dict:
     """Check if the system keyring / secret store is accessible."""
     # Strategy 1: secretstorage (D-Bus Secret Service API)
     try:
         import secretstorage
+
         conn = secretstorage.dbus_init()
         coll = secretstorage.get_default_collection(conn)
         if coll.is_locked():
-            return {"status": "locked", "backend": "gnome-keyring",
-                    "message": "GNOME Keyring is locked"}
+            return {
+                "status": "locked",
+                "backend": "gnome-keyring",
+                "message": "GNOME Keyring is locked",
+            }
         return {"status": "unlocked", "backend": "gnome-keyring"}
     except Exception:
         pass
@@ -375,40 +389,49 @@ def _check_keyring_status() -> dict:
     # Strategy 2: python-keyring probe
     try:
         import keyring
+
         keyring.get_password("secret-tool-status-probe", "__probe__")
         return {"status": "unlocked", "backend": "python-keyring"}
     except Exception as exc:
         err = str(exc).lower()
         if any(kw in err for kw in ("locked", "prompt", "dismissed")):
-            return {"status": "locked", "backend": "python-keyring",
-                    "message": "Keyring is locked"}
+            return {
+                "status": "locked",
+                "backend": "python-keyring",
+                "message": "Keyring is locked",
+            }
         if "no recommended backend" in err:
-            return {"status": "unavailable",
-                    "message": "No keyring backend available"}
+            return {"status": "unavailable", "message": "No keyring backend available"}
 
     # Strategy 3: secret-tool CLI probe (timeout = locked)
     try:
         proc = subprocess.run(
             ["secret-tool", "lookup", "wee-status-probe", "test"],
-            capture_output=True, text=True, timeout=3,
+            capture_output=True,
+            text=True,
+            timeout=3,
         )
         return {"status": "unlocked", "backend": "secret-tool"}
     except subprocess.TimeoutExpired:
-        return {"status": "locked", "backend": "secret-tool",
-                "message": "secret-tool timed out (keyring likely locked)"}
+        return {
+            "status": "locked",
+            "backend": "secret-tool",
+            "message": "secret-tool timed out (keyring likely locked)",
+        }
     except FileNotFoundError:
         pass
 
-    return {"status": "unavailable",
-            "message": "No secret store backend detected"}
+    return {"status": "unavailable", "message": "No secret store backend detected"}
 
 
 def _find_gnome_keyring_daemon():
     path = shutil.which("gnome-keyring-daemon")
     if path:
         return path
-    for candidate in ("/usr/bin/gnome-keyring-daemon",
-                      "/usr/local/bin/gnome-keyring-daemon"):
+    for candidate in (
+        "/usr/bin/gnome-keyring-daemon",
+        "/usr/local/bin/gnome-keyring-daemon",
+    ):
         if os.path.isfile(candidate):
             return candidate
     return None
@@ -437,14 +460,14 @@ def _unlock_keyring(password: str) -> dict:
     # Strategy 2: secretstorage unlock
     try:
         import secretstorage
+
         conn = secretstorage.dbus_init()
         coll = secretstorage.get_default_collection(conn)
         if coll.is_locked():
             coll.unlock()
             if not coll.is_locked():
                 return {"status": "success", "method": "secretstorage"}
-            return {"status": "error",
-                    "message": "Unlock requires interactive prompt"}
+            return {"status": "error", "message": "Unlock requires interactive prompt"}
         return {"status": "success", "message": "Keyring was already unlocked"}
     except Exception:
         pass
@@ -457,6 +480,7 @@ def _unlock_keyring(password: str) -> dict:
             "or log in to the desktop session."
         ),
     }
+
 
 def main(argv=None):
     args = parse_args(argv)

--- a/skill_manager.py
+++ b/skill_manager.py
@@ -13,7 +13,6 @@ import shutil
 import subprocess
 import tempfile
 import time
-
 from typing import Any, Dict, List, Optional
 
 # ── Configuration ─────────────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+
+# Fixture for issue #249 tests
+import pytest
+
+@pytest.fixture
+def mock_agents_config():
+    """Create a mock agents configuration with primary_runtime/primary_model."""
+    return {
+        "agents": [
+            {
+                "name": "orchestrator",
+                "path": "/opt/",
+                "description": "Main orchestrator",
+                "primary_runtime": "claude",
+                "primary_model": "haiku",
+                "fallback_runtime": "copilot",
+                "fallback_model": "auto",
+                "max_concurrent": 1,
+            },
+            {
+                "name": "research",
+                "path": "/opt/research",
+                "description": "Research agent",
+                "primary_runtime": "opencode",
+                "primary_model": "nvidia/llama-3.1-nemotron",
+                "fallback_runtime": "claude",
+                "fallback_model": "sonnet",
+                "max_concurrent": 1,
+            },
+            {
+                "name": "wee-dev",
+                "path": "/opt/wee-dev",
+                "description": "Wee Orchestrator developer",
+                "primary_runtime": "copilot",
+                "primary_model": "gpt-5.4-mini",
+                "fallback_runtime": "claude",
+                "fallback_model": "opus",
+                "max_concurrent": 1,
+            },
+        ]
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
-
 # Fixture for issue #249 tests
 import pytest
+
 
 @pytest.fixture
 def mock_agents_config():

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -30,7 +30,7 @@ class TestAPIEndpoints(unittest.TestCase):
         cls._telegram_patch.start()
         cls._send_pairing_patch = patch.object(
             agent_manager,
-            '_send_pairing_code',
+            "_send_pairing_code",
             return_value=True,
         )
         cls._send_pairing_patch.start()

--- a/tests/test_auto_runtime_removed.py
+++ b/tests/test_auto_runtime_removed.py
@@ -25,17 +25,20 @@ class TestAutoRuntimeRemoved(unittest.TestCase):
         """get_available_runtimes() must not include auto."""
         runtimes = get_available_runtimes()
         runtime_ids = [r["id"] for r in runtimes]
-        self.assertNotIn("auto", runtime_ids,
-                         "'auto' should not appear in available runtimes list")
+        self.assertNotIn(
+            "auto", runtime_ids, "'auto' should not appear in available runtimes list"
+        )
 
     def test_check_runtime_available_rejects_auto(self):
         """check_runtime_available('auto') must return False."""
-        self.assertFalse(check_runtime_available("auto"),
-                         "'auto' runtime should not be available")
+        self.assertFalse(
+            check_runtime_available("auto"), "'auto' runtime should not be available"
+        )
 
     def test_slash_runtime_set_rejects_auto(self):
         """The /runtime set handler must reject 'auto' as invalid."""
         from agent_manager import SessionManager
+
         mgr = SessionManager.__new__(SessionManager)
         mgr._slash_commands = {}
         mgr._agents_config = {"agents": []}
@@ -44,8 +47,11 @@ class TestAutoRuntimeRemoved(unittest.TestCase):
 
         session_data = {"runtime": "copilot", "agent": "orchestrator"}
         result = mgr._slash_runtime("set auto", session_data, "test-session")
-        self.assertIn("Unknown runtime", result,
-                      "/runtime set auto should return 'Unknown runtime' error")
+        self.assertIn(
+            "Unknown runtime",
+            result,
+            "/runtime set auto should return 'Unknown runtime' error",
+        )
 
     def test_valid_runtimes_all_have_handlers(self):
         """Every runtime in get_available_runtimes() must have a check_runtime_available entry."""
@@ -54,7 +60,7 @@ class TestAutoRuntimeRemoved(unittest.TestCase):
             rid = rt["id"]
             self.assertTrue(
                 check_runtime_available(rid),
-                f"Runtime {rid} is listed but check_runtime_available returns False"
+                f"Runtime {rid} is listed but check_runtime_available returns False",
             )
 
 

--- a/tests/test_background_task_reconcile.py
+++ b/tests/test_background_task_reconcile.py
@@ -50,17 +50,20 @@ class TestReconcileOnStartup(unittest.TestCase):
 
     def test_stale_running_marked_failed(self):
         """Running tasks with dead PIDs should be marked failed."""
-        _seed_tasks(self.mgr, [
-            {
-                "task_id": "bg_test1",
-                "status": "running",
-                "pid": 999999999,  # PID that doesn't exist
-                "agent": "orchestrator",
-                "channel": "webui",
-                "user_identity": "test_user",
-                "created_at": "2026-01-01T00:00:00Z",
-            },
-        ])
+        _seed_tasks(
+            self.mgr,
+            [
+                {
+                    "task_id": "bg_test1",
+                    "status": "running",
+                    "pid": 999999999,  # PID that doesn't exist
+                    "agent": "orchestrator",
+                    "channel": "webui",
+                    "user_identity": "test_user",
+                    "created_at": "2026-01-01T00:00:00Z",
+                },
+            ],
+        )
         result = self.mgr.reconcile_stale_tasks()
         self.assertEqual(result["stale_running"], 1)
 
@@ -71,17 +74,20 @@ class TestReconcileOnStartup(unittest.TestCase):
     def test_alive_running_not_touched(self):
         """Running tasks with a live PID should not be touched."""
         my_pid = os.getpid()
-        _seed_tasks(self.mgr, [
-            {
-                "task_id": "bg_alive",
-                "status": "running",
-                "pid": my_pid,
-                "agent": "orchestrator",
-                "channel": "webui",
-                "user_identity": "test_user",
-                "created_at": "2026-01-01T00:00:00Z",
-            },
-        ])
+        _seed_tasks(
+            self.mgr,
+            [
+                {
+                    "task_id": "bg_alive",
+                    "status": "running",
+                    "pid": my_pid,
+                    "agent": "orchestrator",
+                    "channel": "webui",
+                    "user_identity": "test_user",
+                    "created_at": "2026-01-01T00:00:00Z",
+                },
+            ],
+        )
         result = self.mgr.reconcile_stale_tasks()
         self.assertEqual(result["stale_running"], 0)
 
@@ -90,72 +96,81 @@ class TestReconcileOnStartup(unittest.TestCase):
 
     def test_running_no_pid_marked_failed(self):
         """Running tasks with no PID (pid=0) should be marked failed."""
-        _seed_tasks(self.mgr, [
-            {
-                "task_id": "bg_nopid",
-                "status": "running",
-                "pid": 0,
-                "agent": "orchestrator",
-                "channel": "webui",
-                "user_identity": "test_user",
-                "created_at": "2026-01-01T00:00:00Z",
-            },
-        ])
+        _seed_tasks(
+            self.mgr,
+            [
+                {
+                    "task_id": "bg_nopid",
+                    "status": "running",
+                    "pid": 0,
+                    "agent": "orchestrator",
+                    "channel": "webui",
+                    "user_identity": "test_user",
+                    "created_at": "2026-01-01T00:00:00Z",
+                },
+            ],
+        )
         result = self.mgr.reconcile_stale_tasks()
         self.assertEqual(result["stale_running"], 1)
 
     def test_queued_count_returned(self):
         """Queued tasks should be counted in the reconcile result."""
-        _seed_tasks(self.mgr, [
-            {
-                "task_id": "bg_q1",
-                "status": "queued",
-                "agent": "orchestrator",
-                "channel": "webui",
-                "user_identity": "test_user",
-                "created_at": "2026-01-01T00:00:01Z",
-            },
-            {
-                "task_id": "bg_q2",
-                "status": "queued",
-                "agent": "orchestrator",
-                "channel": "webui",
-                "user_identity": "test_user",
-                "created_at": "2026-01-01T00:00:02Z",
-            },
-        ])
+        _seed_tasks(
+            self.mgr,
+            [
+                {
+                    "task_id": "bg_q1",
+                    "status": "queued",
+                    "agent": "orchestrator",
+                    "channel": "webui",
+                    "user_identity": "test_user",
+                    "created_at": "2026-01-01T00:00:01Z",
+                },
+                {
+                    "task_id": "bg_q2",
+                    "status": "queued",
+                    "agent": "orchestrator",
+                    "channel": "webui",
+                    "user_identity": "test_user",
+                    "created_at": "2026-01-01T00:00:02Z",
+                },
+            ],
+        )
         result = self.mgr.reconcile_stale_tasks()
         self.assertEqual(result["queued_ready"], 2)
 
     def test_mixed_scenario(self):
         """Stale running + queued + completed tasks together."""
-        _seed_tasks(self.mgr, [
-            {
-                "task_id": "bg_stale",
-                "status": "running",
-                "pid": 999999999,
-                "agent": "orchestrator",
-                "channel": "webui",
-                "user_identity": "test_user",
-                "created_at": "2026-01-01T00:00:00Z",
-            },
-            {
-                "task_id": "bg_done",
-                "status": "completed",
-                "agent": "orchestrator",
-                "channel": "webui",
-                "user_identity": "test_user",
-                "created_at": "2026-01-01T00:00:00Z",
-            },
-            {
-                "task_id": "bg_queued",
-                "status": "queued",
-                "agent": "orchestrator",
-                "channel": "webui",
-                "user_identity": "test_user",
-                "created_at": "2026-01-01T00:00:01Z",
-            },
-        ])
+        _seed_tasks(
+            self.mgr,
+            [
+                {
+                    "task_id": "bg_stale",
+                    "status": "running",
+                    "pid": 999999999,
+                    "agent": "orchestrator",
+                    "channel": "webui",
+                    "user_identity": "test_user",
+                    "created_at": "2026-01-01T00:00:00Z",
+                },
+                {
+                    "task_id": "bg_done",
+                    "status": "completed",
+                    "agent": "orchestrator",
+                    "channel": "webui",
+                    "user_identity": "test_user",
+                    "created_at": "2026-01-01T00:00:00Z",
+                },
+                {
+                    "task_id": "bg_queued",
+                    "status": "queued",
+                    "agent": "orchestrator",
+                    "channel": "webui",
+                    "user_identity": "test_user",
+                    "created_at": "2026-01-01T00:00:01Z",
+                },
+            ],
+        )
         result = self.mgr.reconcile_stale_tasks()
         self.assertEqual(result["stale_running"], 1)
         self.assertEqual(result["queued_ready"], 1)

--- a/tests/test_bg_task_agent_isolation.py
+++ b/tests/test_bg_task_agent_isolation.py
@@ -3,6 +3,7 @@
 Tests _compute_bg_task_defaults by extracting it directly from agent_manager.py
 without importing the full module (which requires a running server environment).
 """
+
 import ast
 import os
 import re
@@ -11,6 +12,7 @@ import sys
 import pytest
 
 _AM_PATH = os.path.join(os.path.dirname(__file__), "..", "agent_manager.py")
+
 
 def _load_fn():
     with open(_AM_PATH, "r") as f:
@@ -38,32 +40,56 @@ def _sm(sessions):
 # Core: agent field must NEVER appear in defaults
 # ---------------------------------------------------------------------------
 
+
 def test_agent_not_inherited_same_channel():
     d = _compute_bg_task_defaults(
-        _sm([{"identity": "foster", "channel": "tg", "agent": "wee-dev",
-              "runtime": "copilot", "model": "claude-sonnet-4.6"}]),
-        "foster", "tg",
+        _sm(
+            [
+                {
+                    "identity": "foster",
+                    "channel": "tg",
+                    "agent": "wee-dev",
+                    "runtime": "copilot",
+                    "model": "claude-sonnet-4.6",
+                }
+            ]
+        ),
+        "foster",
+        "tg",
     )
     assert "agent" not in d, f"'agent' leaked into defaults: {d}"
 
 
 def test_agent_not_inherited_cross_channel():
     d = _compute_bg_task_defaults(
-        _sm([{"identity": "foster", "channel": "webex", "agent": "email_triage",
-              "runtime": "copilot", "model": "claude-haiku-4.5"}]),
-        "foster", "tg",
+        _sm(
+            [
+                {
+                    "identity": "foster",
+                    "channel": "webex",
+                    "agent": "email_triage",
+                    "runtime": "copilot",
+                    "model": "claude-haiku-4.5",
+                }
+            ]
+        ),
+        "foster",
+        "tg",
     )
     assert "agent" not in d, f"'agent' leaked cross-channel: {d}"
 
 
 def test_agent_not_inherited_multiple_sessions():
     d = _compute_bg_task_defaults(
-        _sm([
-            {"identity": "foster", "channel": "tg",    "agent": "wee-dev"},
-            {"identity": "foster", "channel": "tg",    "agent": "research"},
-            {"identity": "foster", "channel": "webex", "agent": "devops"},
-        ]),
-        "foster", "tg",
+        _sm(
+            [
+                {"identity": "foster", "channel": "tg", "agent": "wee-dev"},
+                {"identity": "foster", "channel": "tg", "agent": "research"},
+                {"identity": "foster", "channel": "webex", "agent": "devops"},
+            ]
+        ),
+        "foster",
+        "tg",
     )
     assert "agent" not in d, f"agent leaked from multi-session map: {d}"
 
@@ -72,11 +98,22 @@ def test_agent_not_inherited_multiple_sessions():
 # Safe fields ARE inherited
 # ---------------------------------------------------------------------------
 
+
 def test_runtime_and_model_inherited():
     d = _compute_bg_task_defaults(
-        _sm([{"identity": "foster", "channel": "tg", "agent": "wee-dev",
-              "runtime": "copilot", "model": "claude-opus-4.6"}]),
-        "foster", "tg",
+        _sm(
+            [
+                {
+                    "identity": "foster",
+                    "channel": "tg",
+                    "agent": "wee-dev",
+                    "runtime": "copilot",
+                    "model": "claude-opus-4.6",
+                }
+            ]
+        ),
+        "foster",
+        "tg",
     )
     assert d.get("runtime") == "copilot"
     assert d.get("model") == "claude-opus-4.6"
@@ -85,9 +122,18 @@ def test_runtime_and_model_inherited():
 
 def test_notification_preference_inherited():
     d = _compute_bg_task_defaults(
-        _sm([{"identity": "foster", "channel": "tg", "agent": "orchestrator",
-              "notification_preference": "telegram"}]),
-        "foster", "tg",
+        _sm(
+            [
+                {
+                    "identity": "foster",
+                    "channel": "tg",
+                    "agent": "orchestrator",
+                    "notification_preference": "telegram",
+                }
+            ]
+        ),
+        "foster",
+        "tg",
     )
     assert d.get("notification_preference") == "telegram"
     assert "agent" not in d
@@ -97,13 +143,27 @@ def test_notification_preference_inherited():
 # Same-channel priority
 # ---------------------------------------------------------------------------
 
+
 def test_same_channel_preferred_over_cross_channel():
     d = _compute_bg_task_defaults(
-        _sm([
-            {"identity": "foster", "channel": "webex", "runtime": "claude",   "model": "haiku"},
-            {"identity": "foster", "channel": "tg",    "runtime": "copilot",  "model": "claude-opus-4.6"},
-        ]),
-        "foster", "tg",
+        _sm(
+            [
+                {
+                    "identity": "foster",
+                    "channel": "webex",
+                    "runtime": "claude",
+                    "model": "haiku",
+                },
+                {
+                    "identity": "foster",
+                    "channel": "tg",
+                    "runtime": "copilot",
+                    "model": "claude-opus-4.6",
+                },
+            ]
+        ),
+        "foster",
+        "tg",
     )
     assert d.get("runtime") == "copilot"
     assert d.get("model") == "claude-opus-4.6"
@@ -113,11 +173,22 @@ def test_same_channel_preferred_over_cross_channel():
 # Identity isolation
 # ---------------------------------------------------------------------------
 
+
 def test_different_identity_not_matched():
     d = _compute_bg_task_defaults(
-        _sm([{"identity": "leslie", "channel": "tg",
-              "agent": "family_knowledge", "runtime": "claude", "model": "haiku"}]),
-        "foster", "tg",
+        _sm(
+            [
+                {
+                    "identity": "leslie",
+                    "channel": "tg",
+                    "agent": "family_knowledge",
+                    "runtime": "claude",
+                    "model": "haiku",
+                }
+            ]
+        ),
+        "foster",
+        "tg",
     )
     assert d == {}, f"Leaked other user's session: {d}"
 
@@ -125,6 +196,7 @@ def test_different_identity_not_matched():
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
+
 
 def test_empty_session_map():
     assert _compute_bg_task_defaults({}, "foster", "tg") == {}
@@ -138,6 +210,7 @@ def test_legacy_string_session_no_crash():
 def test_session_without_identity_not_matched():
     d = _compute_bg_task_defaults(
         _sm([{"channel": "tg", "agent": "wee-dev", "runtime": "copilot"}]),
-        "foster", "tg",
+        "foster",
+        "tg",
     )
     assert d == {}

--- a/tests/test_brief_notifications.py
+++ b/tests/test_brief_notifications.py
@@ -70,9 +70,7 @@ class TestFormatNotificationMessage:
         assert "very long output" not in msg
 
     def test_no_error_in_message(self):
-        msg = self._fmt(
-            status="failed", error="Traceback (most recent call last)..."
-        )
+        msg = self._fmt(status="failed", error="Traceback (most recent call last)...")
         assert "Traceback" not in msg
 
     def test_no_timestamp_in_message(self):
@@ -96,9 +94,7 @@ class TestFormatNotificationMessage:
     def test_default_description_when_missing(self):
         from notification_manager import _format_notification_message
 
-        msg = _format_notification_message(
-            {"task_id": "bg_1", "status": "completed"}
-        )
+        msg = _format_notification_message({"task_id": "bg_1", "status": "completed"})
         assert "Background task" in msg
 
 
@@ -129,9 +125,10 @@ class TestSchedulerBriefNotification:
     """Test the _brief_notification helper in scheduler/executor.py."""
 
     def _brief(self, icon, name, verb):
-        sys.path.insert(0, os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "..", "scheduler"
-        ))
+        sys.path.insert(
+            0,
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "scheduler"),
+        )
         from executor import _brief_notification
 
         return _brief_notification(icon, name, verb)

--- a/tests/test_delegation_session_isolation.py
+++ b/tests/test_delegation_session_isolation.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
 
 # Ensure the repo root is importable
@@ -27,12 +27,11 @@ class TestDelegationSessionIsolation(unittest.TestCase):
 
     def setUp(self):
         """Set up a minimal SessionManager with a temp session map."""
-        from agent_manager import SessionManager
         import threading
 
-        self.tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        )
+        from agent_manager import SessionManager
+
+        self.tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
         self.tmp.write("{}")
         self.tmp.flush()
         self.tmp_path = self.tmp.name
@@ -225,7 +224,9 @@ class TestDelegationSessionIsolation(unittest.TestCase):
                 captured_sessions[effective_sid] = json.load(f).get(effective_sid, {})
             return "Result"
 
-        with patch.object(self.mgr, "_dispatch_single_runtime", side_effect=capture_dispatch):
+        with patch.object(
+            self.mgr, "_dispatch_single_runtime", side_effect=capture_dispatch
+        ):
             self.mgr._execute_with_context("check infra", delegation_data, caller_sid)
 
         ephemeral_key = f"delegation_{delegation_sid}"
@@ -337,12 +338,11 @@ class TestDetectAgentDelegation(unittest.TestCase):
     """Verify detect_agent_delegation patterns match correctly."""
 
     def setUp(self):
-        from agent_manager import SessionManager
         import threading
 
-        self.tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        )
+        from agent_manager import SessionManager
+
+        self.tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
         self.tmp.write("{}")
         self.tmp.flush()
 
@@ -362,7 +362,9 @@ class TestDetectAgentDelegation(unittest.TestCase):
             pass
 
     def test_detects_ask_the_pattern(self):
-        agent, prompt = self.mgr.detect_agent_delegation("ask the devops agent to check disk")
+        agent, prompt = self.mgr.detect_agent_delegation(
+            "ask the devops agent to check disk"
+        )
         self.assertEqual(agent, "devops")
 
     def test_detects_have_the_pattern(self):

--- a/tests/test_f017_bg_events.py
+++ b/tests/test_f017_bg_events.py
@@ -1,4 +1,5 @@
 """Tests for F017: In-thread notification when a background task completes."""
+
 import json
 import os
 import sys
@@ -19,6 +20,7 @@ os.environ.setdefault("API_PORT", "8099")
 # ---------------------------------------------------------------------------
 # BackgroundTaskManager unit tests
 # ---------------------------------------------------------------------------
+
 
 class TestBgEventsStorage:
     """Test push_bg_event / pop_bg_events on BackgroundTaskManager."""
@@ -72,9 +74,7 @@ class TestBgEventsStorage:
         def push_many(session, count):
             try:
                 for i in range(count):
-                    self.mgr.push_bg_event(
-                        session, {"task_id": f"t{i}"}
-                    )
+                    self.mgr.push_bg_event(session, {"task_id": f"t{i}"})
             except Exception as e:
                 errors.append(e)
 
@@ -138,6 +138,7 @@ class TestCreateTaskOriginSession:
 # ---------------------------------------------------------------------------
 # API endpoint tests
 # ---------------------------------------------------------------------------
+
 
 class TestBgEventsEndpoint:
     """Test GET /api/v1/sessions/{session_id}/bg-events."""
@@ -210,7 +211,5 @@ class TestBgEventsEndpoint:
         assert resp2.json()["events"] == []
 
     def test_bg_events_requires_auth(self):
-        resp = self.client.get(
-            "/api/v1/sessions/any-session/bg-events"
-        )
+        resp = self.client.get("/api/v1/sessions/any-session/bg-events")
         assert resp.status_code in (401, 403)

--- a/tests/test_f026_silent_mode.py
+++ b/tests/test_f026_silent_mode.py
@@ -150,13 +150,17 @@ class TestSlashSilentCommand(unittest.TestCase):
             result = self.sm._slash_silent(alias, data, sid)
             self.assertIn("enabled", result.lower(), f"alias '{alias}' failed")
             updated = self.sm.load_session_data(sid)
-            self.assertTrue(updated.get("silent_mode"), f"alias '{alias}' didn't set True")
+            self.assertTrue(
+                updated.get("silent_mode"), f"alias '{alias}' didn't set True"
+            )
 
         for alias in ("false", "0", "disable"):
             result = self.sm._slash_silent(alias, data, sid)
             self.assertIn("disabled", result.lower(), f"alias '{alias}' failed")
             updated = self.sm.load_session_data(sid)
-            self.assertFalse(updated.get("silent_mode"), f"alias '{alias}' didn't set False")
+            self.assertFalse(
+                updated.get("silent_mode"), f"alias '{alias}' didn't set False"
+            )
 
     def test_silent_persists_to_session(self):
         """Silent mode preference persists in session data."""

--- a/tests/test_f027_verbose_toggle.py
+++ b/tests/test_f027_verbose_toggle.py
@@ -9,9 +9,7 @@ import os
 import sys
 import unittest
 
-sys.path.insert(
-    0, os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 os.environ.setdefault("API_SHARED_KEY", "test_key_123")
 os.environ.setdefault("APP_ENV", "DEV")
@@ -28,9 +26,7 @@ class TestSessionStatusIncludesSilentMode(unittest.TestCase):
         cls.am = agent_manager
         cls.sm = agent_manager.SessionManager(
             config_file=os.path.join(
-                os.path.dirname(
-                    os.path.dirname(os.path.abspath(__file__))
-                ),
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                 "agents.json",
             ),
             app_env="DEV",
@@ -235,9 +231,7 @@ class TestWebUIVerboseToggle(unittest.TestCase):
 
     def _read_file(self, *parts):
         path = os.path.join(
-            os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))
-            ),
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             *parts,
         )
         with open(path) as f:

--- a/tests/test_f404_cursor_model.py
+++ b/tests/test_f404_cursor_model.py
@@ -80,7 +80,9 @@ class TestRunCursorModelValidation:
         assert cmd[cmd.index("--model") + 1] == "auto"
 
     def test_invalid_model_defaults_to_auto(self, session_mgr):
-        cmd = _run_cursor_capture_cmd(session_mgr, "opencode/gpt-5-nano", "test-invalid")
+        cmd = _run_cursor_capture_cmd(
+            session_mgr, "opencode/gpt-5-nano", "test-invalid"
+        )
         assert "--model" in cmd
         assert cmd[cmd.index("--model") + 1] == "auto"
 
@@ -90,16 +92,12 @@ class TestRunCursorModelValidation:
         assert cmd[cmd.index("--model") + 1] == "auto"
 
     def test_named_cursor_model_preserved(self, session_mgr):
-        cmd = _run_cursor_capture_cmd(
-            session_mgr, "claude-4-sonnet", "test-named"
-        )
+        cmd = _run_cursor_capture_cmd(session_mgr, "claude-4-sonnet", "test-named")
         assert "--model" in cmd
         assert cmd[cmd.index("--model") + 1] == "claude-4-sonnet"
 
     def test_composer_model_preserved(self, session_mgr):
-        cmd = _run_cursor_capture_cmd(
-            session_mgr, "composer-2", "test-composer"
-        )
+        cmd = _run_cursor_capture_cmd(session_mgr, "composer-2", "test-composer")
         assert "--model" in cmd
         assert cmd[cmd.index("--model") + 1] == "composer-2"
 
@@ -108,9 +106,7 @@ class TestRunCursorModelValidation:
             cmd = _run_cursor_capture_cmd(
                 session_mgr, model_val, f"test-always-{model_val}"
             )
-            assert "--model" in cmd, (
-                f"--model missing for model={model_val!r}"
-            )
+            assert "--model" in cmd, f"--model missing for model={model_val!r}"
 
     def test_env_override_cursor_default_model(self, session_mgr):
         cmd = _run_cursor_capture_cmd(
@@ -123,9 +119,7 @@ class TestRunCursorModelValidation:
 
     def test_copilot_model_rejected(self, session_mgr):
         """A copilot-only model should not reach the cursor CLI."""
-        cmd = _run_cursor_capture_cmd(
-            session_mgr, "gpt-5-nano", "test-copilot-model"
-        )
+        cmd = _run_cursor_capture_cmd(session_mgr, "gpt-5-nano", "test-copilot-model")
         assert cmd[cmd.index("--model") + 1] == "auto"
 
     def test_print_mode_flag_present(self, session_mgr):

--- a/tests/test_f407_memory_promote.py
+++ b/tests/test_f407_memory_promote.py
@@ -60,8 +60,9 @@ class TestMemoryPromoteEndpoint:
         mock_result.stderr = ""
         mock_result.returncode = 0
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run, \
-             patch("pathlib.Path.exists", return_value=True):
+        with patch("subprocess.run", return_value=mock_result) as mock_run, patch(
+            "pathlib.Path.exists", return_value=True
+        ):
             resp = client.post(
                 "/api/v1/memory/promote",
                 json={},
@@ -86,8 +87,9 @@ class TestMemoryPromoteEndpoint:
         mock_result.stderr = ""
         mock_result.returncode = 0
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run, \
-             patch("pathlib.Path.exists", return_value=True):
+        with patch("subprocess.run", return_value=mock_result) as mock_run, patch(
+            "pathlib.Path.exists", return_value=True
+        ):
             resp = client.post(
                 "/api/v1/memory/promote",
                 json={"agent": "wee-dev"},
@@ -109,8 +111,9 @@ class TestMemoryPromoteEndpoint:
         mock_result.stderr = ""
         mock_result.returncode = 0
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run, \
-             patch("pathlib.Path.exists", return_value=True):
+        with patch("subprocess.run", return_value=mock_result) as mock_run, patch(
+            "pathlib.Path.exists", return_value=True
+        ):
             resp = client.post(
                 "/api/v1/memory/promote",
                 json={"agent": "wee-dev"},
@@ -141,8 +144,9 @@ class TestMemoryPromoteEndpoint:
         """Returns 504 when the subprocess times out."""
         import subprocess
 
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 120)), \
-             patch("pathlib.Path.exists", return_value=True):
+        with patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 120)
+        ), patch("pathlib.Path.exists", return_value=True):
             resp = client.post(
                 "/api/v1/memory/promote",
                 json={},
@@ -180,8 +184,9 @@ class TestMemoryPromoteAllEndpoint:
         mock_result.stderr = ""
         mock_result.returncode = 0
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run, \
-             patch("pathlib.Path.exists", return_value=True):
+        with patch("subprocess.run", return_value=mock_result) as mock_run, patch(
+            "pathlib.Path.exists", return_value=True
+        ):
             resp = client.post(
                 "/api/v1/memory/promote-all",
                 headers=auth_headers,
@@ -203,8 +208,9 @@ class TestMemoryPromoteAllEndpoint:
         mock_result.stderr = ""
         mock_result.returncode = 0
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run, \
-             patch("pathlib.Path.exists", return_value=True):
+        with patch("subprocess.run", return_value=mock_result) as mock_run, patch(
+            "pathlib.Path.exists", return_value=True
+        ):
             resp = client.post(
                 "/api/v1/memory/promote-all",
                 headers=auth_headers,
@@ -230,8 +236,9 @@ class TestMemoryPromoteAllEndpoint:
             result.returncode = 0
             return result
 
-        with patch("subprocess.run", side_effect=mock_run), \
-             patch("pathlib.Path.exists", return_value=True):
+        with patch("subprocess.run", side_effect=mock_run), patch(
+            "pathlib.Path.exists", return_value=True
+        ):
             resp = client.post(
                 "/api/v1/memory/promote-all",
                 headers=auth_headers,
@@ -266,8 +273,9 @@ class TestMemoryPromoteAllEndpoint:
             result.returncode = 0
             return result
 
-        with patch("subprocess.run", side_effect=capture_run), \
-             patch("pathlib.Path.exists", return_value=True):
+        with patch("subprocess.run", side_effect=capture_run), patch(
+            "pathlib.Path.exists", return_value=True
+        ):
             resp = client.post(
                 "/api/v1/memory/promote-all",
                 headers=auth_headers,

--- a/tests/test_identity_propagation.py
+++ b/tests/test_identity_propagation.py
@@ -13,8 +13,8 @@ Validates:
 
 import os
 import sys
-import threading
 import tempfile
+import threading
 import unittest
 from unittest.mock import patch
 
@@ -40,6 +40,7 @@ class TestBgIdentityResolution(unittest.TestCase):
 
     def _make_mgr(self, shared_bg_identity=None):
         from agent_manager import SessionManager
+
         mgr = SessionManager.__new__(SessionManager)
         mgr._bg_identity = shared_bg_identity
         mgr._bg_task_mgr = None
@@ -233,6 +234,7 @@ class TestBackgroundTaskIdentityStorage(unittest.TestCase):
 
     def setUp(self):
         from agent_manager import BackgroundTaskManager
+
         fd, self.tmp = tempfile.mkstemp(suffix=".json")
         os.close(fd)
         mgr = BackgroundTaskManager.__new__(BackgroundTaskManager)

--- a/tests/test_issue100_github_todos.py
+++ b/tests/test_issue100_github_todos.py
@@ -8,7 +8,6 @@ closes GitHub Issues.
 import json
 from unittest.mock import MagicMock, patch
 
-
 # ── Test helper: import the inner functions from agent_manager ──────
 
 # agent_manager defines these functions inside setup_routes(),

--- a/tests/test_issue105_wee_runtime_stall.py
+++ b/tests/test_issue105_wee_runtime_stall.py
@@ -13,7 +13,6 @@ import os
 import sys
 import unittest
 
-
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)) + "/..")
 
 

--- a/tests/test_issue107_tool_calling.py
+++ b/tests/test_issue107_tool_calling.py
@@ -67,6 +67,7 @@ def make_tool_call_stream(tool_calls):
 
 def _create_test_manager():
     from agent_manager import SessionManager
+
     mgr = SessionManager.__new__(SessionManager)
     mgr.session_map = {}
     mgr._session_map_lock = threading.Lock()
@@ -86,13 +87,17 @@ def _create_test_manager():
 class TestOllamaPortCorrectness(unittest.TestCase):
 
     def test_agent_manager_presets_port(self):
-        with open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "agent_manager.py")) as f:
+        with open(
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "agent_manager.py")
+        ) as f:
             content = f.read()
         self.assertIn('"http://192.168.1.101:11434/v1"', content)
         self.assertNotIn("11436", content)
 
     def test_wee_runtime_presets_port(self):
-        with open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "wee_runtime.py")) as f:
+        with open(
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "wee_runtime.py")
+        ) as f:
             content = f.read()
         self.assertIn('"http://192.168.1.101:11434/v1"', content)
         self.assertNotIn("11436", content)
@@ -111,14 +116,20 @@ class TestToolCallDetection(unittest.TestCase):
                     idx = tc_delta.index
                     if idx not in tool_calls_acc:
                         tc_counter += 1
-                        tool_calls_acc[idx] = {"id": getattr(tc_delta, "id", None) or f"tc_{tc_counter}", "name": "", "arguments": ""}
+                        tool_calls_acc[idx] = {
+                            "id": getattr(tc_delta, "id", None) or f"tc_{tc_counter}",
+                            "name": "",
+                            "arguments": "",
+                        }
                     if tc_delta.id:
                         tool_calls_acc[idx]["id"] = tc_delta.id
                     if tc_delta.function:
                         if tc_delta.function.name:
                             tool_calls_acc[idx]["name"] = tc_delta.function.name
                         if tc_delta.function.arguments:
-                            tool_calls_acc[idx]["arguments"] += tc_delta.function.arguments
+                            tool_calls_acc[idx][
+                                "arguments"
+                            ] += tc_delta.function.arguments
         self.assertEqual(len(tool_calls_acc), 1)
         self.assertEqual(tool_calls_acc[0]["name"], "bash")
         self.assertEqual(tool_calls_acc[0]["arguments"], '{"command": "date"}')
@@ -126,10 +137,12 @@ class TestToolCallDetection(unittest.TestCase):
     def test_multiple_tool_calls(self):
         tool_calls_acc = {}
         tc_counter = 0
-        stream = make_tool_call_stream([
-            ("c1", "bash", '{"command": "date"}'),
-            ("c2", "python", '{"code": "print(42)"}'),
-        ])
+        stream = make_tool_call_stream(
+            [
+                ("c1", "bash", '{"command": "date"}'),
+                ("c2", "python", '{"code": "print(42)"}'),
+            ]
+        )
         for chunk in stream:
             delta = chunk.choices[0].delta
             if getattr(delta, "tool_calls", None):
@@ -137,14 +150,20 @@ class TestToolCallDetection(unittest.TestCase):
                     idx = tc_delta.index
                     if idx not in tool_calls_acc:
                         tc_counter += 1
-                        tool_calls_acc[idx] = {"id": getattr(tc_delta, "id", None) or f"tc_{tc_counter}", "name": "", "arguments": ""}
+                        tool_calls_acc[idx] = {
+                            "id": getattr(tc_delta, "id", None) or f"tc_{tc_counter}",
+                            "name": "",
+                            "arguments": "",
+                        }
                     if tc_delta.id:
                         tool_calls_acc[idx]["id"] = tc_delta.id
                     if tc_delta.function:
                         if tc_delta.function.name:
                             tool_calls_acc[idx]["name"] = tc_delta.function.name
                         if tc_delta.function.arguments:
-                            tool_calls_acc[idx]["arguments"] += tc_delta.function.arguments
+                            tool_calls_acc[idx][
+                                "arguments"
+                            ] += tc_delta.function.arguments
         self.assertEqual(len(tool_calls_acc), 2)
         self.assertEqual(tool_calls_acc[0]["name"], "bash")
         self.assertEqual(tool_calls_acc[1]["name"], "python")
@@ -168,26 +187,32 @@ class TestToolExecution(unittest.TestCase):
 
     def test_bash_tool(self):
         from wee_runtime import execute_tool
+
         self.assertEqual(execute_tool("bash", {"command": "echo hello"}), "hello")
 
     def test_python_tool(self):
         from wee_runtime import execute_tool
+
         self.assertEqual(execute_tool("python", {"code": "print(2 + 2)"}), "4")
 
     def test_unknown_tool(self):
         from wee_runtime import execute_tool
+
         self.assertIn("Error: Unknown tool", execute_tool("unknown", {}))
 
     def test_empty_command(self):
         from wee_runtime import execute_tool
+
         self.assertIn("Error: No command", execute_tool("bash", {"command": ""}))
 
     def test_empty_code(self):
         from wee_runtime import execute_tool
+
         self.assertIn("Error: No code", execute_tool("python", {"code": ""}))
 
     def test_bash_stderr(self):
         from wee_runtime import execute_tool
+
         result = execute_tool("bash", {"command": "echo err >&2 && exit 1"})
         self.assertIn("STDERR", result)
 
@@ -203,14 +228,26 @@ class TestAgenticLoop(unittest.TestCase):
             iter(list(make_text_stream("Today is Friday"))),
         ]
         mgr = _create_test_manager()
-        with patch.object(mgr, "get_or_create_session_data", return_value={"channel": "api"}), \
-             patch.object(mgr, "build_agent_context_prompt", return_value="ctx"), \
-             patch.object(mgr, "_wee_execute_tool", return_value="Fri Jul 11"), \
-             patch.object(mgr, "_wee_load_messages", return_value=[{"role": "system", "content": "ctx"}]), \
-             patch.object(mgr, "_wee_save_messages"):
+        with patch.object(
+            mgr, "get_or_create_session_data", return_value={"channel": "api"}
+        ), patch.object(
+            mgr, "build_agent_context_prompt", return_value="ctx"
+        ), patch.object(
+            mgr, "_wee_execute_tool", return_value="Fri Jul 11"
+        ), patch.object(
+            mgr,
+            "_wee_load_messages",
+            return_value=[{"role": "system", "content": "ctx"}],
+        ), patch.object(
+            mgr, "_wee_save_messages"
+        ):
             result = mgr.run_wee_native(
-                model="qwen3:8b", prompt="What day?", agent="orchestrator",
-                session_id=None, resume=True, n8n_session_id="t107_1",
+                model="qwen3:8b",
+                prompt="What day?",
+                agent="orchestrator",
+                session_id=None,
+                resume=True,
+                n8n_session_id="t107_1",
             )
         self.assertEqual(result, "Today is Friday")
         self.assertEqual(mock_client.chat.completions.create.call_count, 2)
@@ -219,15 +256,26 @@ class TestAgenticLoop(unittest.TestCase):
     def test_no_tool_calls_direct(self, mock_cls):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter(list(make_text_stream("Simple")))
+        mock_client.chat.completions.create.return_value = iter(
+            list(make_text_stream("Simple"))
+        )
         mgr = _create_test_manager()
-        with patch.object(mgr, "get_or_create_session_data", return_value={"channel": "api"}), \
-             patch.object(mgr, "build_agent_context_prompt", return_value=""), \
-             patch.object(mgr, "_wee_load_messages", return_value=[]), \
-             patch.object(mgr, "_wee_save_messages"):
+        with patch.object(
+            mgr, "get_or_create_session_data", return_value={"channel": "api"}
+        ), patch.object(
+            mgr, "build_agent_context_prompt", return_value=""
+        ), patch.object(
+            mgr, "_wee_load_messages", return_value=[]
+        ), patch.object(
+            mgr, "_wee_save_messages"
+        ):
             result = mgr.run_wee_native(
-                model="qwen3:8b", prompt="Hi", agent="orchestrator",
-                session_id=None, resume=True, n8n_session_id="t107_2",
+                model="qwen3:8b",
+                prompt="Hi",
+                agent="orchestrator",
+                session_id=None,
+                resume=True,
+                n8n_session_id="t107_2",
             )
         self.assertEqual(result, "Simple")
         self.assertEqual(mock_client.chat.completions.create.call_count, 1)
@@ -237,21 +285,39 @@ class TestAgenticLoop(unittest.TestCase):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
         mock_client.chat.completions.create.side_effect = [
-            iter(list(make_tool_call_stream([("call_42", "bash", '{"command": "whoami"}')]))),
+            iter(
+                list(
+                    make_tool_call_stream(
+                        [("call_42", "bash", '{"command": "whoami"}')]
+                    )
+                )
+            ),
             iter(list(make_text_stream("root"))),
         ]
         mgr = _create_test_manager()
         saved = []
+
         def capture(sid, msgs):
             saved.extend(msgs)
-        with patch.object(mgr, "get_or_create_session_data", return_value={"channel": "api"}), \
-             patch.object(mgr, "build_agent_context_prompt", return_value=""), \
-             patch.object(mgr, "_wee_execute_tool", return_value="root"), \
-             patch.object(mgr, "_wee_load_messages", return_value=[]), \
-             patch.object(mgr, "_wee_save_messages", side_effect=capture):
+
+        with patch.object(
+            mgr, "get_or_create_session_data", return_value={"channel": "api"}
+        ), patch.object(
+            mgr, "build_agent_context_prompt", return_value=""
+        ), patch.object(
+            mgr, "_wee_execute_tool", return_value="root"
+        ), patch.object(
+            mgr, "_wee_load_messages", return_value=[]
+        ), patch.object(
+            mgr, "_wee_save_messages", side_effect=capture
+        ):
             mgr.run_wee_native(
-                model="qwen3:8b", prompt="whoami", agent="orchestrator",
-                session_id=None, resume=True, n8n_session_id="t107_3",
+                model="qwen3:8b",
+                prompt="whoami",
+                agent="orchestrator",
+                session_id=None,
+                resume=True,
+                n8n_session_id="t107_3",
             )
         tool_msgs = [m for m in saved if m.get("role") == "tool"]
         self.assertTrue(len(tool_msgs) >= 1)
@@ -263,25 +329,43 @@ class TestAgenticLoop(unittest.TestCase):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
         mock_client.chat.completions.create.side_effect = [
-            iter(list(make_tool_call_stream([
-                ("ca", "bash", '{"command": "date"}'),
-                ("cb", "python", '{"code": "print(42)"}'),
-            ]))),
+            iter(
+                list(
+                    make_tool_call_stream(
+                        [
+                            ("ca", "bash", '{"command": "date"}'),
+                            ("cb", "python", '{"code": "print(42)"}'),
+                        ]
+                    )
+                )
+            ),
             iter(list(make_text_stream("Done"))),
         ]
         mgr = _create_test_manager()
         calls = []
+
         def track(fn, fa, ag):
             calls.append(fn)
             return "r"
-        with patch.object(mgr, "get_or_create_session_data", return_value={"channel": "api"}), \
-             patch.object(mgr, "build_agent_context_prompt", return_value=""), \
-             patch.object(mgr, "_wee_execute_tool", side_effect=track), \
-             patch.object(mgr, "_wee_load_messages", return_value=[]), \
-             patch.object(mgr, "_wee_save_messages"):
+
+        with patch.object(
+            mgr, "get_or_create_session_data", return_value={"channel": "api"}
+        ), patch.object(
+            mgr, "build_agent_context_prompt", return_value=""
+        ), patch.object(
+            mgr, "_wee_execute_tool", side_effect=track
+        ), patch.object(
+            mgr, "_wee_load_messages", return_value=[]
+        ), patch.object(
+            mgr, "_wee_save_messages"
+        ):
             result = mgr.run_wee_native(
-                model="qwen3:8b", prompt="two things", agent="orchestrator",
-                session_id=None, resume=True, n8n_session_id="t107_4",
+                model="qwen3:8b",
+                prompt="two things",
+                agent="orchestrator",
+                session_id=None,
+                resume=True,
+                n8n_session_id="t107_4",
             )
         self.assertEqual(len(calls), 2)
         self.assertEqual(result, "Done")
@@ -298,14 +382,24 @@ class TestMaxRoundsSafetyNet(unittest.TestCase):
             for _ in range(12)
         ]
         mgr = _create_test_manager()
-        with patch.object(mgr, "get_or_create_session_data", return_value={"channel": "api"}), \
-             patch.object(mgr, "build_agent_context_prompt", return_value=""), \
-             patch.object(mgr, "_wee_execute_tool", return_value="round result"), \
-             patch.object(mgr, "_wee_load_messages", return_value=[]), \
-             patch.object(mgr, "_wee_save_messages"):
+        with patch.object(
+            mgr, "get_or_create_session_data", return_value={"channel": "api"}
+        ), patch.object(
+            mgr, "build_agent_context_prompt", return_value=""
+        ), patch.object(
+            mgr, "_wee_execute_tool", return_value="round result"
+        ), patch.object(
+            mgr, "_wee_load_messages", return_value=[]
+        ), patch.object(
+            mgr, "_wee_save_messages"
+        ):
             result = mgr.run_wee_native(
-                model="qwen3:8b", prompt="loop", agent="orchestrator",
-                session_id=None, resume=True, n8n_session_id="t107_5",
+                model="qwen3:8b",
+                prompt="loop",
+                agent="orchestrator",
+                session_id=None,
+                resume=True,
+                n8n_session_id="t107_5",
             )
         self.assertIn("Tool execution completed", result)
         self.assertIn("round result", result)
@@ -322,13 +416,22 @@ class TestToolsRetryFallback(unittest.TestCase):
             iter(list(make_text_stream("Fallback"))),
         ]
         mgr = _create_test_manager()
-        with patch.object(mgr, "get_or_create_session_data", return_value={"channel": "api"}), \
-             patch.object(mgr, "build_agent_context_prompt", return_value=""), \
-             patch.object(mgr, "_wee_load_messages", return_value=[]), \
-             patch.object(mgr, "_wee_save_messages"):
+        with patch.object(
+            mgr, "get_or_create_session_data", return_value={"channel": "api"}
+        ), patch.object(
+            mgr, "build_agent_context_prompt", return_value=""
+        ), patch.object(
+            mgr, "_wee_load_messages", return_value=[]
+        ), patch.object(
+            mgr, "_wee_save_messages"
+        ):
             result = mgr.run_wee_native(
-                model="qwen3:8b", prompt="Hi", agent="orchestrator",
-                session_id=None, resume=True, n8n_session_id="t107_6",
+                model="qwen3:8b",
+                prompt="Hi",
+                agent="orchestrator",
+                session_id=None,
+                resume=True,
+                n8n_session_id="t107_6",
             )
         self.assertEqual(result, "Fallback")
 
@@ -337,24 +440,28 @@ class TestWeeRuntimeStandalone(unittest.TestCase):
 
     def test_resolve_ollama_prefix(self):
         from wee_runtime import resolve_model_and_endpoint
+
         m, b, k = resolve_model_and_endpoint("ollama/qwen3:8b")
         self.assertEqual(m, "qwen3:8b")
         self.assertIn("11434", b)
 
     def test_resolve_no_prefix(self):
         from wee_runtime import resolve_model_and_endpoint
+
         m, b, k = resolve_model_and_endpoint("gemma4:e4b")
         self.assertEqual(m, "gemma4:e4b")
         self.assertIn("11434", b)
 
     def test_tool_definitions(self):
         from wee_runtime import _WEE_TOOLS
+
         names = [t["function"]["name"] for t in _WEE_TOOLS]
         self.assertIn("bash", names)
         self.assertIn("python", names)
 
     def test_constants(self):
         import wee_runtime
+
         self.assertEqual(wee_runtime.MAX_TOOL_ROUNDS, 10)
         self.assertEqual(wee_runtime.TOOL_TIMEOUT, 120)
 

--- a/tests/test_issue111_wee_tool_audit.py
+++ b/tests/test_issue111_wee_tool_audit.py
@@ -9,6 +9,7 @@ Tests:
 5. _wee_augment_system_prompt_with_tools appends tool section
 6. Skills/AGENTS.md context injected for wee runtime via build_agent_context_prompt
 """
+
 import json
 import os
 import sys
@@ -80,8 +81,15 @@ def _make_tool_call_chunks(tool_id, func_name, arguments_json):
     return chunks
 
 
-def _run_wee_with_openai(mgr, session_id, mock_client, prompt="test",
-                          model="ollama/qwen3:8b", resume=False, **kwargs):
+def _run_wee_with_openai(
+    mgr,
+    session_id,
+    mock_client,
+    prompt="test",
+    model="ollama/qwen3:8b",
+    resume=False,
+    **kwargs,
+):
     """Run wee native with a pre-configured mock OpenAI client."""
     session_data = {
         "runtime": "wee",
@@ -103,9 +111,14 @@ def _run_wee_with_openai(mgr, session_id, mock_client, prompt="test",
     defaults.update(kwargs)
 
     with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
-        with patch.object(mgr, "build_agent_context_prompt",
-                          return_value="[sys] You are a helpful assistant."):
-            with patch.object(mgr, "load_session_map", return_value={session_id: session_data}):
+        with patch.object(
+            mgr,
+            "build_agent_context_prompt",
+            return_value="[sys] You are a helpful assistant.",
+        ):
+            with patch.object(
+                mgr, "load_session_map", return_value={session_id: session_data}
+            ):
                 with patch.object(mgr, "save_session_map"):
                     return mgr.run_wee_native(**defaults)
 
@@ -116,7 +129,7 @@ class TestIssue111ToolAudit(unittest.TestCase):
     @patch("openai.OpenAI")
     def test_build_agent_context_prompt_correct_arg_order(self, mock_openai_cls):
         """Issue #111: build_agent_context_prompt must be called with (agent, prompt, session_id, ...)
-        
+
         The old buggy call was build_agent_context_prompt(prompt, agent, channel, session_id)
         which passed user text as agent name and vice versa.
         """
@@ -125,23 +138,31 @@ class TestIssue111ToolAudit(unittest.TestCase):
         session_data = {"runtime": "wee", "model": "ollama/qwen3:8b", "channel": "api"}
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = iter([_make_text_chunk("done")])
+        mock_client.chat.completions.create.return_value = iter(
+            [_make_text_chunk("done")]
+        )
         mock_openai_cls.return_value = mock_client
 
         captured_calls = []
 
         def capture_context_prompt(agent, prompt, n8n_session_id, **kw):
-            captured_calls.append({
-                "agent": agent,
-                "prompt": prompt,
-                "n8n_session_id": n8n_session_id,
-                "kwargs": kw,
-            })
+            captured_calls.append(
+                {
+                    "agent": agent,
+                    "prompt": prompt,
+                    "n8n_session_id": n8n_session_id,
+                    "kwargs": kw,
+                }
+            )
             return "system prompt for testing"
 
         with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
-            with patch.object(mgr, "build_agent_context_prompt", side_effect=capture_context_prompt):
-                with patch.object(mgr, "load_session_map", return_value={sid: session_data}):
+            with patch.object(
+                mgr, "build_agent_context_prompt", side_effect=capture_context_prompt
+            ):
+                with patch.object(
+                    mgr, "load_session_map", return_value={sid: session_data}
+                ):
                     with patch.object(mgr, "save_session_map"):
                         mgr.run_wee_native(
                             prompt="run ls /opt",
@@ -153,7 +174,9 @@ class TestIssue111ToolAudit(unittest.TestCase):
                             timeout=30,
                         )
 
-        self.assertEqual(len(captured_calls), 1, "build_agent_context_prompt must be called once")
+        self.assertEqual(
+            len(captured_calls), 1, "build_agent_context_prompt must be called once"
+        )
         call_args = captured_calls[0]
 
         # The first positional arg must be the AGENT name, not the user prompt
@@ -182,7 +205,9 @@ class TestIssue111ToolAudit(unittest.TestCase):
         sid = "test_111_tool_schemas"
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = iter([_make_text_chunk("Hello!")])
+        mock_client.chat.completions.create.return_value = iter(
+            [_make_text_chunk("Hello!")]
+        )
         mock_openai_cls.return_value = mock_client
 
         _run_wee_with_openai(mgr, sid, mock_client, prompt="Hello")
@@ -205,7 +230,7 @@ class TestIssue111ToolAudit(unittest.TestCase):
 
     def test_system_prompt_contains_tool_declaration(self):
         """Issue #111: System prompt must explicitly declare available tools.
-        
+
         Many Ollama models ignore JSON tool schemas without a text declaration.
         """
         mgr = _make_mgr()
@@ -230,7 +255,9 @@ class TestIssue111ToolAudit(unittest.TestCase):
             f"System prompt must include tool usage guidance (one of: {tool_keywords})",
         )
         # Original content must be preserved
-        self.assertIn(base_prompt, augmented, "Original prompt content must be preserved")
+        self.assertIn(
+            base_prompt, augmented, "Original prompt content must be preserved"
+        )
         # New content must be appended (not prepended)
         self.assertTrue(
             augmented.startswith(base_prompt),
@@ -260,6 +287,7 @@ class TestIssue111ToolAudit(unittest.TestCase):
         final_chunk = _make_text_chunk("Here are the contents of /opt: ...")
 
         call_count = [0]
+
         def mock_create(**kwargs):
             call_count[0] += 1
             if call_count[0] == 1:
@@ -277,11 +305,18 @@ class TestIssue111ToolAudit(unittest.TestCase):
             return "bin  etc  opt  usr"
 
         with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
-            with patch.object(mgr, "build_agent_context_prompt",
-                              return_value="[sys] bash python tools available"):
-                with patch.object(mgr, "load_session_map", return_value={sid: session_data}):
+            with patch.object(
+                mgr,
+                "build_agent_context_prompt",
+                return_value="[sys] bash python tools available",
+            ):
+                with patch.object(
+                    mgr, "load_session_map", return_value={sid: session_data}
+                ):
                     with patch.object(mgr, "save_session_map"):
-                        with patch.object(mgr, "_wee_execute_tool", side_effect=mock_execute_tool):
+                        with patch.object(
+                            mgr, "_wee_execute_tool", side_effect=mock_execute_tool
+                        ):
                             mgr.run_wee_native(
                                 prompt="run ls /opt and tell me what you see",
                                 model="ollama/qwen3:8b",
@@ -329,7 +364,9 @@ class TestIssue111ToolAudit(unittest.TestCase):
 
         with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
             with patch.object(mgr, "build_agent_context_prompt", return_value="sys"):
-                with patch.object(mgr, "load_session_map", return_value={sid: session_data}):
+                with patch.object(
+                    mgr, "load_session_map", return_value={sid: session_data}
+                ):
                     with patch.object(mgr, "save_session_map"):
                         mgr.run_wee_native(
                             prompt="test",
@@ -341,17 +378,23 @@ class TestIssue111ToolAudit(unittest.TestCase):
                             timeout=30,
                         )
 
-        self.assertGreater(len(captured_tools), 0, "Tools must be captured from API calls")
+        self.assertGreater(
+            len(captured_tools), 0, "Tools must be captured from API calls"
+        )
 
         for tool in captured_tools:
-            self.assertEqual(tool.get("type"), "function", "Tool type must be 'function'")
+            self.assertEqual(
+                tool.get("type"), "function", "Tool type must be 'function'"
+            )
             self.assertIn("function", tool, "Tool must have 'function' key")
             func = tool["function"]
             self.assertIn("name", func, "Tool function must have 'name'")
             self.assertIn("description", func, "Tool function must have 'description'")
             self.assertIn("parameters", func, "Tool function must have 'parameters'")
             params = func["parameters"]
-            self.assertEqual(params.get("type"), "object", "Parameters type must be 'object'")
+            self.assertEqual(
+                params.get("type"), "object", "Parameters type must be 'object'"
+            )
             self.assertIn("properties", params, "Parameters must have 'properties'")
             self.assertIn("required", params, "Parameters must have 'required'")
 
@@ -362,7 +405,9 @@ class TestIssue111ToolAudit(unittest.TestCase):
         sid = "test_111_sys_msg"
         session_data = {"runtime": "wee", "model": "ollama/qwen3:8b", "channel": "api"}
 
-        expected_sys_content = "[sys] You are a helpful assistant with bash/python tools."
+        expected_sys_content = (
+            "[sys] You are a helpful assistant with bash/python tools."
+        )
 
         captured_messages = []
 
@@ -375,8 +420,12 @@ class TestIssue111ToolAudit(unittest.TestCase):
         mock_openai_cls.return_value = mock_client
 
         with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
-            with patch.object(mgr, "build_agent_context_prompt", return_value=expected_sys_content):
-                with patch.object(mgr, "load_session_map", return_value={sid: session_data}):
+            with patch.object(
+                mgr, "build_agent_context_prompt", return_value=expected_sys_content
+            ):
+                with patch.object(
+                    mgr, "load_session_map", return_value={sid: session_data}
+                ):
                     with patch.object(mgr, "save_session_map"):
                         mgr.run_wee_native(
                             prompt="test user message",
@@ -389,7 +438,9 @@ class TestIssue111ToolAudit(unittest.TestCase):
                         )
 
         system_msgs = [m for m in captured_messages if m.get("role") == "system"]
-        self.assertGreater(len(system_msgs), 0, "At least one system message must be in API call")
+        self.assertGreater(
+            len(system_msgs), 0, "At least one system message must be in API call"
+        )
         sys_content = system_msgs[0]["content"]
         # The augmented prompt must contain the base content
         self.assertIn(

--- a/tests/test_issue113_ssh_sanitize.py
+++ b/tests/test_issue113_ssh_sanitize.py
@@ -7,10 +7,8 @@ Tests cover:
 """
 
 import os
-
 import sys
 import unittest
-
 
 # ---------------------------------------------------------------------------
 # Standalone wee_runtime tests
@@ -147,6 +145,7 @@ class TestSSHBinRegex(unittest.TestCase):
 # agent_manager.py SessionManager static method tests
 # ---------------------------------------------------------------------------
 
+
 class TestSessionManagerSanitize(unittest.TestCase):
     """Test SessionManager._wee_sanitize_bash_command (same logic, class method)."""
 
@@ -157,6 +156,7 @@ class TestSessionManagerSanitize(unittest.TestCase):
             # Try to import just the class without starting the server
             import importlib
             import importlib.util
+
             spec = importlib.util.spec_from_file_location(  # noqa: F841
                 "agent_manager_mod",
                 "/opt/n8n-copilot-shim-dev/agent_manager.py",
@@ -189,7 +189,7 @@ class TestSessionManagerSanitize(unittest.TestCase):
         idx = content.find("def run_wee_native(")
         self.assertGreater(idx, 0, "run_wee_native not found")
         # Check within the next ~200 lines
-        method_slice = content[idx:idx + 5000]
+        method_slice = content[idx : idx + 5000]
         self.assertIn("_wee_anti_hallucination_prompt()", method_slice)
 
     def test_ssh_regex_compiled_as_class_attribute(self):
@@ -204,28 +204,50 @@ class TestKnownHostsInfrastructure(unittest.TestCase):
     def test_known_hosts_has_dev_host_key(self):
         """Verify 192.168.1.100 is in root's known_hosts on the dev host."""
         import subprocess
+
         result = subprocess.run(
-            ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes",
-             "root@192.168.1.100",
-             "grep -c '192.168.1.100' ~/.ssh/known_hosts"],
-            capture_output=True, text=True, timeout=10,
+            [
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "BatchMode=yes",
+                "root@192.168.1.100",
+                "grep -c '192.168.1.100' ~/.ssh/known_hosts",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         count = int(result.stdout.strip() or "0")
-        self.assertGreater(count, 0,
-                           "192.168.1.100 not in known_hosts on dev host — "
-                           "run: ssh-keyscan 192.168.1.100 >> ~/.ssh/known_hosts")
+        self.assertGreater(
+            count,
+            0,
+            "192.168.1.100 not in known_hosts on dev host — "
+            "run: ssh-keyscan 192.168.1.100 >> ~/.ssh/known_hosts",
+        )
 
     def test_loopback_ssh_works(self):
         """Verify SSH from dev host to itself works."""
         import subprocess
+
         result = subprocess.run(
-            ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes",
-             "root@192.168.1.100",
-             "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes root@192.168.1.100 echo SSH_LOOPBACK_OK"],  # noqa: E501
-            capture_output=True, text=True, timeout=15,
+            [
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "BatchMode=yes",
+                "root@192.168.1.100",
+                "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes root@192.168.1.100 echo SSH_LOOPBACK_OK",
+            ],  # noqa: E501
+            capture_output=True,
+            text=True,
+            timeout=15,
         )
-        self.assertIn("SSH_LOOPBACK_OK", result.stdout,
-                       f"Loopback SSH failed: {result.stderr}")  # noqa: E127
+        self.assertIn(
+            "SSH_LOOPBACK_OK", result.stdout, f"Loopback SSH failed: {result.stderr}"
+        )  # noqa: E127
 
 
 if __name__ == "__main__":

--- a/tests/test_issue114_model_discovery.py
+++ b/tests/test_issue114_model_discovery.py
@@ -18,7 +18,7 @@ import sys
 import threading
 import time
 import unittest
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 # Ensure the dev codebase is importable
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -33,6 +33,7 @@ class TestWeeModelDiscoveryInit(unittest.TestCase):
     def test_import(self):
         """wee_model_discovery module is importable."""
         import wee_model_discovery
+
         self.assertTrue(hasattr(wee_model_discovery, "WeeModelDiscovery"))
         self.assertTrue(hasattr(wee_model_discovery, "discover_wee_models"))
         self.assertTrue(hasattr(wee_model_discovery, "get_discovery"))
@@ -40,6 +41,7 @@ class TestWeeModelDiscoveryInit(unittest.TestCase):
     def test_default_hosts(self):
         """Default hosts include Ollama on kubuntu."""
         from wee_model_discovery import _DEFAULT_HOSTS
+
         self.assertTrue(len(_DEFAULT_HOSTS) >= 1)
         self.assertEqual(_DEFAULT_HOSTS[0]["type"], "ollama")
         self.assertIn("192.168.1.101", _DEFAULT_HOSTS[0]["url"])
@@ -47,6 +49,7 @@ class TestWeeModelDiscoveryInit(unittest.TestCase):
     def test_custom_ttl(self):
         """Custom TTL and timeout are respected."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=120, timeout=10)
         self.assertEqual(d.ttl, 120)
         self.assertEqual(d.timeout, 10)
@@ -54,7 +57,15 @@ class TestWeeModelDiscoveryInit(unittest.TestCase):
     def test_env_hosts_override(self):
         """WEE_DISCOVERY_HOSTS env var overrides default hosts."""
         from wee_model_discovery import _load_hosts
-        custom = [{"name": "test", "type": "ollama", "url": "http://localhost:11434", "prefix": "test"}]
+
+        custom = [
+            {
+                "name": "test",
+                "type": "ollama",
+                "url": "http://localhost:11434",
+                "prefix": "test",
+            }
+        ]
         with patch.dict(os.environ, {"WEE_DISCOVERY_HOSTS": json.dumps(custom)}):
             hosts = _load_hosts()
             self.assertEqual(len(hosts), 1)
@@ -62,7 +73,8 @@ class TestWeeModelDiscoveryInit(unittest.TestCase):
 
     def test_env_hosts_invalid_json_falls_back(self):
         """Invalid JSON in WEE_DISCOVERY_HOSTS falls back to defaults."""
-        from wee_model_discovery import _load_hosts, _DEFAULT_HOSTS
+        from wee_model_discovery import _DEFAULT_HOSTS, _load_hosts
+
         with patch.dict(os.environ, {"WEE_DISCOVERY_HOSTS": "not-json"}):
             hosts = _load_hosts()
             self.assertEqual(hosts, _DEFAULT_HOSTS)
@@ -70,6 +82,7 @@ class TestWeeModelDiscoveryInit(unittest.TestCase):
     def test_singleton_pattern(self):
         """get_discovery() returns the same instance on repeated calls."""
         import wee_model_discovery
+
         # Reset singleton for clean test
         wee_model_discovery._discovery_instance = None
         d1 = wee_model_discovery.get_discovery()
@@ -84,16 +97,27 @@ class TestOllamaDiscovery(unittest.TestCase):
 
     def setUp(self):
         from wee_model_discovery import WeeModelDiscovery
+
         self.discovery = WeeModelDiscovery(ttl=60, timeout=5)
 
     def test_discover_ollama_success(self):
         """Ollama /api/tags discovery parses model names correctly."""
-        mock_response = json.dumps({
-            "models": [
-                {"name": "gemma4:latest", "size": 5000000000, "modified_at": "2026-01-01T00:00:00Z"},
-                {"name": "qwen3:8b", "size": 4000000000, "modified_at": "2026-01-02T00:00:00Z"},
-            ]
-        }).encode()
+        mock_response = json.dumps(
+            {
+                "models": [
+                    {
+                        "name": "gemma4:latest",
+                        "size": 5000000000,
+                        "modified_at": "2026-01-01T00:00:00Z",
+                    },
+                    {
+                        "name": "qwen3:8b",
+                        "size": 4000000000,
+                        "modified_at": "2026-01-02T00:00:00Z",
+                    },
+                ]
+            }
+        ).encode()
         with patch("wee_model_discovery.urlopen") as mock_urlopen:
             mock_resp = MagicMock()
             mock_resp.read.return_value = mock_response
@@ -120,7 +144,10 @@ class TestOllamaDiscovery(unittest.TestCase):
     def test_discover_ollama_unreachable(self):
         """Unreachable Ollama host returns empty list (no crash)."""
         from urllib.error import URLError
-        with patch("wee_model_discovery.urlopen", side_effect=URLError("Connection refused")):
+
+        with patch(
+            "wee_model_discovery.urlopen", side_effect=URLError("Connection refused")
+        ):
             models = self.discovery.discover_ollama("http://unreachable:11434")
             self.assertEqual(models, [])
 
@@ -130,16 +157,19 @@ class TestOpenAICompatDiscovery(unittest.TestCase):
 
     def setUp(self):
         from wee_model_discovery import WeeModelDiscovery
+
         self.discovery = WeeModelDiscovery(ttl=60, timeout=5)
 
     def test_discover_openai_compat_success(self):
         """OpenAI-compat /v1/models returns model IDs."""
-        mock_response = json.dumps({
-            "data": [
-                {"id": "gpt-4", "object": "model"},
-                {"id": "gpt-3.5-turbo", "object": "model"},
-            ]
-        }).encode()
+        mock_response = json.dumps(
+            {
+                "data": [
+                    {"id": "gpt-4", "object": "model"},
+                    {"id": "gpt-3.5-turbo", "object": "model"},
+                ]
+            }
+        ).encode()
         with patch("wee_model_discovery.urlopen") as mock_urlopen:
             mock_resp = MagicMock()
             mock_resp.read.return_value = mock_response
@@ -153,7 +183,10 @@ class TestOpenAICompatDiscovery(unittest.TestCase):
     def test_discover_openai_compat_unreachable(self):
         """Unreachable OpenAI-compat host returns empty list."""
         from urllib.error import URLError
-        with patch("wee_model_discovery.urlopen", side_effect=URLError("Connection refused")):
+
+        with patch(
+            "wee_model_discovery.urlopen", side_effect=URLError("Connection refused")
+        ):
             models = self.discovery.discover_openai_compat("http://unreachable:1234")
             self.assertEqual(models, [])
 
@@ -164,16 +197,26 @@ class TestDiscoverAll(unittest.TestCase):
     def test_discover_all_with_prefix(self):
         """Models are prefixed with provider name."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=60, timeout=5)
 
-        mock_response = json.dumps({
-            "models": [
-                {"name": "gemma4:latest"},
-                {"name": "qwen3:8b"},
-            ]
-        }).encode()
+        mock_response = json.dumps(
+            {
+                "models": [
+                    {"name": "gemma4:latest"},
+                    {"name": "qwen3:8b"},
+                ]
+            }
+        ).encode()
 
-        hosts = [{"name": "kubuntu", "type": "ollama", "url": "http://test:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "kubuntu",
+                "type": "ollama",
+                "url": "http://test:11434",
+                "prefix": "ollama",
+            }
+        ]
         with patch("wee_model_discovery._load_hosts", return_value=hosts):
             with patch("wee_model_discovery.urlopen") as mock_urlopen:
                 mock_resp = MagicMock()
@@ -189,11 +232,20 @@ class TestDiscoverAll(unittest.TestCase):
 
     def test_discover_all_offline_host(self):
         """Offline host shows offline indicator."""
-        from wee_model_discovery import WeeModelDiscovery
         from urllib.error import URLError
+
+        from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=60, timeout=5)
 
-        hosts = [{"name": "down-host", "type": "ollama", "url": "http://down:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "down-host",
+                "type": "ollama",
+                "url": "http://down:11434",
+                "prefix": "ollama",
+            }
+        ]
         with patch("wee_model_discovery._load_hosts", return_value=hosts):
             with patch("wee_model_discovery.urlopen", side_effect=URLError("refused")):
                 result = d.discover_all()
@@ -203,11 +255,22 @@ class TestDiscoverAll(unittest.TestCase):
     def test_discover_all_multiple_hosts(self):
         """Multiple hosts are all queried and grouped."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=60, timeout=5)
 
         hosts = [
-            {"name": "host1", "type": "ollama", "url": "http://h1:11434", "prefix": "ollama"},
-            {"name": "host2", "type": "openai-compat", "url": "http://h2:1234", "prefix": "lmstudio"},
+            {
+                "name": "host1",
+                "type": "ollama",
+                "url": "http://h1:11434",
+                "prefix": "ollama",
+            },
+            {
+                "name": "host2",
+                "type": "openai-compat",
+                "url": "http://h2:1234",
+                "prefix": "lmstudio",
+            },
         ]
 
         def mock_fetch(url):
@@ -223,7 +286,9 @@ class TestDiscoverAll(unittest.TestCase):
                 self.assertIn("host1 (ollama)", result)
                 self.assertIn("host2 (openai-compat)", result)
                 self.assertEqual(result["host1 (ollama)"], ["ollama/gemma4:latest"])
-                self.assertEqual(result["host2 (openai-compat)"], ["lmstudio/local-model"])
+                self.assertEqual(
+                    result["host2 (openai-compat)"], ["lmstudio/local-model"]
+                )
 
 
 class TestCaching(unittest.TestCase):
@@ -232,12 +297,21 @@ class TestCaching(unittest.TestCase):
     def test_cache_hit_within_ttl(self):
         """Second call within TTL uses cached results (no network call)."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=60, timeout=5)
 
-        hosts = [{"name": "h1", "type": "ollama", "url": "http://h1:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "h1",
+                "type": "ollama",
+                "url": "http://h1:11434",
+                "prefix": "ollama",
+            }
+        ]
         mock_response = {"models": [{"name": "model1"}]}
 
         call_count = 0
+
         def counting_fetch(url):
             nonlocal call_count
             call_count += 1
@@ -253,12 +327,21 @@ class TestCaching(unittest.TestCase):
     def test_cache_miss_after_ttl(self):
         """Cache expires after TTL, triggers fresh discovery."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=1, timeout=5)  # 1-second TTL
 
-        hosts = [{"name": "h1", "type": "ollama", "url": "http://h1:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "h1",
+                "type": "ollama",
+                "url": "http://h1:11434",
+                "prefix": "ollama",
+            }
+        ]
         mock_response = {"models": [{"name": "model1"}]}
 
         call_count = 0
+
         def counting_fetch(url):
             nonlocal call_count
             call_count += 1
@@ -274,12 +357,21 @@ class TestCaching(unittest.TestCase):
     def test_force_bypasses_cache(self):
         """force=True always makes a network call."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=600, timeout=5)
 
-        hosts = [{"name": "h1", "type": "ollama", "url": "http://h1:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "h1",
+                "type": "ollama",
+                "url": "http://h1:11434",
+                "prefix": "ollama",
+            }
+        ]
         mock_response = {"models": [{"name": "model1"}]}
 
         call_count = 0
+
         def counting_fetch(url):
             nonlocal call_count
             call_count += 1
@@ -294,6 +386,7 @@ class TestCaching(unittest.TestCase):
     def test_invalidate_cache(self):
         """invalidate_cache clears all cached data."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=600, timeout=5)
         d._cache["test"] = (time.time(), ["model1"])
         d._cache_status["test"] = "online"
@@ -309,9 +402,12 @@ class TestCaching(unittest.TestCase):
         the old value was read, so fallback always returned [].
         """
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=1, timeout=5)  # 1-second TTL
 
-        hosts = [{"name": "h", "type": "ollama", "url": "http://h:11434", "prefix": "ollama"}]
+        hosts = [
+            {"name": "h", "type": "ollama", "url": "http://h:11434", "prefix": "ollama"}
+        ]
         online_response = {"models": [{"name": "gemma4:latest"}]}
 
         with patch("wee_model_discovery._load_hosts", return_value=hosts):
@@ -336,7 +432,8 @@ class TestCaching(unittest.TestCase):
         # Must show the cached group with the previously-discovered models
         cached_key = "h (ollama) (cached)"
         self.assertIn(
-            cached_key, result2,
+            cached_key,
+            result2,
             f"Expected '{cached_key}' in result. Got: {list(result2.keys())}",
         )
         self.assertIn("ollama/gemma4:latest", result2[cached_key])
@@ -348,9 +445,17 @@ class TestHostStatus(unittest.TestCase):
     def test_host_status_online(self):
         """Online host is tracked as 'online'."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=60, timeout=5)
 
-        hosts = [{"name": "h1", "type": "ollama", "url": "http://h1:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "h1",
+                "type": "ollama",
+                "url": "http://h1:11434",
+                "prefix": "ollama",
+            }
+        ]
         mock_response = {"models": [{"name": "model1"}]}
 
         with patch("wee_model_discovery._load_hosts", return_value=hosts):
@@ -362,9 +467,17 @@ class TestHostStatus(unittest.TestCase):
     def test_host_status_offline(self):
         """Offline host is tracked as 'offline'."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=60, timeout=5)
 
-        hosts = [{"name": "h1", "type": "ollama", "url": "http://h1:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "h1",
+                "type": "ollama",
+                "url": "http://h1:11434",
+                "prefix": "ollama",
+            }
+        ]
 
         with patch("wee_model_discovery._load_hosts", return_value=hosts):
             with patch.object(d, "_fetch_json", return_value=None):
@@ -382,6 +495,7 @@ class TestFetchWeeModels(unittest.TestCase):
     def _get_session_mgr(self):
         """Get a SessionManager instance for testing."""
         from agent_manager import SessionManager
+
         return SessionManager.__new__(SessionManager)
 
     def test_fetch_wee_models_calls_discovery(self):
@@ -389,14 +503,18 @@ class TestFetchWeeModels(unittest.TestCase):
         mgr = self._get_session_mgr()
         mock_result = {"kubuntu (ollama)": ["ollama/gemma4:latest", "ollama/qwen3:8b"]}
         with patch("agent_manager.discover_wee_models", mock_result, create=True):
-            with patch("wee_model_discovery.discover_wee_models", return_value=mock_result):
+            with patch(
+                "wee_model_discovery.discover_wee_models", return_value=mock_result
+            ):
                 result = mgr._fetch_wee_models()
                 self.assertIn("kubuntu (ollama)", result)
 
     def test_fetch_wee_models_fallback_on_error(self):
         """_fetch_wee_models falls back to static list on exception."""
         mgr = self._get_session_mgr()
-        with patch("wee_model_discovery.discover_wee_models", side_effect=RuntimeError("boom")):
+        with patch(
+            "wee_model_discovery.discover_wee_models", side_effect=RuntimeError("boom")
+        ):
             result = mgr._fetch_wee_models()
             self.assertIn("Wee Native (static)", result)
             models = result["Wee Native (static)"]
@@ -411,7 +529,9 @@ class TestFetchWeeModels(unittest.TestCase):
             result = mgr._fetch_wee_models()
             for group, models in result.items():
                 for m in models:
-                    self.assertIsInstance(m, str, f"Model {m!r} in group {group!r} is not a string")
+                    self.assertIsInstance(
+                        m, str, f"Model {m!r} in group {group!r} is not a string"
+                    )
 
 
 class TestGetModelsForRuntimeWee(unittest.TestCase):
@@ -419,6 +539,7 @@ class TestGetModelsForRuntimeWee(unittest.TestCase):
 
     def _get_session_mgr(self):
         from agent_manager import SessionManager
+
         return SessionManager.__new__(SessionManager)
 
     def test_wee_in_dispatch(self):
@@ -437,10 +558,12 @@ class TestApiModelsEndpointWee(unittest.TestCase):
         """'wee' is in the known_runtimes set in the API endpoint."""
         # Read the source to verify (static analysis)
         import agent_manager
+
         source = open(agent_manager.__file__).read()
         # Find the known_runtimes block in the endpoint
         import re
-        match = re.search(r'known_runtimes\s*=\s*\{([^}]+)\}', source)
+
+        match = re.search(r"known_runtimes\s*=\s*\{([^}]+)\}", source)
         self.assertIsNotNone(match, "Could not find known_runtimes set")
         runtimes_block = match.group(1)
         self.assertIn('"wee"', runtimes_block)
@@ -491,9 +614,17 @@ class TestThreadSafety(unittest.TestCase):
     def test_concurrent_discover_all(self):
         """Multiple threads calling discover_all don't crash."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=60, timeout=5)
 
-        hosts = [{"name": "h1", "type": "ollama", "url": "http://h1:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "h1",
+                "type": "ollama",
+                "url": "http://h1:11434",
+                "prefix": "ollama",
+            }
+        ]
         mock_response = {"models": [{"name": "model1"}, {"name": "model2"}]}
 
         errors = []
@@ -522,15 +653,25 @@ class TestDiscoverAllEnriched(unittest.TestCase):
     def test_enriched_includes_size_and_timestamp(self):
         """Enriched Ollama discovery includes size and modified_at."""
         from wee_model_discovery import WeeModelDiscovery
+
         d = WeeModelDiscovery(ttl=60, timeout=5)
 
-        hosts = [{"name": "kubuntu", "type": "ollama", "url": "http://h1:11434", "prefix": "ollama"}]
+        hosts = [
+            {
+                "name": "kubuntu",
+                "type": "ollama",
+                "url": "http://h1:11434",
+                "prefix": "ollama",
+            }
+        ]
         mock_response = {
-            "models": [{
-                "name": "gemma4:latest",
-                "size": 5000000000,
-                "modified_at": "2026-01-01T00:00:00Z",
-            }]
+            "models": [
+                {
+                    "name": "gemma4:latest",
+                    "size": 5000000000,
+                    "modified_at": "2026-01-01T00:00:00Z",
+                }
+            ]
         }
 
         with patch("wee_model_discovery._load_hosts", return_value=hosts):

--- a/tests/test_issue118_model_selection.py
+++ b/tests/test_issue118_model_selection.py
@@ -69,7 +69,8 @@ class TestFetchWeeModels(unittest.TestCase):
             self.assertIsInstance(models, list, f"Section {section!r} must be a list")
             for m in models:
                 self.assertIsInstance(
-                    m, str,
+                    m,
+                    str,
                     f"Model {m!r} in section {section!r} must be a str, not {type(m)}",
                 )
 
@@ -198,8 +199,9 @@ class TestOllamaPort(unittest.TestCase):
         source = am_path.read_text()
         # Find occurrences of 11436 — there should be none
         import re
+
         # Specifically check that 11436 doesn't appear near ollama
-        ollama_section = re.findall(r'.{100}11436.{100}', source)
+        ollama_section = re.findall(r".{100}11436.{100}", source)
         for ctx in ollama_section:
             if "ollama" in ctx.lower():
                 self.fail(f"Found 11436 near 'ollama' in agent_manager.py: ...{ctx}...")
@@ -226,14 +228,22 @@ class TestRunWeeNativeModelPassthrough(unittest.TestCase):
             captured["base_url"] = kwargs.get("base_url", "")
             captured["model"] = kwargs.get("model", "")
             client = MagicMock()
-            client.chat.completions.create.return_value = iter([
-                MagicMock(choices=[
-                    MagicMock(delta=MagicMock(content="hi"), finish_reason=None)
-                ]),
-                MagicMock(choices=[
-                    MagicMock(delta=MagicMock(content=None), finish_reason="stop")
-                ]),
-            ])
+            client.chat.completions.create.return_value = iter(
+                [
+                    MagicMock(
+                        choices=[
+                            MagicMock(delta=MagicMock(content="hi"), finish_reason=None)
+                        ]
+                    ),
+                    MagicMock(
+                        choices=[
+                            MagicMock(
+                                delta=MagicMock(content=None), finish_reason="stop"
+                            )
+                        ]
+                    ),
+                ]
+            )
             return client
 
         session_data = {
@@ -304,6 +314,7 @@ class TestWeeInKnownRuntimes(unittest.TestCase):
 class TestSessionValidationWee(unittest.TestCase):
     def setUp(self):
         self.mgr = _make_mgr()
+
     """Verify session validation properly handles wee model switching."""
 
     def test_empty_model_gets_default(self):
@@ -313,9 +324,7 @@ class TestSessionValidationWee(unittest.TestCase):
         # Simulate the validation logic
         runtime = "wee"  # noqa: F841
         current_model = session_data.get("model", "")
-        if not current_model or not self.mgr.get_model_from_name(
-            current_model, "wee"
-        ):
+        if not current_model or not self.mgr.get_model_from_name(current_model, "wee"):
             session_data["model"] = os.getenv("WEE_DEFAULT_MODEL", "ollama/gemma4:e4b")
         assert session_data["model"] == "ollama/gemma4:e4b"
 
@@ -324,9 +333,7 @@ class TestSessionValidationWee(unittest.TestCase):
         session_data = {"runtime": "wee", "model": "ollama/gemma4:e4b"}
         runtime = "wee"  # noqa: F841
         current_model = session_data.get("model", "")
-        if not current_model or not self.mgr.get_model_from_name(
-            current_model, "wee"
-        ):
+        if not current_model or not self.mgr.get_model_from_name(current_model, "wee"):
             session_data["model"] = "ollama/gemma4:e4b"
         assert session_data["model"] == "ollama/gemma4:e4b"
 

--- a/tests/test_issue119_openrouter.py
+++ b/tests/test_issue119_openrouter.py
@@ -22,6 +22,7 @@ import pytest
 # ── helpers ─────────────────────────────────────────────────────────────
 sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 
+
 def _get_session_mgr():
     """Instantiate SessionManager without starting the full server."""
     mod = importlib.import_module("agent_manager")
@@ -29,12 +30,14 @@ def _get_session_mgr():
     mgr.__init__()
     return mgr
 
+
 @pytest.fixture(scope="module")
 def mgr():
     return _get_session_mgr()
 
 
 # ── WEE_MODELS constant ────────────────────────────────────────────────
+
 
 class TestWeeModelsConstant:
     def test_wee_models_has_ollama_group(self, mgr):
@@ -64,6 +67,7 @@ class TestWeeModelsConstant:
 
 # ── OPENROUTER_POPULAR_MODELS ──────────────────────────────────────────
 
+
 class TestOpenrouterPopularModels:
     def test_is_a_set(self, mgr):
         assert isinstance(mgr.OPENROUTER_POPULAR_MODELS, set)
@@ -81,11 +85,13 @@ class TestOpenrouterPopularModels:
 
     def test_ids_have_no_openrouter_prefix(self, mgr):
         for mid in mgr.OPENROUTER_POPULAR_MODELS:
-            assert not mid.startswith("openrouter/"), \
-                f"Popular model IDs should be bare provider/model: {mid}"
+            assert not mid.startswith(
+                "openrouter/"
+            ), f"Popular model IDs should be bare provider/model: {mid}"
 
 
 # ── fetch_wee_models() ─────────────────────────────────────────────────
+
 
 class TestFetchWeeModels:
     def test_returns_dict_with_string_keys(self, mgr):
@@ -97,8 +103,9 @@ class TestFetchWeeModels:
             assert isinstance(k, str)
             assert isinstance(v, list)
             for model_id in v:
-                assert isinstance(model_id, str), \
-                    f"Expected flat string IDs, got {type(model_id)}: {model_id}"
+                assert isinstance(
+                    model_id, str
+                ), f"Expected flat string IDs, got {type(model_id)}: {model_id}"
 
     def test_ollama_group_in_result(self, mgr):
         mgr._env_wee_models = None
@@ -155,13 +162,15 @@ class TestFetchWeeModels:
         """Only models in OPENROUTER_POPULAR_MODELS are returned."""
         mgr._env_wee_models = None
         mgr._openrouter_cache_ts = 0
-        fake_api_response = json.dumps({
-            "data": [
-                {"id": "meta-llama/llama-4-maverick", "name": "Llama 4 Maverick"},
-                {"id": "meta-llama/llama-4-scout", "name": "Llama 4 Scout"},
-                {"id": "some-vendor/obscure-model", "name": "Obscure Model"},
-            ]
-        }).encode()
+        fake_api_response = json.dumps(
+            {
+                "data": [
+                    {"id": "meta-llama/llama-4-maverick", "name": "Llama 4 Maverick"},
+                    {"id": "meta-llama/llama-4-scout", "name": "Llama 4 Scout"},
+                    {"id": "some-vendor/obscure-model", "name": "Obscure Model"},
+                ]
+            }
+        ).encode()
         mock_resp = MagicMock()
         mock_resp.read.return_value = fake_api_response
 
@@ -178,11 +187,13 @@ class TestFetchWeeModels:
         """Discovered models get openrouter/ prefix."""
         mgr._env_wee_models = None
         mgr._openrouter_cache_ts = 0
-        fake_api_response = json.dumps({
-            "data": [
-                {"id": "openai/gpt-4.1", "name": "GPT-4.1"},
-            ]
-        }).encode()
+        fake_api_response = json.dumps(
+            {
+                "data": [
+                    {"id": "openai/gpt-4.1", "name": "GPT-4.1"},
+                ]
+            }
+        ).encode()
         mock_resp = MagicMock()
         mock_resp.read.return_value = fake_api_response
 
@@ -196,13 +207,16 @@ class TestFetchWeeModels:
 
 # ── _get_model_description ──────────────────────────────────────────────
 
+
 class TestGetModelDescription:
     def test_ollama_model_description(self, mgr):
         desc = mgr._get_model_description("ollama/gemma4:e4b", "wee")
         assert desc and "Gemma" in desc
 
     def test_openrouter_static_model_description(self, mgr):
-        desc = mgr._get_model_description("openrouter/meta-llama/llama-4-maverick", "wee")
+        desc = mgr._get_model_description(
+            "openrouter/meta-llama/llama-4-maverick", "wee"
+        )
         assert desc and ("Llama" in desc or "Maverick" in desc)
 
     def test_unknown_model_returns_none_or_empty(self, mgr):
@@ -212,6 +226,7 @@ class TestGetModelDescription:
 
 
 # ── get_model_from_name ─────────────────────────────────────────────────
+
 
 class TestGetModelFromName:
     def _reset_cache(self, mgr):
@@ -231,7 +246,9 @@ class TestGetModelFromName:
 
     def test_openrouter_exact_id(self, mgr):
         self._reset_cache(mgr)
-        result = mgr.get_model_from_name("openrouter/meta-llama/llama-4-maverick", "wee")
+        result = mgr.get_model_from_name(
+            "openrouter/meta-llama/llama-4-maverick", "wee"
+        )
         assert result == "openrouter/meta-llama/llama-4-maverick"
 
     def test_openrouter_alias(self, mgr):
@@ -247,6 +264,7 @@ class TestGetModelFromName:
 
 # ── /api/v1/models endpoint ────────────────────────────────────────────
 
+
 class TestModelsEndpoint:
     def test_wee_in_known_runtimes(self, mgr):
         """Verify wee is accepted as a valid runtime."""
@@ -257,14 +275,13 @@ class TestModelsEndpoint:
 
     def test_endpoint_returns_models(self):
         """Hit the real endpoint on the dev server."""
-        import urllib.request
         import ssl
+        import urllib.request
+
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
-        req = urllib.request.Request(
-            "https://127.0.0.1:8001/api/v1/models?runtime=wee"
-        )
+        req = urllib.request.Request("https://127.0.0.1:8001/api/v1/models?runtime=wee")
         try:
             resp = urllib.request.urlopen(req, context=ctx, timeout=10)
             data = json.loads(resp.read())
@@ -277,14 +294,13 @@ class TestModelsEndpoint:
 
     def test_endpoint_models_have_group_field(self):
         """Each model in the response should have a group field."""
-        import urllib.request
         import ssl
+        import urllib.request
+
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
-        req = urllib.request.Request(
-            "https://127.0.0.1:8001/api/v1/models?runtime=wee"
-        )
+        req = urllib.request.Request("https://127.0.0.1:8001/api/v1/models?runtime=wee")
         try:
             resp = urllib.request.urlopen(req, context=ctx, timeout=10)
             data = json.loads(resp.read())
@@ -298,14 +314,13 @@ class TestModelsEndpoint:
 
     def test_endpoint_has_ollama_and_openrouter_groups(self):
         """Response should contain both Ollama and OpenRouter groups."""
-        import urllib.request
         import ssl
+        import urllib.request
+
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
-        req = urllib.request.Request(
-            "https://127.0.0.1:8001/api/v1/models?runtime=wee"
-        )
+        req = urllib.request.Request("https://127.0.0.1:8001/api/v1/models?runtime=wee")
         try:
             resp = urllib.request.urlopen(req, context=ctx, timeout=10)
             data = json.loads(resp.read())
@@ -318,8 +333,9 @@ class TestModelsEndpoint:
 
     def test_endpoint_unknown_runtime_rejected(self):
         """Unknown runtime should return error."""
-        import urllib.request
         import ssl
+        import urllib.request
+
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
@@ -338,6 +354,7 @@ class TestModelsEndpoint:
 
 # ── Session dispatch ────────────────────────────────────────────────────
 
+
 class TestSessionDispatch:
     def test_wee_runtime_resolves_openrouter_model(self, mgr):
         """Selecting an openrouter/ model should pass through to resolve."""
@@ -351,17 +368,20 @@ class TestSessionDispatch:
         """All OpenRouter model IDs in static list have openrouter/ prefix."""
         for entry in mgr.WEE_MODELS.get("Wee Native (OpenRouter)", []):
             model_id = entry[0]
-            assert model_id.startswith("openrouter/"), \
-                f"OpenRouter model should have openrouter/ prefix: {model_id}"
+            assert model_id.startswith(
+                "openrouter/"
+            ), f"OpenRouter model should have openrouter/ prefix: {model_id}"
 
 
 # ── Keyring integration ────────────────────────────────────────────────
+
 
 class TestKeyringIntegration:
     def test_keyring_has_openrouter_key(self):
         """keyring should have the OpenRouter API key stored."""
         try:
             import keyring
+
             val = keyring.get_password("openrouter", "api_key")
         except Exception:
             pytest.skip("keyring not available")

--- a/tests/test_issue123_124.py
+++ b/tests/test_issue123_124.py
@@ -8,19 +8,21 @@ import json
 import sys
 import time
 import unittest
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 
 
 def make_manager():
     from agent_manager import SessionManager
+
     return SessionManager("/opt/n8n-copilot-shim-dev/agents.json")
 
 
 # ---------------------------------------------------------------------------
 # Issue #124 — Live Ollama model discovery
 # ---------------------------------------------------------------------------
+
 
 class TestLiveOllamaDiscovery(unittest.TestCase):
 
@@ -45,7 +47,9 @@ class TestLiveOllamaDiscovery(unittest.TestCase):
         mgr._ollama_models_cache = ["old_model"]
         mgr._ollama_cache_ts = time.time() - 61  # expired
 
-        fake_tags = json.dumps({"models": [{"name": "gemma4:e4b"}, {"name": "qwen3:8b"}]}).encode()
+        fake_tags = json.dumps(
+            {"models": [{"name": "gemma4:e4b"}, {"name": "qwen3:8b"}]}
+        ).encode()
         mock_resp = MagicMock()
         mock_resp.read.return_value = fake_tags
 
@@ -62,7 +66,9 @@ class TestLiveOllamaDiscovery(unittest.TestCase):
         mgr._ollama_models_cache = ["gemma4:e4b"]
         mgr._ollama_cache_ts = time.time() - 120  # expired
 
-        with patch("urllib.request.urlopen", side_effect=Exception("connection refused")):
+        with patch(
+            "urllib.request.urlopen", side_effect=Exception("connection refused")
+        ):
             result = mgr._fetch_ollama_models_live()
 
         self.assertEqual(result, ["gemma4:e4b"])
@@ -103,7 +109,9 @@ class TestLiveOllamaDiscovery(unittest.TestCase):
 
         ollama_group = result.get("Wee Native (Ollama)", [])
         for mid in ollama_group:
-            self.assertTrue(mid.startswith("ollama/"), f"{mid!r} should start with 'ollama/'")
+            self.assertTrue(
+                mid.startswith("ollama/"), f"{mid!r} should start with 'ollama/'"
+            )
 
     def test_fetch_wee_models_fallback_on_ollama_failure(self):
         """Falls back to static WEE_MODELS Ollama entries when live discovery fails."""
@@ -147,7 +155,9 @@ class TestLiveOllamaDiscovery(unittest.TestCase):
         mgr._ollama_cache_ts = time.time() - 70  # Ollama TTL expired
         mgr._ollama_models_cache = []
 
-        fake_tags = json.dumps({"models": [{"name": "gemma4:e4b"}, {"name": "qwen3:8b"}]}).encode()
+        fake_tags = json.dumps(
+            {"models": [{"name": "gemma4:e4b"}, {"name": "qwen3:8b"}]}
+        ).encode()
         mock_resp = MagicMock()
         mock_resp.read.return_value = fake_tags
 
@@ -173,7 +183,9 @@ class TestLiveOllamaDiscovery(unittest.TestCase):
         # Inject known models
         mgr._ollama_models_cache = ["gemma4:e4b"]
         mgr._ollama_cache_ts = time.time()
-        with patch.object(mgr, "_fetch_ollama_models_live", return_value=["gemma4:e4b"]):
+        with patch.object(
+            mgr, "_fetch_ollama_models_live", return_value=["gemma4:e4b"]
+        ):
             with patch("urllib.request.urlopen", side_effect=Exception("no or")):
                 models = mgr.get_models_for_runtime("wee")
 
@@ -187,6 +199,7 @@ class TestLiveOllamaDiscovery(unittest.TestCase):
 # Issue #123 — Tool call agentic loop
 # ---------------------------------------------------------------------------
 
+
 class TestWeeRuntimeToolLoop(unittest.TestCase):
 
     def test_run_wee_native_exists(self):
@@ -198,7 +211,9 @@ class TestWeeRuntimeToolLoop(unittest.TestCase):
     def test_wee_execute_tool_bash(self):
         """_wee_execute_tool('bash', ...) executes a shell command and returns output."""
         mgr = make_manager()
-        result = mgr._wee_execute_tool("bash", {"command": "echo 'test123'"}, "orchestrator")
+        result = mgr._wee_execute_tool(
+            "bash", {"command": "echo 'test123'"}, "orchestrator"
+        )
         self.assertIn("test123", result)
 
     def test_wee_execute_tool_unknown(self):
@@ -211,7 +226,9 @@ class TestWeeRuntimeToolLoop(unittest.TestCase):
     def test_wee_execute_tool_python(self):
         """_wee_execute_tool('python', ...) executes python code and returns output."""
         mgr = make_manager()
-        result = mgr._wee_execute_tool("python", {"code": "print('hello_py')"}, "orchestrator")
+        result = mgr._wee_execute_tool(
+            "python", {"code": "print('hello_py')"}, "orchestrator"
+        )
         self.assertIn("hello_py", result)
 
     def _make_streaming_mock(self, tool_calls_chunks=None, content_chunks=None):
@@ -228,7 +245,9 @@ class TestWeeRuntimeToolLoop(unittest.TestCase):
                 tc_delta.id = tc.get("id", f"tc_{i}")
                 tc_delta.function = MagicMock()
                 tc_delta.function.name = tc.get("name", "bash")
-                tc_delta.function.arguments = tc.get("arguments", '{"command":"echo hi"}')
+                tc_delta.function.arguments = tc.get(
+                    "arguments", '{"command":"echo hi"}'
+                )
                 delta.tool_calls = [tc_delta]
                 choice = MagicMock()
                 choice.delta = delta
@@ -261,7 +280,9 @@ class TestWeeRuntimeToolLoop(unittest.TestCase):
 
         # Round 1: model calls bash
         round1_chunks = self._make_streaming_mock(
-            tool_calls_chunks=[{"id": "tc_1", "name": "bash", "arguments": '{"command":"echo hello"}'}]
+            tool_calls_chunks=[
+                {"id": "tc_1", "name": "bash", "arguments": '{"command":"echo hello"}'}
+            ]
         )
         # Round 2: model returns final text
         round2_chunks = self._make_streaming_mock(
@@ -269,6 +290,7 @@ class TestWeeRuntimeToolLoop(unittest.TestCase):
         )
 
         call_count = [0]
+
         def mock_create(**kwargs):
             call_count[0] += 1
             if call_count[0] == 1:
@@ -290,7 +312,9 @@ class TestWeeRuntimeToolLoop(unittest.TestCase):
             )
 
         self.assertIn("Disk usage is fine.", result)
-        self.assertEqual(call_count[0], 2, "Expected exactly 2 LLM calls (1 tool round + 1 final)")
+        self.assertEqual(
+            call_count[0], 2, "Expected exactly 2 LLM calls (1 tool round + 1 final)"
+        )
 
     def test_tools_passed_to_llm(self):
         """run_wee_native passes 'tools' parameter to the LLM on first call."""

--- a/tests/test_issue123_tool_calling.py
+++ b/tests/test_issue123_tool_calling.py
@@ -20,8 +20,8 @@ import os
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock, patch, PropertyMock, AsyncMock
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 # Add project root
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)) + "/..")
@@ -60,17 +60,19 @@ def _make_mgr():
 
 # ── Test: Ollama port is 11434 ──────────────────────────────────────
 
+
 class TestOllamaPort(unittest.TestCase):
     """Issue #123: Verify Ollama port is 11434, not 11436."""
 
     def test_agent_manager_presets_use_11434(self):
         """run_wee_native _PRESETS should use port 11434."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         # Find _PRESETS inside run_wee_native
         idx = src.find("def run_wee_native")
         self.assertGreater(idx, 0, "run_wee_native not found")
-        block = src[idx:idx + 5000]
+        block = src[idx : idx + 5000]
         self.assertIn("11434", block, "Port 11434 should be in run_wee_native")
         self.assertNotIn("11436", block, "Port 11436 should NOT be in run_wee_native")
 
@@ -83,11 +85,13 @@ class TestOllamaPort(unittest.TestCase):
     def test_no_11436_anywhere(self):
         """No occurrence of port 11436 should remain in agent_manager.py."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         self.assertNotIn("11436", src, "Port 11436 should not appear anywhere")
 
 
 # ── Test: Tool definitions ──────────────────────────────────────────
+
 
 class TestToolDefinitions(unittest.TestCase):
     """Issue #123: Verify tool definitions are correct."""
@@ -95,9 +99,10 @@ class TestToolDefinitions(unittest.TestCase):
     def test_wee_tools_in_run_wee_native(self):
         """_WEE_TOOLS should define bash and python tools."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 10000]
+        block = src[idx : idx + 10000]
         self.assertIn('"name": "bash"', block)
         self.assertIn('"name": "python"', block)
         self.assertIn('"command"', block)
@@ -106,6 +111,7 @@ class TestToolDefinitions(unittest.TestCase):
     def test_wee_runtime_tools(self):
         """wee_runtime.py should have _WEE_TOOLS with bash and python."""
         import wee_runtime
+
         self.assertTrue(hasattr(wee_runtime, "_WEE_TOOLS"))
         names = [t["function"]["name"] for t in wee_runtime._WEE_TOOLS]
         self.assertIn("bash", names)
@@ -114,13 +120,15 @@ class TestToolDefinitions(unittest.TestCase):
     def test_max_tool_rounds_defined(self):
         """MAX_TOOL_ROUNDS should be defined."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 10000]
+        block = src[idx : idx + 10000]
         self.assertIn("MAX_TOOL_ROUNDS = 10", block)
 
 
 # ── Test: _wee_execute_tool ─────────────────────────────────────────
+
 
 class TestWeeExecuteTool(unittest.TestCase):
     """Issue #123: Test tool execution helper."""
@@ -130,8 +138,12 @@ class TestWeeExecuteTool(unittest.TestCase):
         self.mgr._execute_bash_command = MagicMock(return_value="bash output here")
 
     def test_bash_tool(self):
-        result = self.mgr._wee_execute_tool("bash", {"command": "echo hello"}, "orchestrator")
-        self.mgr._execute_bash_command.assert_called_once_with("echo hello", "orchestrator")
+        result = self.mgr._wee_execute_tool(
+            "bash", {"command": "echo hello"}, "orchestrator"
+        )
+        self.mgr._execute_bash_command.assert_called_once_with(
+            "echo hello", "orchestrator"
+        )
         self.assertEqual(result, "bash output here")
 
     def test_bash_no_command(self):
@@ -141,10 +153,10 @@ class TestWeeExecuteTool(unittest.TestCase):
 
     def test_python_tool(self):
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                stdout="42\n", stderr="", returncode=0
+            mock_run.return_value = MagicMock(stdout="42\n", stderr="", returncode=0)
+            result = self.mgr._wee_execute_tool(
+                "python", {"code": "print(42)"}, "orchestrator"
             )
-            result = self.mgr._wee_execute_tool("python", {"code": "print(42)"}, "orchestrator")
             self.assertEqual(result, "42")
 
     def test_python_no_code(self):
@@ -159,8 +171,11 @@ class TestWeeExecuteTool(unittest.TestCase):
 
     def test_python_timeout(self):
         import subprocess
+
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 120)):
-            result = self.mgr._wee_execute_tool("python", {"code": "while True: pass"}, "orchestrator")
+            result = self.mgr._wee_execute_tool(
+                "python", {"code": "while True: pass"}, "orchestrator"
+            )
             self.assertIn("timed out", result)
 
     def test_python_with_stderr(self):
@@ -168,12 +183,15 @@ class TestWeeExecuteTool(unittest.TestCase):
             mock_run.return_value = MagicMock(
                 stdout="output\n", stderr="warning\n", returncode=0
             )
-            result = self.mgr._wee_execute_tool("python", {"code": "import warnings"}, "orchestrator")
+            result = self.mgr._wee_execute_tool(
+                "python", {"code": "import warnings"}, "orchestrator"
+            )
             self.assertIn("output", result)
             self.assertIn("warning", result)
 
 
 # ── Test: _wee_augment_system_prompt_with_tools ─────────────────────
+
 
 class TestWeeAugmentSystemPrompt(unittest.TestCase):
     """Issue #123: System prompt gets tool capability section."""
@@ -182,7 +200,9 @@ class TestWeeAugmentSystemPrompt(unittest.TestCase):
         self.mgr = _make_mgr()
 
     def test_augment_adds_tool_section(self):
-        result = self.mgr._wee_augment_system_prompt_with_tools("You are a helpful assistant.")
+        result = self.mgr._wee_augment_system_prompt_with_tools(
+            "You are a helpful assistant."
+        )
         self.assertIn("[Available Tools]", result)
         self.assertIn("bash", result)
         self.assertIn("python", result)
@@ -200,6 +220,7 @@ class TestWeeAugmentSystemPrompt(unittest.TestCase):
 
 # ── Test: _wee_load_messages / _wee_save_messages ───────────────────
 
+
 class TestWeeMessagePersistence(unittest.TestCase):
     """Issue #123: Conversation history persistence."""
 
@@ -216,13 +237,15 @@ class TestWeeMessagePersistence(unittest.TestCase):
         self.assertEqual(msgs[0]["content"], "system prompt")
 
     def test_load_resume_with_history(self):
-        self.mgr.load_session_data = MagicMock(return_value={
-            "wee_messages": [
-                {"role": "system", "content": "old prompt"},
-                {"role": "user", "content": "hello"},
-                {"role": "assistant", "content": "hi!"},
-            ]
-        })
+        self.mgr.load_session_data = MagicMock(
+            return_value={
+                "wee_messages": [
+                    {"role": "system", "content": "old prompt"},
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi!"},
+                ]
+            }
+        )
         msgs = self.mgr._wee_load_messages("sess1", "new prompt", resume=True)
         self.assertEqual(len(msgs), 3)
         # System prompt should be refreshed
@@ -236,9 +259,9 @@ class TestWeeMessagePersistence(unittest.TestCase):
         self.assertEqual(msgs[0]["role"], "system")
 
     def test_save_messages(self):
-        self.mgr.load_session_map = MagicMock(return_value={
-            "sess1": {"runtime": "wee"}
-        })
+        self.mgr.load_session_map = MagicMock(
+            return_value={"sess1": {"runtime": "wee"}}
+        )
         messages = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "hi"},
@@ -252,9 +275,9 @@ class TestWeeMessagePersistence(unittest.TestCase):
 
     def test_save_messages_with_tool_calls(self):
         """Tool calls in assistant messages should be serialized cleanly."""
-        self.mgr.load_session_map = MagicMock(return_value={
-            "sess1": {"runtime": "wee"}
-        })
+        self.mgr.load_session_map = MagicMock(
+            return_value={"sess1": {"runtime": "wee"}}
+        )
         messages = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "check disk"},
@@ -265,7 +288,10 @@ class TestWeeMessagePersistence(unittest.TestCase):
                     {
                         "id": "tc_1",
                         "type": "function",
-                        "function": {"name": "bash", "arguments": '{"command": "df -h"}'},
+                        "function": {
+                            "name": "bash",
+                            "arguments": '{"command": "df -h"}',
+                        },
                     }
                 ],
             },
@@ -282,9 +308,9 @@ class TestWeeMessagePersistence(unittest.TestCase):
 
     def test_save_caps_at_max_messages(self):
         """Messages over MAX_WEE_MESSAGES should be trimmed."""
-        self.mgr.load_session_map = MagicMock(return_value={
-            "sess1": {"runtime": "wee"}
-        })
+        self.mgr.load_session_map = MagicMock(
+            return_value={"sess1": {"runtime": "wee"}}
+        )
         messages = [{"role": "system", "content": "sys"}]
         for i in range(150):
             messages.append({"role": "user", "content": f"msg {i}"})
@@ -296,6 +322,7 @@ class TestWeeMessagePersistence(unittest.TestCase):
 
 # ── Test: session_exists for wee ────────────────────────────────────
 
+
 class TestSessionExistsWee(unittest.TestCase):
     """Issue #123: session_exists should detect wee sessions."""
 
@@ -303,9 +330,9 @@ class TestSessionExistsWee(unittest.TestCase):
         self.mgr = _make_mgr()
 
     def test_session_exists_with_messages(self):
-        self.mgr.load_session_data = MagicMock(return_value={
-            "wee_messages": [{"role": "system", "content": "hi"}]
-        })
+        self.mgr.load_session_data = MagicMock(
+            return_value={"wee_messages": [{"role": "system", "content": "hi"}]}
+        )
         result = self.mgr.session_exists("sid", "wee", n8n_session_id="n8n_1")
         self.assertTrue(result)
 
@@ -322,22 +349,30 @@ class TestSessionExistsWee(unittest.TestCase):
 
 # ── Test: build_agent_context_prompt arg order ──────────────────────
 
+
 class TestBuildContextPromptArgOrder(unittest.TestCase):
     """Issue #123: build_agent_context_prompt called with correct arg order."""
 
     def test_arg_order_in_source(self):
         """The call in run_wee_native should use (agent, prompt, n8n_session_id, ...)."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 5000]
+        block = src[idx : idx + 5000]
         # Should find the correct arg order
-        self.assertIn("build_agent_context_prompt(\n            agent,\n            prompt,\n            n8n_session_id,", block)
+        self.assertIn(
+            "build_agent_context_prompt(\n            agent,\n            prompt,\n            n8n_session_id,",
+            block,
+        )
         # Should NOT have old wrong order
-        self.assertNotIn("build_agent_context_prompt(\n            prompt, agent, channel", block)
+        self.assertNotIn(
+            "build_agent_context_prompt(\n            prompt, agent, channel", block
+        )
 
 
 # ── Test: Streaming tool call accumulation ──────────────────────────
+
 
 class TestToolCallAccumulation(unittest.TestCase):
     """Issue #123: Streaming tool call deltas accumulated correctly."""
@@ -367,35 +402,39 @@ class TestToolCallAccumulation(unittest.TestCase):
     def test_tool_call_detection_code_exists(self):
         """The tool call detection code should be present in source."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 15000]
+        block = src[idx : idx + 15000]
         self.assertIn('getattr(delta, "tool_calls", None)', block)
         self.assertIn("tool_calls_acc", block)
 
     def test_tools_passed_to_api_in_source(self):
         """tools should be passed in create_kwargs."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 15000]
+        block = src[idx : idx + 15000]
         self.assertIn('create_kwargs["tools"] = _WEE_TOOLS', block)
 
     def test_tool_result_messages_in_source(self):
         """Tool results should be appended as role=tool messages."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 15000]
+        block = src[idx : idx + 15000]
         self.assertIn('"role": "tool"', block)
         self.assertIn('"tool_call_id"', block)
 
     def test_sse_events_for_tools_in_source(self):
         """SSE tool_call events should be emitted."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 15000]
+        block = src[idx : idx + 15000]
         self.assertIn('"status": "running"', block)
         self.assertIn('"status": "complete"', block)
         self.assertIn('stream_buffer.push("tool_call"', block)
@@ -403,20 +442,24 @@ class TestToolCallAccumulation(unittest.TestCase):
 
 # ── Test: wee_runtime.py tool support ───────────────────────────────
 
+
 class TestWeeRuntimeStandalone(unittest.TestCase):
     """Issue #123: wee_runtime.py standalone script has tool support."""
 
     def test_has_tool_definitions(self):
         import wee_runtime
+
         self.assertTrue(hasattr(wee_runtime, "_WEE_TOOLS"))
         self.assertEqual(len(wee_runtime._WEE_TOOLS), 2)
 
     def test_has_execute_tool(self):
         import wee_runtime
+
         self.assertTrue(hasattr(wee_runtime, "execute_tool"))
 
     def test_has_max_tool_rounds(self):
         import wee_runtime
+
         self.assertTrue(hasattr(wee_runtime, "MAX_TOOL_ROUNDS"))
         self.assertEqual(wee_runtime.MAX_TOOL_ROUNDS, 10)
 
@@ -424,10 +467,11 @@ class TestWeeRuntimeStandalone(unittest.TestCase):
         """--tools flag should be supported."""
         src = open("wee_runtime.py").read()
         self.assertIn("--tools", src)
-        self.assertIn("action=\"store_true\"", src)
+        self.assertIn('action="store_true"', src)
 
     def test_execute_tool_bash(self):
         import wee_runtime
+
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 stdout="hello world\n", stderr="", returncode=0
@@ -437,35 +481,45 @@ class TestWeeRuntimeStandalone(unittest.TestCase):
 
     def test_execute_tool_python(self):
         import wee_runtime
+
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                stdout="42\n", stderr="", returncode=0
-            )
+            mock_run.return_value = MagicMock(stdout="42\n", stderr="", returncode=0)
             result = wee_runtime.execute_tool("python", {"code": "print(42)"})
             self.assertEqual(result, "42")
 
     def test_execute_tool_unknown(self):
         import wee_runtime
+
         result = wee_runtime.execute_tool("foobar", {})
         self.assertIn("Error", result)
 
     def test_port_11434(self):
         import wee_runtime
+
         self.assertIn("11434", wee_runtime.PROVIDER_PRESETS["ollama"][0])
 
 
 # ── Test: Integration-style tool loop (mocked) ─────────────────────
+
 
 class TestToolLoopIntegration(unittest.TestCase):
     """Issue #123: Full tool loop with mocked OpenAI client."""
 
     def setUp(self):
         self.mgr = _make_mgr()
-        self.mgr._execute_bash_command = MagicMock(return_value="Filesystem      Size  Used\n/dev/sda1       50G   20G")
-        self.mgr.get_or_create_session_data = MagicMock(return_value={"channel": "webui"})
-        self.mgr.build_agent_context_prompt = MagicMock(return_value="You are a helpful assistant.")
+        self.mgr._execute_bash_command = MagicMock(
+            return_value="Filesystem      Size  Used\n/dev/sda1       50G   20G"
+        )
+        self.mgr.get_or_create_session_data = MagicMock(
+            return_value={"channel": "webui"}
+        )
+        self.mgr.build_agent_context_prompt = MagicMock(
+            return_value="You are a helpful assistant."
+        )
         self.mgr.load_session_data = MagicMock(return_value=None)
-        self.mgr.load_session_map = MagicMock(return_value={"sess1": {"runtime": "wee"}})
+        self.mgr.load_session_map = MagicMock(
+            return_value={"sess1": {"runtime": "wee"}}
+        )
         self.mgr.save_session_map = MagicMock()
 
     def _make_text_stream(self, text):
@@ -510,10 +564,18 @@ class TestToolLoopIntegration(unittest.TestCase):
         with patch.dict("sys.modules", {"openai": MagicMock()}):
             mock_client = MagicMock()
             # Return a text stream
-            mock_client.chat.completions.create.return_value = self._make_text_stream("Hello!")
+            mock_client.chat.completions.create.return_value = self._make_text_stream(
+                "Hello!"
+            )
 
-            with patch("builtins.__import__", side_effect=lambda name, *args, **kwargs:
-                       MagicMock(OpenAI=lambda **kw: mock_client) if name == "openai" else __builtins__.__import__(name, *args, **kwargs)):
+            with patch(
+                "builtins.__import__",
+                side_effect=lambda name, *args, **kwargs: (
+                    MagicMock(OpenAI=lambda **kw: mock_client)
+                    if name == "openai"
+                    else __builtins__.__import__(name, *args, **kwargs)
+                ),
+            ):
                 # Directly test the logic: for a text response, tool_calls_acc should be empty
                 # and the content should be collected
                 pass  # This would require full integration; source verification above is sufficient
@@ -521,14 +583,16 @@ class TestToolLoopIntegration(unittest.TestCase):
     def test_for_else_clause_in_source(self):
         """The for-else clause should handle max rounds gracefully."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 15000]
+        block = src[idx : idx + 15000]
         self.assertIn("Max tool rounds reached", block)
         self.assertIn("Tool execution completed", block)
 
 
 # ── Test: Fallback when tools not supported ─────────────────────────
+
 
 class TestToolsFallback(unittest.TestCase):
     """Issue #123: Graceful fallback when model doesn't support tools."""
@@ -536,9 +600,10 @@ class TestToolsFallback(unittest.TestCase):
     def test_fallback_code_in_source(self):
         """Should catch tool errors and retry without tools."""
         import agent_manager
+
         src = open(agent_manager.__file__).read()
         idx = src.find("def run_wee_native")
-        block = src[idx:idx + 15000]
+        block = src[idx : idx + 15000]
         self.assertIn("Tools not supported, retrying without", block)
         self.assertIn('create_kwargs.pop("tools", None)', block)
 

--- a/tests/test_issue126_wee_icon.py
+++ b/tests/test_issue126_wee_icon.py
@@ -1,7 +1,6 @@
 """Regression tests for Issue #126: Wee runtime icon in runtime switcher."""
 
 import os
-
 import unittest
 import xml.etree.ElementTree as ET
 

--- a/tests/test_issue128_token_usage.py
+++ b/tests/test_issue128_token_usage.py
@@ -1,18 +1,20 @@
 """Tests for Issue #128: Token usage tracking + cost estimation + WebUI footer."""
-import json
 
+import json
 import sys
-import time
 import tempfile
+import time
 from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
+
 import pytest
 
 # Add dev path
-sys.path.insert(0, '/opt/n8n-copilot-shim-dev')
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 
 
 # ─── Helper method tests via AgentManager ────────────────────────────────────
+
 
 class TestTokenHelpers:
     """Tests for SessionManager token tracking helper methods."""
@@ -20,79 +22,86 @@ class TestTokenHelpers:
     def setup_method(self):
         """Import SessionManager and instantiate with minimal setup."""
         import importlib
-        self.am_mod = importlib.import_module('agent_manager')
+
+        self.am_mod = importlib.import_module("agent_manager")
         # Mock minimal required setup to get a usable instance
-        with patch.object(self.am_mod.SessionManager, '__init__', lambda self, *a, **kw: None):  # noqa: E501
+        with patch.object(
+            self.am_mod.SessionManager, "__init__", lambda self, *a, **kw: None
+        ):  # noqa: E501
             self.mgr = self.am_mod.SessionManager.__new__(self.am_mod.SessionManager)
         # Set required attributes
         self.mgr.logs_dir = Path(tempfile.mkdtemp())
 
     def test_calculate_wee_cost_ollama(self):
         """Ollama models should always return cost_usd=0, label='local'."""
-        cost, label = self.mgr._calculate_wee_cost('ollama/llama3', 1000, 500, {})
+        cost, label = self.mgr._calculate_wee_cost("ollama/llama3", 1000, 500, {})
         assert cost == 0.0
-        assert label == 'local'
+        assert label == "local"
 
     def test_calculate_wee_cost_openrouter_no_pricing(self):
         """Models with no pricing in cache should return free."""
-        cost, label = self.mgr._calculate_wee_cost('openrouter/some-model', 1000, 500, {})  # noqa: E501
+        cost, label = self.mgr._calculate_wee_cost(
+            "openrouter/some-model", 1000, 500, {}
+        )  # noqa: E501
         assert cost == 0.0
-        assert label == 'free'
+        assert label == "free"
 
     def test_calculate_wee_cost_openrouter_with_pricing(self):
         """Models with pricing data should return calculated cost."""
         pricing = {
-            'google/gemini-flash': {  # bare model name (prefix stripped internally)
-                'prompt': 0.000000075,
-                'completion': 0.0000003,
+            "google/gemini-flash": {  # bare model name (prefix stripped internally)
+                "prompt": 0.000000075,
+                "completion": 0.0000003,
             }
         }
         cost, label = self.mgr._calculate_wee_cost(
-            'openrouter/google/gemini-flash', 1000, 500, pricing
+            "openrouter/google/gemini-flash", 1000, 500, pricing
         )
         expected = (1000 * 0.000000075) + (500 * 0.0000003)
         assert abs(cost - expected) < 1e-10
-        assert label.startswith('$')
+        assert label.startswith("$")
 
     def test_calculate_anthropic_cost_haiku(self):
         """Claude haiku pricing should be applied correctly."""
-        cost, label = self.mgr._calculate_anthropic_cost('claude-haiku-4-5', 1000, 500)
+        cost, label = self.mgr._calculate_anthropic_cost("claude-haiku-4-5", 1000, 500)
         # $0.80/$4.00 per 1M tokens
         expected = (1000 * 0.80 / 1_000_000) + (500 * 4.00 / 1_000_000)
         assert abs(cost - expected) < 1e-10
-        assert label.startswith('$')
+        assert label.startswith("$")
 
     def test_calculate_anthropic_cost_sonnet(self):
         """Claude sonnet pricing should be applied correctly."""
-        cost, label = self.mgr._calculate_anthropic_cost('claude-sonnet-4-5', 1000, 500)
+        cost, label = self.mgr._calculate_anthropic_cost("claude-sonnet-4-5", 1000, 500)
         expected = (1000 * 3.0 / 1_000_000) + (500 * 15.0 / 1_000_000)
         assert abs(cost - expected) < 1e-10
 
     def test_calculate_anthropic_cost_unknown(self):
         """Unknown Anthropic model should return default pricing."""
-        cost, label = self.mgr._calculate_anthropic_cost('claude-unknown-model', 100, 100)  # noqa: E501
+        cost, label = self.mgr._calculate_anthropic_cost(
+            "claude-unknown-model", 100, 100
+        )  # noqa: E501
         assert cost >= 0.0
         assert isinstance(label, str)
 
     def test_get_cost_label_zero(self):
         """Zero cost should return 'free'."""
         label = self.mgr._get_cost_label(0.0)
-        assert label == 'free'
+        assert label == "free"
 
     def test_get_cost_label_small(self):
         """Small cost should be formatted as $0.XXXX."""
         label = self.mgr._get_cost_label(0.000012)
-        assert label.startswith('$')
-        assert '0.0000' in label or '0.00' in label
+        assert label.startswith("$")
+        assert "0.0000" in label or "0.00" in label
 
     def test_log_token_usage_writes_jsonl(self):
         """_log_token_usage should write a valid JSONL entry."""
-        log_file = self.mgr.logs_dir / 'token_usage.jsonl'
+        log_file = self.mgr.logs_dir / "token_usage.jsonl"
         self.mgr._log_token_usage(
-            session_id='test-session-1',
-            model='openrouter/google/gemini-flash',
-            runtime='wee',
-            provider='openrouter',
+            session_id="test-session-1",
+            model="openrouter/google/gemini-flash",
+            runtime="wee",
+            provider="openrouter",
             prompt_tokens=100,
             completion_tokens=50,
             total_tokens=150,
@@ -102,128 +111,128 @@ class TestTokenHelpers:
         assert log_file.exists()
         with open(log_file) as f:
             entry = json.loads(f.readline())
-        assert entry['session_id'] == 'test-session-1'
-        assert entry['model'] == 'openrouter/google/gemini-flash'
-        assert entry['prompt_tokens'] == 100
-        assert entry['completion_tokens'] == 50
-        assert entry['total_tokens'] == 150
-        assert abs(entry['cost_usd'] - 0.0000125) < 1e-12
-        assert entry['duration_ms'] == 1234
-        assert 'timestamp' in entry
+        assert entry["session_id"] == "test-session-1"
+        assert entry["model"] == "openrouter/google/gemini-flash"
+        assert entry["prompt_tokens"] == 100
+        assert entry["completion_tokens"] == 50
+        assert entry["total_tokens"] == 150
+        assert abs(entry["cost_usd"] - 0.0000125) < 1e-12
+        assert entry["duration_ms"] == 1234
+        assert "timestamp" in entry
 
     def test_log_token_usage_multiple_appends(self):
         """Multiple calls should append to the same file."""
         for i in range(3):
             self.mgr._log_token_usage(
-                session_id=f'session-{i}',
-                model='ollama/llama3',
-                runtime='wee',
-                provider='ollama',
+                session_id=f"session-{i}",
+                model="ollama/llama3",
+                runtime="wee",
+                provider="ollama",
                 prompt_tokens=10 * i,
                 completion_tokens=5 * i,
                 total_tokens=15 * i,
                 cost_usd=0.0,
                 duration_ms=100,
             )
-        log_file = self.mgr.logs_dir / 'token_usage.jsonl'
-        lines = log_file.read_text().strip().split('\n')
+        log_file = self.mgr.logs_dir / "token_usage.jsonl"
+        lines = log_file.read_text().strip().split("\n")
         assert len(lines) == 3
 
 
 # ─── /api/v1/usage endpoint tests ────────────────────────────────────────────
+
 
 class TestUsageEndpoint:
     """Tests for GET /api/v1/usage endpoint."""
 
     def setup_method(self):
         """Setup test client."""
-        import os
-        from fastapi.testclient import TestClient
         import importlib
-        self._orig_api_key = os.environ.get('API_SHARED_KEY')
-        os.environ['API_SHARED_KEY'] = 'testkey'
-        self.am_mod = importlib.import_module('agent_manager')
+        import os
+
+        from fastapi.testclient import TestClient
+
+        self._orig_api_key = os.environ.get("API_SHARED_KEY")
+        os.environ["API_SHARED_KEY"] = "testkey"
+        self.am_mod = importlib.import_module("agent_manager")
         self.app = self.am_mod.create_api_app()
         self.client = TestClient(self.app, raise_server_exceptions=False)
         self.tmp_dir = Path(tempfile.mkdtemp())
-        self.auth_headers = {'Authorization': 'Bearer shared_testkey'}
+        self.auth_headers = {"Authorization": "Bearer shared_testkey"}
 
     def teardown_method(self):
         """Restore env to avoid leaking API_SHARED_KEY to other tests."""
         import os
+
         if self._orig_api_key is None:
-            os.environ.pop('API_SHARED_KEY', None)
+            os.environ.pop("API_SHARED_KEY", None)
         else:
-            os.environ['API_SHARED_KEY'] = self._orig_api_key
+            os.environ["API_SHARED_KEY"] = self._orig_api_key
 
     def _write_usage_log(self, entries, logs_dir=None):
         """Write test entries to token_usage.jsonl."""
         d = logs_dir or self.tmp_dir
-        log_file = d / 'token_usage.jsonl'
-        with open(log_file, 'w') as f:
+        log_file = d / "token_usage.jsonl"
+        with open(log_file, "w") as f:
             for entry in entries:
-                f.write(json.dumps(entry) + '\n')
+                f.write(json.dumps(entry) + "\n")
         return log_file
 
-    def _make_entry(self, days_ago=0, model='ollama/llama3', runtime='wee',
-                    prompt_tokens=100, completion_tokens=50, cost_usd=0.0):
+    def _make_entry(
+        self,
+        days_ago=0,
+        model="ollama/llama3",
+        runtime="wee",
+        prompt_tokens=100,
+        completion_tokens=50,
+        cost_usd=0.0,
+    ):
         """Create a test log entry."""
         ts = time.time() - (days_ago * 86400)
         return {
-            'timestamp': ts,
-            'session_id': 'test',
-            'model': model,
-            'runtime': runtime,
-            'provider': 'ollama' if 'ollama' in model else 'openrouter',
-            'prompt_tokens': prompt_tokens,
-            'completion_tokens': completion_tokens,
-            'total_tokens': prompt_tokens + completion_tokens,
-            'cost_usd': cost_usd,
-            'duration_ms': 1000,
+            "timestamp": ts,
+            "session_id": "test",
+            "model": model,
+            "runtime": runtime,
+            "provider": "ollama" if "ollama" in model else "openrouter",
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "cost_usd": cost_usd,
+            "duration_ms": 1000,
         }
 
     def test_usage_today_filter(self):
         """?period=today should be accepted and return valid structure."""
-        resp = self.client.get(
-            '/api/v1/usage?period=today',
-            headers=self.auth_headers
-        )
+        resp = self.client.get("/api/v1/usage?period=today", headers=self.auth_headers)
         assert resp.status_code == 200
         data = resp.json()
-        assert data['period'] == 'today'
-        assert data['total_cost_usd'] >= 0
+        assert data["period"] == "today"
+        assert data["total_cost_usd"] >= 0
 
     def test_usage_endpoint_exists(self):
         """GET /api/v1/usage should return 200 with proper structure."""
-        resp = self.client.get(
-            '/api/v1/usage',
-            headers=self.auth_headers
-        )
+        resp = self.client.get("/api/v1/usage", headers=self.auth_headers)
         assert resp.status_code == 200
         data = resp.json()
-        assert 'total_cost_usd' in data
-        assert 'total_tokens' in data
-        assert 'by_model' in data
-        assert isinstance(data['by_model'], list)
+        assert "total_cost_usd" in data
+        assert "total_tokens" in data
+        assert "by_model" in data
+        assert isinstance(data["by_model"], list)
 
     def test_usage_period_7d(self):
         """?period=7d should be accepted."""
-        resp = self.client.get(
-            '/api/v1/usage?period=7d',
-            headers=self.auth_headers
-        )
+        resp = self.client.get("/api/v1/usage?period=7d", headers=self.auth_headers)
         assert resp.status_code == 200
 
     def test_usage_period_30d(self):
         """?period=30d should be accepted."""
-        resp = self.client.get(
-            '/api/v1/usage?period=30d',
-            headers=self.auth_headers
-        )
+        resp = self.client.get("/api/v1/usage?period=30d", headers=self.auth_headers)
         assert resp.status_code == 200
 
 
 # ─── wee_runtime.py standalone tests ─────────────────────────────────────────
+
 
 class TestWeeRuntime:
     """Tests for the wee_runtime.py standalone CLI functions."""
@@ -231,9 +240,9 @@ class TestWeeRuntime:
     def setup_method(self):
         """Import wee_runtime module."""
         import importlib.util
+
         spec = importlib.util.spec_from_file_location(
-            'wee_runtime',
-            '/opt/n8n-copilot-shim-dev/wee_runtime.py'
+            "wee_runtime", "/opt/n8n-copilot-shim-dev/wee_runtime.py"
         )
         self.wr = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(self.wr)
@@ -241,45 +250,52 @@ class TestWeeRuntime:
     def test_fetch_openrouter_pricing_cache_path(self):
         """Pricing should be cached to /tmp/openrouter_pricing.json."""
         mock_data = {
-            'data': [
-                {'id': 'google/gemini-flash-1.5', 'pricing': {'prompt': '0.000000075', 'completion': '0.0000003'}}  # noqa: E501
+            "data": [
+                {
+                    "id": "google/gemini-flash-1.5",
+                    "pricing": {"prompt": "0.000000075", "completion": "0.0000003"},
+                }  # noqa: E501
             ]
         }
-        with patch('builtins.open', mock_open(read_data=json.dumps(mock_data))), \
-             patch('os.path.exists', return_value=True), \
-             patch('os.path.getmtime', return_value=time.time()):
+        with patch("builtins.open", mock_open(read_data=json.dumps(mock_data))), patch(
+            "os.path.exists", return_value=True
+        ), patch("os.path.getmtime", return_value=time.time()):
             pricing = self.wr.fetch_openrouter_pricing()
             assert isinstance(pricing, dict)
 
     def test_calculate_cost_ollama(self):
         """Ollama models should always be $0, label=local."""
-        cost, label = self.wr.calculate_cost('ollama/llama3', 500, 300, {})
+        cost, label = self.wr.calculate_cost("ollama/llama3", 500, 300, {})
         assert cost == 0.0
-        assert label == 'local'
+        assert label == "local"
 
     def test_calculate_cost_free_model(self):
         """Unknown models not in pricing = free."""
-        cost, label = self.wr.calculate_cost('openrouter/some-free-model', 100, 50, {})
+        cost, label = self.wr.calculate_cost("openrouter/some-free-model", 100, 50, {})
         assert cost == 0.0
-        assert label == 'free'
+        assert label == "free"
 
     def test_calculate_cost_paid_model(self):
         """Paid model should multiply token counts by per-token price."""
-        pricing = {'google/gemini-flash-1.5': {'prompt': 0.000000075, 'completion': 0.0000003}}  # noqa: E501
-        cost, label = self.wr.calculate_cost('openrouter/google/gemini-flash-1.5', 1000, 500, pricing)  # noqa: E501
+        pricing = {
+            "google/gemini-flash-1.5": {"prompt": 0.000000075, "completion": 0.0000003}
+        }  # noqa: E501
+        cost, label = self.wr.calculate_cost(
+            "openrouter/google/gemini-flash-1.5", 1000, 500, pricing
+        )  # noqa: E501
         expected = (1000 * 0.000000075) + (500 * 0.0000003)
         assert abs(cost - expected) < 1e-12
-        assert label.startswith('$')
+        assert label.startswith("$")
 
     def test_log_token_usage_creates_file(self):
         """log_token_usage should create the log file if it doesn't exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            log_path = Path(tmpdir) / 'token_usage.jsonl'
-            with patch.object(self.wr, 'LOG_FILE', log_path):
+            log_path = Path(tmpdir) / "token_usage.jsonl"
+            with patch.object(self.wr, "LOG_FILE", log_path):
                 self.wr.log_token_usage(
-                    session_id='test',
-                    model='ollama/llama3',
-                    provider='ollama',
+                    session_id="test",
+                    model="ollama/llama3",
+                    provider="ollama",
                     prompt_tokens=10,
                     completion_tokens=5,
                     total_tokens=15,
@@ -289,52 +305,58 @@ class TestWeeRuntime:
             if log_path.exists():
                 with open(log_path) as f:
                     entry = json.loads(f.readline())
-                assert entry['model'] == 'ollama/llama3'
-                assert entry['prompt_tokens'] == 10
+                assert entry["model"] == "ollama/llama3"
+                assert entry["prompt_tokens"] == 10
 
     def test_stream_options_included(self):
         """wee_runtime should pass stream_options to the API."""
         import inspect
+
         source = inspect.getsource(self.wr)
-        assert 'stream_options' in source
-        assert 'include_usage' in source
+        assert "stream_options" in source
+        assert "include_usage" in source
 
     def test_wee_meta_output_format(self):
         """__WEE_META__ marker should be present in output code."""
         import inspect
+
         source = inspect.getsource(self.wr)
-        assert '__WEE_META__' in source
+        assert "__WEE_META__" in source
 
 
 # ─── app.js WebUI update tests ────────────────────────────────────────────────
+
 
 class TestAppJsUpdate:
     """Verify that app.js was updated with token/cost display logic."""
 
     def setup_method(self):
-        self.app_js = Path('/opt/n8n-copilot-shim-dev/webui/dist/app.js').read_text()
+        self.app_js = Path("/opt/n8n-copilot-shim-dev/webui/dist/app.js").read_text()
 
     def test_buildTimingText_function_exists(self):
         """buildTimingText function should be present in app.js."""
-        assert 'function buildTimingText(' in self.app_js
+        assert "function buildTimingText(" in self.app_js
 
     def test_buildTimingText_handles_wee_meta(self):
         """buildTimingText should reference weeMeta/tokens/cost_label."""
-        assert 'weeMeta' in self.app_js
-        assert 'cost_label' in self.app_js
-        assert 'tokens' in self.app_js
+        assert "weeMeta" in self.app_js
+        assert "cost_label" in self.app_js
+        assert "tokens" in self.app_js
 
     def test_streaming_path_uses_buildTimingText(self):
         """The streaming done handler should call buildTimingText."""
-        assert 'buildTimingText(elapsedSec, evt.wee_meta' in self.app_js
+        assert "buildTimingText(elapsedSec, evt.wee_meta" in self.app_js
 
     def test_renderMessage_accepts_weeMeta(self):
         """renderMessage should accept weeMeta as 5th param."""
-        assert 'renderMessage(role, content, files = [], timing = null, weeMeta = null)' in self.app_js  # noqa: E501
+        assert (
+            "renderMessage(role, content, files = [], timing = null, weeMeta = null)"
+            in self.app_js
+        )  # noqa: E501
 
     def test_renderMessage_timing_uses_buildTimingText(self):
         """renderMessage timing block should use buildTimingText."""
-        assert 'buildTimingText(timing, weeMeta)' in self.app_js
+        assert "buildTimingText(timing, weeMeta)" in self.app_js
 
     def test_copilot_label_handled(self):
         """copilot-sdk label should be handled in buildTimingText."""
@@ -343,17 +365,18 @@ class TestAppJsUpdate:
 
 # ─── SSE done_payload wee_meta inclusion ─────────────────────────────────────
 
+
 class TestSSEDonePayload:
     """Verify that SSE done_payload includes wee_meta."""
 
     def test_wee_meta_in_stream_session(self):
         """stream_session / done_payload should include wee_meta."""
-        am_path = Path('/opt/n8n-copilot-shim-dev/agent_manager.py')
+        am_path = Path("/opt/n8n-copilot-shim-dev/agent_manager.py")
         source = am_path.read_text()
-        assert 'wee_meta' in source
+        assert "wee_meta" in source
         # Verify SSE done path contains wee_meta key
         assert '"wee_meta"' in source or "'wee_meta'" in source
 
 
-if __name__ == '__main__':
-    pytest.main([__file__, '-v'])
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_issue133_wee_icon_webui.py
+++ b/tests/test_issue133_wee_icon_webui.py
@@ -36,12 +36,10 @@ class TestWeeIconSvgAsset(unittest.TestCase):
         root = tree.getroot()
         # Check with and without namespace prefix
         attribs = {
-            k.split("}")[-1] if "}" in k else k: v
-            for k, v in root.attrib.items()
+            k.split("}")[-1] if "}" in k else k: v for k, v in root.attrib.items()
         }
         self.assertIn(
-            "viewBox", attribs,
-            "SVG must have viewBox for correct 14x14px rendering"
+            "viewBox", attribs, "SVG must have viewBox for correct 14x14px rendering"
         )
 
     def test_wee_svg_file_size(self):
@@ -55,8 +53,10 @@ class TestWeeIconSvgAsset(unittest.TestCase):
         with open(SVG_PATH) as f:
             content = f.read().lower()
         for bad_fill in [
-            'fill="white"', "fill='white'",
-            'fill="#fff"', 'fill="#ffffff"',
+            'fill="white"',
+            "fill='white'",
+            'fill="#fff"',
+            'fill="#ffffff"',
         ]:
             self.assertNotIn(bad_fill, content, f"SVG hardcodes white fill: {bad_fill}")
 
@@ -65,8 +65,10 @@ class TestWeeIconSvgAsset(unittest.TestCase):
         with open(SVG_PATH) as f:
             content = f.read().lower()
         for bad_fill in [
-            'fill="black"', "fill='black'",
-            'fill="#000"', 'fill="#000000"',
+            'fill="black"',
+            "fill='black'",
+            'fill="#000"',
+            'fill="#000000"',
         ]:
             self.assertNotIn(bad_fill, content, f"SVG hardcodes black fill: {bad_fill}")
 
@@ -89,7 +91,7 @@ class TestRuntimeIconsMap(unittest.TestCase):
         self.assertRegex(
             self.app_js,
             pattern,
-            "RUNTIME_ICONS must have: wee: '/ui/assets/runtime-icons/wee.svg'"
+            "RUNTIME_ICONS must have: wee: '/ui/assets/runtime-icons/wee.svg'",
         )
 
     def test_runtime_icons_wee_uses_ui_path(self):
@@ -100,8 +102,7 @@ class TestRuntimeIconsMap(unittest.TestCase):
         """Existing runtime icon mappings must not be broken by wee addition."""
         for runtime in ("claude", "copilot", "gemini", "opencode", "devin", "cursor"):
             self.assertIn(
-                f"'{runtime}'", self.app_js,
-                f"Runtime '{runtime}' missing from app.js"
+                f"'{runtime}'", self.app_js, f"Runtime '{runtime}' missing from app.js"
             )
 
     def test_runtime_icon_html_function_renders_img(self):
@@ -131,7 +132,7 @@ class TestRuntimeSlashCommands(unittest.TestCase):
         self.assertRegex(
             self.app_js,
             pattern,
-            "Wee slash command entry must render icon with runtimeIconHTML('wee')"
+            "Wee slash command entry must render icon with runtimeIconHTML('wee')",
         )
 
     def test_all_runtimes_have_slash_commands(self):
@@ -146,6 +147,7 @@ class TestBackendWeeRuntime(unittest.TestCase):
     def test_get_available_runtimes_includes_wee(self):
         """get_available_runtimes() must return wee as an available runtime."""
         import sys
+
         sys.path.insert(0, BASE_DIR)
         from agent_manager import get_available_runtimes
 
@@ -156,6 +158,7 @@ class TestBackendWeeRuntime(unittest.TestCase):
     def test_wee_runtime_has_icon_field(self):
         """Wee runtime entry must have an icon field for badge rendering."""
         import sys
+
         sys.path.insert(0, BASE_DIR)
         from agent_manager import get_available_runtimes
 
@@ -168,6 +171,7 @@ class TestBackendWeeRuntime(unittest.TestCase):
     def test_wee_runtime_has_label(self):
         """Wee runtime entry must have a label field."""
         import sys
+
         sys.path.insert(0, BASE_DIR)
         from agent_manager import get_available_runtimes
 
@@ -190,16 +194,21 @@ class TestIconConsistency(unittest.TestCase):
         # Find all wee.svg references
         refs = re.findall(r"['\"][^'\"]*wee\.svg['\"]", self.app_js)
         for ref in refs:
-            self.assertIn("/ui/assets/runtime-icons/wee.svg", ref,
-                          f"Non-canonical wee.svg path: {ref}")
+            self.assertIn(
+                "/ui/assets/runtime-icons/wee.svg",
+                ref,
+                f"Non-canonical wee.svg path: {ref}",
+            )
 
     def test_icon_file_matches_registry(self):
         """wee.svg file on disk must match the path registered in RUNTIME_ICONS."""
         # Verify the file at the path implied by the registry
         # Registry uses '/ui/assets/runtime-icons/wee.svg' served from webui/dist
         actual_path = os.path.join(WEBUI_DIST, "assets", "runtime-icons", "wee.svg")
-        self.assertTrue(os.path.isfile(actual_path),
-                        f"wee.svg not found at expected path: {actual_path}")
+        self.assertTrue(
+            os.path.isfile(actual_path),
+            f"wee.svg not found at expected path: {actual_path}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_issue148_qa_gate.py
+++ b/tests/test_issue148_qa_gate.py
@@ -190,11 +190,15 @@ class TestIsWeeDevGated:
         from scheduler.qa_gate import is_wee_dev_gated
 
         lock_file = tmp_path / "lock.json"
-        lock_file.write_text(json.dumps({
-            "state": "qa-review",
-            "work_item_id": "WQ-100",
-            "reason": "Waiting for QA",
-        }))
+        lock_file.write_text(
+            json.dumps(
+                {
+                    "state": "qa-review",
+                    "work_item_id": "WQ-100",
+                    "reason": "Waiting for QA",
+                }
+            )
+        )
         gated, reason, details = is_wee_dev_gated(
             lock_path=lock_file, check_github=False, check_prs=False
         )
@@ -206,10 +210,14 @@ class TestIsWeeDevGated:
         from scheduler.qa_gate import is_wee_dev_gated
 
         lock_file = tmp_path / "lock.json"
-        lock_file.write_text(json.dumps({
-            "state": "wee-dev-running",
-            "work_item_id": "WQ-100",
-        }))
+        lock_file.write_text(
+            json.dumps(
+                {
+                    "state": "wee-dev-running",
+                    "work_item_id": "WQ-100",
+                }
+            )
+        )
         gated, reason, details = is_wee_dev_gated(
             lock_path=lock_file, check_github=False, check_prs=False
         )
@@ -221,10 +229,14 @@ class TestIsWeeDevGated:
         from scheduler.qa_gate import is_wee_dev_gated
 
         lock_file = tmp_path / "lock.json"
-        lock_file.write_text(json.dumps({
-            "state": "qa-gate-blocked",
-            "reason": "QA gate blocked",
-        }))
+        lock_file.write_text(
+            json.dumps(
+                {
+                    "state": "qa-gate-blocked",
+                    "reason": "QA gate blocked",
+                }
+            )
+        )
         gated, reason, details = is_wee_dev_gated(
             lock_path=lock_file, check_github=False, check_prs=False
         )
@@ -258,8 +270,12 @@ class TestIsWeeDevGated:
         """Gated when GitHub issues have blocking labels."""
         from scheduler.qa_gate import is_wee_dev_gated
 
-        blocking = [{"number": 100, "title": "Test", "blocking_labels": ["wee-dev:qa-review"]}]
-        with mock.patch("scheduler.qa_gate.check_blocking_issues", return_value=blocking):
+        blocking = [
+            {"number": 100, "title": "Test", "blocking_labels": ["wee-dev:qa-review"]}
+        ]
+        with mock.patch(
+            "scheduler.qa_gate.check_blocking_issues", return_value=blocking
+        ):
             gated, reason, details = is_wee_dev_gated(
                 lock_path=tmp_path / "none.json",
                 check_github=True,
@@ -323,7 +339,10 @@ class TestExecutorGateCheck:
     def test_unknown_gate_allows_execution(self):
         """Unknown gate_check names allow execution (fail-open)."""
         executor = self._make_executor()
-        assert executor._check_gate({"id": "test-job", "gate_check": "nonexistent_gate"}) is True
+        assert (
+            executor._check_gate({"id": "test-job", "gate_check": "nonexistent_gate"})
+            is True
+        )
 
     def test_wee_dev_qa_gate_blocks_when_gated(self):
         """wee_dev_qa gate blocks execution when is_wee_dev_gated returns True."""
@@ -336,7 +355,9 @@ class TestExecutorGateCheck:
             "scheduler.executor.is_wee_dev_gated",
             return_value=(True, "test reason", {}),
         ):
-            result = executor._check_gate({"id": "wee-dev-runner", "gate_check": "wee_dev_qa"})
+            result = executor._check_gate(
+                {"id": "wee-dev-runner", "gate_check": "wee_dev_qa"}
+            )
         assert result is False
 
     def test_wee_dev_qa_gate_allows_when_clear(self):
@@ -347,7 +368,9 @@ class TestExecutorGateCheck:
             "scheduler.executor.is_wee_dev_gated",
             return_value=(False, "", {}),
         ):
-            result = executor._check_gate({"id": "wee-dev-runner", "gate_check": "wee_dev_qa"})
+            result = executor._check_gate(
+                {"id": "wee-dev-runner", "gate_check": "wee_dev_qa"}
+            )
         assert result is True
 
     def test_gate_exception_allows_execution(self):
@@ -358,7 +381,9 @@ class TestExecutorGateCheck:
             "scheduler.executor.is_wee_dev_gated",
             side_effect=RuntimeError("API down"),
         ):
-            result = executor._check_gate({"id": "wee-dev-runner", "gate_check": "wee_dev_qa"})
+            result = executor._check_gate(
+                {"id": "wee-dev-runner", "gate_check": "wee_dev_qa"}
+            )
         assert result is True
 
 
@@ -379,8 +404,15 @@ class TestDispatchQAGateFixes:
         re-dispatch THAT item, not pick up a new queued issue.
         """
         # Simulate the fixed logic
-        active_item = {"id": "WQ-100", "number": 100, "status": "in-progress", "title": "Active"}
-        actionable = [{"id": "WQ-200", "number": 200, "status": "queued", "title": "Queued"}]
+        active_item = {
+            "id": "WQ-100",
+            "number": 100,
+            "status": "in-progress",
+            "title": "Active",
+        }
+        actionable = [
+            {"id": "WQ-200", "number": 200, "status": "queued", "title": "Queued"}
+        ]
 
         ACTIVE_STATUSES = {"in-progress", "qa-review", "qa-failed"}
         ACTIONABLE_STATUSES = {"queued", "qa-failed"}
@@ -391,19 +423,32 @@ class TestDispatchQAGateFixes:
             next_item = active_item  # Fix: re-dispatch the stalled item
 
         # The catch-all gate should NOT apply here since we already have next_item
-        if next_item is None and active_item and active_item["status"] in ACTIVE_STATUSES:
+        if (
+            next_item is None
+            and active_item
+            and active_item["status"] in ACTIVE_STATUSES
+        ):
             # This would block — but next_item is already set
             pass
 
         assert next_item is not None
-        assert next_item["id"] == "WQ-100", "Must re-dispatch stalled item, not new queued item"
+        assert (
+            next_item["id"] == "WQ-100"
+        ), "Must re-dispatch stalled item, not new queued item"
 
     def test_qa_review_blocks_new_dispatch(self):
         """Bug 3: When active_item is 'qa-review', the catch-all gate must
         prevent picking up a new queued issue.
         """
-        active_item = {"id": "WQ-100", "number": 100, "status": "qa-review", "title": "In QA"}
-        actionable = [{"id": "WQ-200", "number": 200, "status": "queued", "title": "Queued"}]
+        active_item = {
+            "id": "WQ-100",
+            "number": 100,
+            "status": "qa-review",
+            "title": "In QA",
+        }
+        actionable = [
+            {"id": "WQ-200", "number": 200, "status": "queued", "title": "Queued"}
+        ]
 
         ACTIVE_STATUSES = {"in-progress", "qa-review", "qa-failed"}
 
@@ -411,16 +456,30 @@ class TestDispatchQAGateFixes:
         next_item = None
         # qa-review is not in-progress or qa-failed, so next_item stays None
         blocked = False
-        if next_item is None and active_item and active_item["status"] in ACTIVE_STATUSES:
+        if (
+            next_item is None
+            and active_item
+            and active_item["status"] in ACTIVE_STATUSES
+        ):
             blocked = True
 
         assert blocked is True, "qa-review must block dispatch of new issues"
 
     def test_qa_failed_redispatches_same_issue(self):
         """When active_item is 'qa-failed', must re-dispatch same issue."""
-        active_item = {"id": "WQ-100", "number": 100, "status": "qa-failed", "title": "Failed QA"}
+        active_item = {
+            "id": "WQ-100",
+            "number": 100,
+            "status": "qa-failed",
+            "title": "Failed QA",
+        }
         actionable = [
-            {"id": "WQ-100", "number": 100, "status": "qa-failed", "title": "Failed QA"},
+            {
+                "id": "WQ-100",
+                "number": 100,
+                "status": "qa-failed",
+                "title": "Failed QA",
+            },
             {"id": "WQ-200", "number": 200, "status": "queued", "title": "New item"},
         ]
 
@@ -434,7 +493,9 @@ class TestDispatchQAGateFixes:
     def test_no_active_item_picks_from_queue(self):
         """When no active item exists, pick from actionable queue."""
         active_item = None
-        actionable = [{"id": "WQ-200", "number": 200, "status": "queued", "title": "Queued"}]
+        actionable = [
+            {"id": "WQ-200", "number": 200, "status": "queued", "title": "Queued"}
+        ]
 
         ACTIVE_STATUSES = {"in-progress", "qa-review", "qa-failed"}
         ACTIONABLE_STATUSES = {"queued", "qa-failed"}
@@ -545,7 +606,12 @@ class TestQAGateIntegrationScenarios:
         After rejection, the issue has wee-dev:qa-failed label. The dispatch
         script should re-dispatch wee-dev for the SAME issue.
         """
-        active_item = {"id": "WQ-100", "number": 100, "status": "qa-failed", "title": "Fix bug"}
+        active_item = {
+            "id": "WQ-100",
+            "number": 100,
+            "status": "qa-failed",
+            "title": "Fix bug",
+        }
 
         next_item = None
         if active_item and active_item["status"] == "qa-failed":
@@ -559,10 +625,14 @@ class TestQAGateIntegrationScenarios:
         from scheduler.qa_gate import is_wee_dev_gated
 
         lock_file = tmp_path / "lock.json"
-        lock_file.write_text(json.dumps({
-            "state": "wee-dev-running",
-            "work_item_id": "WQ-100",
-        }))
+        lock_file.write_text(
+            json.dumps(
+                {
+                    "state": "wee-dev-running",
+                    "work_item_id": "WQ-100",
+                }
+            )
+        )
 
         gated, reason, details = is_wee_dev_gated(
             lock_path=lock_file,
@@ -576,10 +646,14 @@ class TestQAGateIntegrationScenarios:
         from scheduler.qa_gate import is_wee_dev_gated
 
         lock_file = tmp_path / "lock.json"
-        lock_file.write_text(json.dumps({
-            "state": "qa-review",
-            "work_item_id": "WQ-100",
-        }))
+        lock_file.write_text(
+            json.dumps(
+                {
+                    "state": "qa-review",
+                    "work_item_id": "WQ-100",
+                }
+            )
+        )
 
         gated, reason, details = is_wee_dev_gated(
             lock_path=lock_file,

--- a/tests/test_issue155_devin_permission_mode.py
+++ b/tests/test_issue155_devin_permission_mode.py
@@ -9,7 +9,6 @@ Tests verify:
 """
 
 import inspect
-
 import re
 import sys
 import unittest

--- a/tests/test_issue166_agent_bot_manager.py
+++ b/tests/test_issue166_agent_bot_manager.py
@@ -14,8 +14,11 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from agent_bot_manager import TelegramAgentBot  # noqa: E402
-from agent_bot_manager import (AgentBotManager, WebExAgentBot,  # noqa: E402
-                               resolve_secret)
+from agent_bot_manager import WebExAgentBot  # noqa: E402
+from agent_bot_manager import (
+    AgentBotManager,
+    resolve_secret,
+)
 
 # ---------------------------------------------------------------------------
 # resolve_secret

--- a/tests/test_issue168_runtime_preferences.py
+++ b/tests/test_issue168_runtime_preferences.py
@@ -833,6 +833,7 @@ class TestBackupRuntimeFallback(unittest.TestCase):
                 "_compute_bg_task_defaults",
                 return_value={},
             ):
+
                 async def fake_bg(
                     self_sm,
                     task_id,
@@ -876,6 +877,7 @@ class TestBackupRuntimeFallback(unittest.TestCase):
                 )
         finally:
             import os
+
             if os.path.exists(tmp):
                 os.unlink(tmp)
 

--- a/tests/test_issue174_domcontentloaded_crash.py
+++ b/tests/test_issue174_domcontentloaded_crash.py
@@ -39,24 +39,36 @@ class TestButtonsInHTML(unittest.TestCase):
 
     def test_btn_toggle_queue_exists_in_html(self):
         """btn-toggle-queue button must exist in index.html."""
-        self.assertIn('id="btn-toggle-queue"', self.index_html,
-                      "btn-toggle-queue button missing from HTML. "
-                      "This causes DOMContentLoaded crash at app.js line 2354.")
+        self.assertIn(
+            'id="btn-toggle-queue"',
+            self.index_html,
+            "btn-toggle-queue button missing from HTML. "
+            "This causes DOMContentLoaded crash at app.js line 2354.",
+        )
 
     def test_btn_toggle_queue_has_click_handler_class(self):
         """btn-toggle-queue must have the queue-toggle-btn class."""
-        self.assertIn('id="btn-toggle-queue" class="queue-toggle-btn"', self.index_html,
-                      "btn-toggle-queue must have class='queue-toggle-btn'")
+        self.assertIn(
+            'id="btn-toggle-queue" class="queue-toggle-btn"',
+            self.index_html,
+            "btn-toggle-queue must have class='queue-toggle-btn'",
+        )
 
     def test_btn_pause_queue_exists_in_html(self):
         """btn-pause-queue button must exist in index.html."""
-        self.assertIn('id="btn-pause-queue"', self.index_html,
-                      "btn-pause-queue button missing from HTML")
+        self.assertIn(
+            'id="btn-pause-queue"',
+            self.index_html,
+            "btn-pause-queue button missing from HTML",
+        )
 
     def test_btn_toggle_queue_section_exists_in_html(self):
         """btn-toggle-queue-section button must exist in index.html."""
-        self.assertIn('id="btn-toggle-queue-section"', self.index_html,
-                      "btn-toggle-queue-section button missing from HTML")
+        self.assertIn(
+            'id="btn-toggle-queue-section"',
+            self.index_html,
+            "btn-toggle-queue-section button missing from HTML",
+        )
 
 
 class TestEventListenerSetup(unittest.TestCase):
@@ -69,10 +81,10 @@ class TestEventListenerSetup(unittest.TestCase):
 
     def test_btn_toggle_queue_listener_has_null_check(self):
         """Event listener for btn-toggle-queue must include a null check.
-        
+
         The vulnerable pattern is:
             $('btn-toggle-queue').addEventListener('click', toggleQueuePanel);
-        
+
         Safe pattern is:
             const btnToggleQueue = $('btn-toggle-queue');
             if (btnToggleQueue) {
@@ -84,7 +96,8 @@ class TestEventListenerSetup(unittest.TestCase):
             r"const\s+btnToggleQueue\s*=\s*\$\s*\(\s*['\"]btn-toggle-queue['\"]\s*\)"
         )
         self.assertRegex(
-            self.app_js, pattern_declare,
+            self.app_js,
+            pattern_declare,
             "btn-toggle-queue must be assigned to a const variable for null checking",
         )
 
@@ -95,13 +108,14 @@ class TestEventListenerSetup(unittest.TestCase):
             r"\s*toggleQueuePanel\s*\)"
         )
         self.assertRegex(
-            self.app_js, pattern_check,
+            self.app_js,
+            pattern_check,
             "btnToggleQueue listener setup must be guarded by if (btnToggleQueue)",
         )
 
     def test_btn_pause_queue_listener_has_null_check(self):
         """Event listener for btn-pause-queue must include a null check.
-        
+
         Similar pattern to btnToggleQueue:
             const btnPauseQueue = $('btn-pause-queue');
             if (btnPauseQueue) {
@@ -113,7 +127,8 @@ class TestEventListenerSetup(unittest.TestCase):
             r"const\s+btnPauseQueue\s*=\s*\$\s*\(\s*['\"]btn-pause-queue['\"]\s*\)"
         )
         self.assertRegex(
-            self.app_js, pattern_declare,
+            self.app_js,
+            pattern_declare,
             "btn-pause-queue must be assigned to a const variable for null checking",
         )
 
@@ -124,16 +139,17 @@ class TestEventListenerSetup(unittest.TestCase):
             r"\s*toggleQueuePause\s*\)"
         )
         self.assertRegex(
-            self.app_js, pattern_check,
+            self.app_js,
+            pattern_check,
             "btnPauseQueue listener setup must be guarded by if (btnPauseQueue)",
         )
 
     def test_no_unconditional_btn_toggle_queue_getelementbyid(self):
         """app.js must NOT call addEventListener on btn-toggle-queue without null check.
-        
+
         The vulnerable pattern must not appear anywhere in app.js:
             $('btn-toggle-queue').addEventListener(
-            
+
         This is the exact bug from issue #174.
         """
         # Ensure vulnerable pattern does not exist
@@ -151,27 +167,34 @@ class TestEventListenerSetup(unittest.TestCase):
                 if vulnerable_pattern in line:
                     # Check if this line is preceded by an if check
                     # (Simple heuristic: look back up to 3 lines)
-                    context = "\n".join(lines[max(0, i-3):i+1])
+                    context = "\n".join(lines[max(0, i - 3) : i + 1])
                     self.assertIn(
-                        "if (", context,
+                        "if (",
+                        context,
                         f"Found unconditional addEventListener on btn-toggle-queue"
                         f" at line {i+1}",
                     )
 
     def test_domcontentloaded_handler_completes(self):
         """The DOMContentLoaded handler must complete without errors.
-        
+
         With the null checks in place, even if the button is missing from HTML,
         the handler will skip the listener setup and continue gracefully.
         With the button restored to HTML, listeners will be attached normally.
         """
         # Verify DOMContentLoaded handler is present
-        self.assertIn("document.addEventListener('DOMContentLoaded'", self.app_js,
-                      "DOMContentLoaded handler must be registered")
+        self.assertIn(
+            "document.addEventListener('DOMContentLoaded'",
+            self.app_js,
+            "DOMContentLoaded handler must be registered",
+        )
 
         # Verify the handler includes the queue button setup
-        self.assertIn("Request Queue", self.app_js,
-                      "DOMContentLoaded handler must reference Request Queue section")
+        self.assertIn(
+            "Request Queue",
+            self.app_js,
+            "DOMContentLoaded handler must reference Request Queue section",
+        )
 
 
 class TestRegressionScenarios(unittest.TestCase):
@@ -186,7 +209,7 @@ class TestRegressionScenarios(unittest.TestCase):
 
     def test_button_exists_and_listener_is_safe(self):
         """Simulates: Button is in HTML AND listener is safely registered.
-        
+
         This is the correct state after the fix:
         - Button exists in HTML
         - Listener registration is guarded
@@ -204,10 +227,10 @@ class TestRegressionScenarios(unittest.TestCase):
 
     def test_vulnerable_pattern_not_present(self):
         """Verifies the exact vulnerable pattern from issue #174 is not present.
-        
+
         Vulnerable code from issue:
             $('btn-toggle-queue').addEventListener('click', toggleQueuePanel);
-        
+
         This pattern should NOT be in the current codebase (except in comments).
         """
         # The vulnerable pattern: direct call to addEventListener on result of $()

--- a/tests/test_issue192_toctou_race.py
+++ b/tests/test_issue192_toctou_race.py
@@ -614,9 +614,7 @@ class TestIssue192SlashCommandPerAgentLimit(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         sm = SessionManager.__new__(SessionManager)
         sm._bg_task_mgr = BackgroundTaskManager()
-        sm._bg_task_mgr._path = os.path.join(
-            self.temp_dir, "bg-tasks-slash-test.json"
-        )
+        sm._bg_task_mgr._path = os.path.join(self.temp_dir, "bg-tasks-slash-test.json")
         sm._bg_task_mgr._tasks_cache = None
         sm._bg_identity = "test-user-slash"
         sm.AGENTS = {
@@ -628,9 +626,7 @@ class TestIssue192SlashCommandPerAgentLimit(unittest.TestCase):
 
     def _call_slash(self, argument):
         session_data = {"channel": "telegram"}
-        return self.sm._slash_background(
-            argument, session_data, "n8n-test-session"
-        )
+        return self.sm._slash_background(argument, session_data, "n8n-test-session")
 
     def test_slash_queues_when_agent_limit_reached(self):
         """Second /background for agent at max_concurrent=1 must be queued."""

--- a/tests/test_issue219_bg_fallback.py
+++ b/tests/test_issue219_bg_fallback.py
@@ -9,9 +9,10 @@ runtime fails due to infrastructure issues (429, rate_limit, quota exceeded, 503
 import json
 import os
 import sys
-import pytest
-from unittest.mock import Mock, patch, MagicMock
 from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
 
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -123,14 +124,14 @@ class TestBGTaskFallback:
             fallback_runtime="claude-sdk",
             fallback_model="gpt-4",
         )
-        
+
         assert status == "queued"
         assert task["fallback_runtime"] == "claude-sdk"
-        
+
         # Promote the task
         new_sid = "sess_promoted001"
         self.bg_mgr.promote_queued_task(task_id, new_sid)
-        
+
         # Verify fallback params persisted
         promoted = self.bg_mgr.get_task(task_id)
         assert promoted["status"] == "running"
@@ -162,7 +163,7 @@ class TestBGTaskFallback:
 
 class TestBGTaskFallbackIntegration:
     """Integration tests for fallback retry logic.
-    
+
     These tests mock the subprocess calls to simulate infrastructure failures
     and verify that fallback retries are attempted.
     """
@@ -235,6 +236,7 @@ class TestBGTaskDispatchConfigFallback:
 # Placeholder tests for future implementation
 # These are marked as placeholder to allow the test file to pass
 # They should be replaced with actual subprocess mocking tests
+
 
 def test_issue219_placeholder():
     """Placeholder test to ensure test file has at least one passing test."""

--- a/tests/test_issue219_bg_task_fallback.py
+++ b/tests/test_issue219_bg_task_fallback.py
@@ -275,7 +275,9 @@ class TestIssue219BackgroundTaskFallback(unittest.TestCase):
         primary_result = "Success response"
         primary_error = None
 
-        fallback_patterns = [re.compile(p, re.IGNORECASE) for p in [r"429", r"rate.?limit"]]
+        fallback_patterns = [
+            re.compile(p, re.IGNORECASE) for p in [r"429", r"rate.?limit"]
+        ]
 
         error_text = primary_error or ""
         is_eligible = any(p.search(error_text) for p in fallback_patterns)
@@ -291,7 +293,9 @@ class TestIssue219BackgroundTaskFallback(unittest.TestCase):
         fallback_result = "Fallback success response"
         fallback_error = None
 
-        fallback_patterns = [re.compile(p, re.IGNORECASE) for p in [r"429", r"rate.?limit"]]
+        fallback_patterns = [
+            re.compile(p, re.IGNORECASE) for p in [r"429", r"rate.?limit"]
+        ]
 
         error_text = primary_error or ""
         is_eligible = any(p.search(error_text) for p in fallback_patterns)
@@ -306,7 +310,9 @@ class TestIssue219BackgroundTaskFallback(unittest.TestCase):
         primary_error = "429: Rate limit exceeded"
         fallback_error = "503: Service unavailable"
 
-        fallback_patterns = [re.compile(p, re.IGNORECASE) for p in [r"429", r"rate.?limit"]]
+        fallback_patterns = [
+            re.compile(p, re.IGNORECASE) for p in [r"429", r"rate.?limit"]
+        ]
 
         error_text = primary_error or ""
         is_eligible = any(p.search(error_text) for p in fallback_patterns)

--- a/tests/test_issue223_str_upper_runtime_failure.py
+++ b/tests/test_issue223_str_upper_runtime_failure.py
@@ -136,6 +136,7 @@ class TestIssue223StrUpperRuntimeFailure(unittest.TestCase):
     def test_issue_223_channel_upper_call_syntax_absent_from_source(self):
         """{channel.upper()} must not appear in the file_handling template source."""
         import ast
+
         src_path = Path(__file__).parent.parent / "agent_manager.py"
         src = src_path.read_text()
         self.assertNotIn(

--- a/tests/test_issue225_runtime_config_consolidation.py
+++ b/tests/test_issue225_runtime_config_consolidation.py
@@ -11,7 +11,7 @@ This test verifies that:
 import json
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -71,9 +71,7 @@ class TestRuntimeConfigConsolidation:
 
     def test_agent_manager_loads_new_runtime_fields(self, sample_agent_config):
         """Test that agent_manager loads new primary/fallback fields correctly."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             json.dump(sample_agent_config, tmp)
             tmp_path = tmp.name
 
@@ -99,9 +97,7 @@ class TestRuntimeConfigConsolidation:
         self, legacy_agent_config
     ):
         """Test that agent_manager maintains backward compatibility with legacy runtime/model."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             json.dump(legacy_agent_config, tmp)
             tmp_path = tmp.name
 
@@ -250,49 +246,52 @@ class TestRuntimeConfigConsolidation:
         self, sample_agent_config
     ):
         """Test that reload_agents_from_disk preserves primary/fallback and dispatch_config.
-        
-        This is a regression test for the QA failure where reload_agents_from_disk() 
+
+        This is a regression test for the QA failure where reload_agents_from_disk()
         was using old 'runtime'/'model' field names instead of 'primary_runtime'/'primary_model'.
         """
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             json.dump(sample_agent_config, tmp)
             tmp_path = tmp.name
 
         try:
-            from agent_manager import SessionManager
             from pathlib import Path
+
+            from agent_manager import SessionManager
 
             sm = SessionManager.__new__(SessionManager)
             sm._agents_config_path = Path(tmp_path)
             sm._agents_json_mtime = 0
-            
+
             # Load agents via _load_agents_config
             agents = sm._load_agents_config(tmp_path)
             sm.AGENTS = agents
-            
+
             # Verify initial load has all fields
             agent = sm.AGENTS["test-agent"]
             assert agent["primary_runtime"] == "copilot"
             assert agent["primary_model"] == "claude-sonnet-4.6"
             assert agent["fallback_runtime"] == "claude"
             assert agent["fallback_model"] == "claude-3-opus"
-            
+
             # Now trigger reload_agents_from_disk (simulating hot-reload)
             success, msg = sm.reload_agents_from_disk()
             assert success
-            
+
             # Verify all fields are preserved after reload
             agent_after = sm.AGENTS["test-agent"]
-            assert agent_after["primary_runtime"] == "copilot", \
-                "primary_runtime not preserved after reload"
-            assert agent_after["primary_model"] == "claude-sonnet-4.6", \
-                "primary_model not preserved after reload"
-            assert agent_after["fallback_runtime"] == "claude", \
-                "fallback_runtime not preserved after reload"
-            assert agent_after["fallback_model"] == "claude-3-opus", \
-                "fallback_model not preserved after reload"
+            assert (
+                agent_after["primary_runtime"] == "copilot"
+            ), "primary_runtime not preserved after reload"
+            assert (
+                agent_after["primary_model"] == "claude-sonnet-4.6"
+            ), "primary_model not preserved after reload"
+            assert (
+                agent_after["fallback_runtime"] == "claude"
+            ), "fallback_runtime not preserved after reload"
+            assert (
+                agent_after["fallback_model"] == "claude-3-opus"
+            ), "fallback_model not preserved after reload"
         finally:
             Path(tmp_path).unlink()
 

--- a/tests/test_issue243_fallback_indicator.py
+++ b/tests/test_issue243_fallback_indicator.py
@@ -79,7 +79,9 @@ class TestFallbackFieldsInTaskRecord(unittest.TestCase):
 
     def test_mark_fallback_used_sets_fields(self):
         """mark_fallback_used() sets used_fallback=True and actual_runtime/model."""
-        self._create("bg_fallback001", fallback_runtime="copilot", fallback_model="auto")
+        self._create(
+            "bg_fallback001", fallback_runtime="copilot", fallback_model="auto"
+        )
         self.mgr.mark_fallback_used("bg_fallback001", "copilot", "auto")
         task = self.mgr.get_task("bg_fallback001")
         self.assertTrue(task["used_fallback"])
@@ -88,7 +90,9 @@ class TestFallbackFieldsInTaskRecord(unittest.TestCase):
 
     def test_mark_fallback_used_persisted(self):
         """mark_fallback_used() changes persist to disk (task survives reload)."""
-        self._create("bg_persist001", fallback_runtime="copilot", fallback_model="gpt-5-mini")
+        self._create(
+            "bg_persist001", fallback_runtime="copilot", fallback_model="gpt-5-mini"
+        )
         self.mgr.mark_fallback_used("bg_persist001", "copilot", "gpt-5-mini")
         # Create new manager pointing to same file — simulates service restart read
         mgr2 = _make_mgr(self.tmp.name)
@@ -120,15 +124,26 @@ class TestFallbackRateLimitPatterns(unittest.TestCase):
     """Verify the rate-limit/infra error detection patterns."""
 
     PATTERNS = [
-        r"429", r"rate.?limit", r"quota.?exceeded",
-        r"401", r"unauthorized", r"missing.?authentication",
+        r"429",
+        r"rate.?limit",
+        r"quota.?exceeded",
+        r"401",
+        r"unauthorized",
+        r"missing.?authentication",
         r"api[_\-]?key.?(invalid|expired|missing)",
-        r"503", r"service.?unavailable", r"502", r"bad.?gateway",
-        r"connection.?refused", r"timed?.?out", r"etimedout", r"overloaded",
+        r"503",
+        r"service.?unavailable",
+        r"502",
+        r"bad.?gateway",
+        r"connection.?refused",
+        r"timed?.?out",
+        r"etimedout",
+        r"overloaded",
     ]
 
     def _is_infra_error(self, text):
         import re
+
         return any(re.search(p, text, re.IGNORECASE) for p in self.PATTERNS)
 
     def test_429_triggers_fallback(self):
@@ -185,7 +200,10 @@ class TestFallbackNotAppliedWhenAlreadyUsed(unittest.TestCase):
         task = self.mgr.get_task("bg_double001")
         # Simulate the guard check used in _run_background_task
         already_fb = task.get("used_fallback", False)
-        self.assertTrue(already_fb, "Second fallback attempt should be blocked by used_fallback flag")
+        self.assertTrue(
+            already_fb,
+            "Second fallback attempt should be blocked by used_fallback flag",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_issue248_agent_name_in_session_list.py
+++ b/tests/test_issue248_agent_name_in_session_list.py
@@ -20,12 +20,14 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 def _make_history_manager():
     """Create a HistoryManager with a temp file."""
     import agent_manager as am
+
     mgr = am.HistoryManager.__new__(am.HistoryManager)
     # Point to a temp file
     tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
     json.dump({}, tmp)
     tmp.close()
     import threading
+
     mgr._path = tmp.name
     mgr._lock = threading.Lock()
     return mgr, tmp.name
@@ -63,9 +65,7 @@ def test_get_sessions_returns_agent_field():
     """get_sessions() must include agent in returned data."""
     mgr, path = _make_history_manager()
     try:
-        mgr.create_session(
-            "telegram", "testuser", "sess003", agent="orchestrator"
-        )
+        mgr.create_session("telegram", "testuser", "sess003", agent="orchestrator")
         sessions = mgr.get_sessions("telegram", "testuser")
         assert "agent" in sessions[0], "agent field missing from get_sessions()"
         assert sessions[0]["agent"] == "orchestrator"
@@ -77,9 +77,7 @@ def test_update_session_agent():
     """update_session_agent() should update the agent on an existing session."""
     mgr, path = _make_history_manager()
     try:
-        mgr.create_session(
-            "telegram", "testuser", "sess004", agent="orchestrator"
-        )
+        mgr.create_session("telegram", "testuser", "sess004", agent="orchestrator")
         result = mgr.update_session_agent("telegram", "testuser", "sess004", "wee-qa")
         assert result is True, "update_session_agent should return True on success"
         sessions = mgr.get_sessions("telegram", "testuser")

--- a/tests/test_issue93_keyring_unlock.py
+++ b/tests/test_issue93_keyring_unlock.py
@@ -2,7 +2,6 @@
 """Tests for Issue #93: Keyring unlock via WebUI."""
 
 import json
-
 import sys
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/test_issue94_claude_sdk_elevated.py
+++ b/tests/test_issue94_claude_sdk_elevated.py
@@ -67,8 +67,11 @@ class TestIssue94ArgsSwapBug(unittest.TestCase):
         result = mgr._resolve_permission_mode(mode_str, session_data)
         # With swapped args, session_data (a dict) lands in prompt_mode.
         # dict != "restricted" is True, so it returns the dict — a dict, not a string.
-        self.assertIsInstance(result, dict,
-            "Bug scenario: swapped args should return dict (demonstrating the bug)")
+        self.assertIsInstance(
+            result,
+            dict,
+            "Bug scenario: swapped args should return dict (demonstrating the bug)",
+        )
 
     def test_correct_args_returns_string(self):
         """With correct arg order, mode is always a string."""
@@ -78,10 +81,14 @@ class TestIssue94ArgsSwapBug(unittest.TestCase):
 
         # CORRECT call order
         result = mgr._resolve_permission_mode(session_data, mode_str)
-        self.assertIsInstance(result, str,
-            "Correct arg order must always return a string mode")
-        self.assertEqual(result, "elevated",
-            "Elevated session permissions must resolve to 'elevated'")
+        self.assertIsInstance(
+            result, str, "Correct arg order must always return a string mode"
+        )
+        self.assertEqual(
+            result,
+            "elevated",
+            "Elevated session permissions must resolve to 'elevated'",
+        )
 
     def test_elevated_mode_never_dict(self):
         """mode == 'elevated' comparison must succeed (not dict == str)."""
@@ -93,12 +100,15 @@ class TestIssue94ArgsSwapBug(unittest.TestCase):
         self.assertEqual(result, "elevated")
         # And the downstream mapping must work
         sdk_permission_mode = (
-            "bypassPermissions" if result == "elevated"
-            else "plan" if result == "sandboxed"
-            else "default"
+            "bypassPermissions"
+            if result == "elevated"
+            else "plan" if result == "sandboxed" else "default"
         )
-        self.assertEqual(sdk_permission_mode, "bypassPermissions",
-            "Elevated mode must map to bypassPermissions for claude-sdk")
+        self.assertEqual(
+            sdk_permission_mode,
+            "bypassPermissions",
+            "Elevated mode must map to bypassPermissions for claude-sdk",
+        )
 
     def test_background_task_elevated_resolves_correctly(self):
         """Background task with elevated permissions resolves to bypassPermissions."""
@@ -140,8 +150,11 @@ class TestIssue94ArgsSwapBug(unittest.TestCase):
         session_data = {"permissions": {"mode": "restricted"}}
 
         result = mgr._resolve_permission_mode(session_data, "elevated")
-        self.assertEqual(result, "elevated",
-            "prompt_mode 'elevated' must override session permissions")
+        self.assertEqual(
+            result,
+            "elevated",
+            "prompt_mode 'elevated' must override session permissions",
+        )
 
     def test_return_type_is_always_string(self):
         """_resolve_permission_mode must ALWAYS return a string, never a dict."""
@@ -157,9 +170,12 @@ class TestIssue94ArgsSwapBug(unittest.TestCase):
         ]
         for session_data, prompt_mode in test_cases:
             result = mgr._resolve_permission_mode(session_data, prompt_mode)
-            self.assertIsInstance(result, str,
+            self.assertIsInstance(
+                result,
+                str,
                 f"Must return str, got {type(result).__name__} for "
-                f"session_data={session_data}, prompt_mode={prompt_mode}")
+                f"session_data={session_data}, prompt_mode={prompt_mode}",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_issue96_run_now_command_mode.py
+++ b/tests/test_issue96_run_now_command_mode.py
@@ -6,10 +6,8 @@ correctly routes command-mode jobs to direct shell execution instead of
 dispatching them through the LLM pipeline.
 """
 
-
 import os
 import sys
-
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -182,9 +180,7 @@ class TestRunCommandTaskExecution(unittest.TestCase):
         self.assertNotIn("shell=True", func_body, "Should not use shell=True")
 
         # Should use capture_output=True
-        self.assertIn(
-            "capture_output=True", func_body, "Should capture output"
-        )
+        self.assertIn("capture_output=True", func_body, "Should capture output")
 
         # Should use text=True
         self.assertIn("text=True", func_body, "Should use text mode")
@@ -251,8 +247,9 @@ class TestRunNowAPIIntegration(unittest.TestCase):
     def _get_test_client(self):
         """Get a test client for the API."""
         try:
-            from agent_manager import create_api_app
             from httpx import ASGITransport, AsyncClient
+
+            from agent_manager import create_api_app
 
             app = create_api_app()
             transport = ASGITransport(app=app)
@@ -267,7 +264,9 @@ class TestRunNowAPIIntegration(unittest.TestCase):
         except ImportError:
             self.skipTest("httpx not available")
 
-        agent_manager = _load_module("issue96_agent_manager_api", REPO / "agent_manager.py")
+        agent_manager = _load_module(
+            "issue96_agent_manager_api", REPO / "agent_manager.py"
+        )
         create_api_app = agent_manager.create_api_app
         app = create_api_app()
 

--- a/tests/test_issue_170_bg_task_deadlock.py
+++ b/tests/test_issue_170_bg_task_deadlock.py
@@ -17,7 +17,7 @@ import tempfile
 import threading
 import time
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -43,7 +43,9 @@ class TestIssue170BackgroundTaskDeadlock(unittest.TestCase):
         mgr._cleanup_thread_started = True  # skip thread startup in tests
         return mgr
 
-    def _make_task(self, task_id, status="completed", completed_at=None, created_at=None):
+    def _make_task(
+        self, task_id, status="completed", completed_at=None, created_at=None
+    ):
         """Create a minimal task dict."""
         now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         return {
@@ -106,7 +108,9 @@ class TestIssue170BackgroundTaskDeadlock(unittest.TestCase):
 
         # Verify total tasks <= MAX_TOTAL_TASKS
         loaded = mgr._load()
-        self.assertLessEqual(len(loaded), mgr.MAX_TOTAL_TASKS + 1)  # +1 for the new task
+        self.assertLessEqual(
+            len(loaded), mgr.MAX_TOTAL_TASKS + 1
+        )  # +1 for the new task
 
         # Verify the new task exists
         task_ids = [t["task_id"] for t in loaded]
@@ -197,7 +201,9 @@ class TestIssue170BackgroundTaskDeadlock(unittest.TestCase):
         elapsed = time.time() - start
 
         self.assertEqual(len(result), 300)
-        self.assertLess(elapsed, 1.0, f"list_all_tasks took {elapsed:.3f}s (should be <1s)")
+        self.assertLess(
+            elapsed, 1.0, f"list_all_tasks took {elapsed:.3f}s (should be <1s)"
+        )
 
     # --- Test 3: Cleanup old tasks ---
 
@@ -213,7 +219,9 @@ class TestIssue170BackgroundTaskDeadlock(unittest.TestCase):
             t = self._make_task(
                 f"old-{i}",
                 status="completed",
-                completed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 7200)),
+                completed_at=time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 7200)
+                ),
             )
             tasks.append(t)
 
@@ -222,7 +230,9 @@ class TestIssue170BackgroundTaskDeadlock(unittest.TestCase):
             t = self._make_task(
                 f"recent-{i}",
                 status="completed",
-                completed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 1800)),
+                completed_at=time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 1800)
+                ),
             )
             tasks.append(t)
 
@@ -322,7 +332,9 @@ class TestIssue170BackgroundTaskDeadlock(unittest.TestCase):
             t = self._make_task(
                 f"old-{i}",
                 status="completed",
-                completed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 7200)),
+                completed_at=time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 7200)
+                ),
             )
             tasks.append(t)
 
@@ -331,7 +343,9 @@ class TestIssue170BackgroundTaskDeadlock(unittest.TestCase):
             t = self._make_task(
                 f"recent-{i}",
                 status="completed",
-                completed_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 1800)),
+                completed_at=time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 1800)
+                ),
             )
             tasks.append(t)
 
@@ -421,7 +435,6 @@ class TestIssue170AsyncIO(unittest.TestCase):
 
         self.assertEqual(len(errors), 0, f"Errors during concurrent reads: {errors}")
         self.assertEqual(len(results), 50)  # 5 threads × 10 reads
-
 
 
 class TestIssue170InMemoryCache(unittest.TestCase):
@@ -529,7 +542,11 @@ class TestIssue170InMemoryCache(unittest.TestCase):
             mgr.list_all_tasks()
         elapsed = (time.time() - start) / 100  # avg per call
 
-        self.assertLess(elapsed, 0.01, f"list_all_tasks avg {elapsed*1000:.1f}ms (should be <10ms with cache)")
+        self.assertLess(
+            elapsed,
+            0.01,
+            f"list_all_tasks avg {elapsed*1000:.1f}ms (should be <10ms with cache)",
+        )
 
 
 class TestIssue170HealthEndpoint(unittest.TestCase):
@@ -538,31 +555,33 @@ class TestIssue170HealthEndpoint(unittest.TestCase):
     def test_health_response_has_no_active_sessions(self):
         """Health endpoint must not call load_session_map (blocking disk I/O)."""
         import agent_manager as am
+
         src_path = am.__file__
-        with open(src_path, 'r') as f:
+        with open(src_path, "r") as f:
             src = f.read()
 
         # Extract the health handler body
-        health_start = src.find('async def health():')
-        health_end = src.find('\n    @app.', health_start + 1)
+        health_start = src.find("async def health():")
+        health_end = src.find("\n    @app.", health_start + 1)
         health_src = src[health_start:health_end]
 
         # Strip comment lines before checking for prohibited calls
         code_lines = [
-            line for line in health_src.splitlines()
-            if line.strip() and not line.strip().startswith('#')
+            line
+            for line in health_src.splitlines()
+            if line.strip() and not line.strip().startswith("#")
         ]
-        code_only = '\n'.join(code_lines)
+        code_only = "\n".join(code_lines)
 
         self.assertNotIn(
-            'load_session_map()',
+            "load_session_map()",
             code_only,
-            "Health endpoint must not call load_session_map() — blocking disk I/O"
+            "Health endpoint must not call load_session_map() — blocking disk I/O",
         )
         self.assertNotIn(
-            'active_sessions',
+            "active_sessions",
             code_only,
-            "Health endpoint must not include active_sessions (requires blocking disk read)"
+            "Health endpoint must not include active_sessions (requires blocking disk read)",
         )
 
 

--- a/tests/test_issue_197_dispatch_fallback.py
+++ b/tests/test_issue_197_dispatch_fallback.py
@@ -42,6 +42,7 @@ class TestCheckRuntimeBlocked(unittest.TestCase):
             "|----|-----------------|-------|---------------|------------|----------------|\n"
         )
         import tempfile
+
         with tempfile.TemporaryDirectory() as d:
             path = self._write_state(d, content)
             self.assertFalse(agent_manager.check_runtime_blocked("copilot", path))
@@ -55,6 +56,7 @@ class TestCheckRuntimeBlocked(unittest.TestCase):
             "| RS-001 | `copilot` | Rate limited | 2099-12-31 23:59 UTC | wee-dev | use claude-sdk |\n"  # noqa: E501
         )
         import tempfile
+
         with tempfile.TemporaryDirectory() as d:
             path = self._write_state(d, content)
             self.assertTrue(agent_manager.check_runtime_blocked("copilot", path))
@@ -68,6 +70,7 @@ class TestCheckRuntimeBlocked(unittest.TestCase):
             "| RS-002 | `copilot` | Old issue | 2000-01-01 00:00 UTC | wee-dev | use claude-sdk |\n"  # noqa: E501
         )
         import tempfile
+
         with tempfile.TemporaryDirectory() as d:
             path = self._write_state(d, content)
             self.assertFalse(agent_manager.check_runtime_blocked("copilot", path))
@@ -81,6 +84,7 @@ class TestCheckRuntimeBlocked(unittest.TestCase):
             "| RS-003 | `claude-sdk` | Auth failure |  | wee-dev | use copilot |\n"
         )
         import tempfile
+
         with tempfile.TemporaryDirectory() as d:
             path = self._write_state(d, content)
             self.assertTrue(agent_manager.check_runtime_blocked("claude-sdk", path))
@@ -94,6 +98,7 @@ class TestCheckRuntimeBlocked(unittest.TestCase):
             "| RS-004 | `claude-sdk` | Auth failure | 2099-01-01 00:00 UTC | wee-dev | use copilot |\n"  # noqa: E501
         )
         import tempfile
+
         with tempfile.TemporaryDirectory() as d:
             path = self._write_state(d, content)
             self.assertFalse(agent_manager.check_runtime_blocked("copilot", path))
@@ -107,6 +112,7 @@ class TestCheckRuntimeBlocked(unittest.TestCase):
             "| RS-005 | `openrouter/:free` | Quota | 2099-01-01 00:00 UTC | wee-dev | use copilot |\n"  # noqa: E501
         )
         import tempfile
+
         with tempfile.TemporaryDirectory() as d:
             path = self._write_state(d, content)
             # "openrouter" alone should match "openrouter/:free"
@@ -121,6 +127,7 @@ class TestCheckRuntimeBlocked(unittest.TestCase):
             "| RS-006 | copilot | Rate limit | 2099-01-01 00:00 UTC | wee-dev | - |\n"
         )
         import tempfile
+
         with tempfile.TemporaryDirectory() as d:
             path = self._write_state(d, content)
             self.assertTrue(agent_manager.check_runtime_blocked("copilot", path))
@@ -157,8 +164,9 @@ class TestResolveDispatchRuntimeModel(unittest.TestCase):
         self.assertFalse(used)
 
     def test_primary_healthy_no_fallback(self):
-        with patch.object(agent_manager, "check_runtime_blocked", return_value=False), \
-             patch.object(agent_manager, "check_runtime_available", return_value=True):
+        with patch.object(
+            agent_manager, "check_runtime_blocked", return_value=False
+        ), patch.object(agent_manager, "check_runtime_available", return_value=True):
             rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
                 "wee-dev", "claude-sdk", "claude-sonnet-4.6", self.AGENTS_WITH_FALLBACK
             )
@@ -176,8 +184,9 @@ class TestResolveDispatchRuntimeModel(unittest.TestCase):
         self.assertIn("blocked in RUNTIME_STATE.md", reason)
 
     def test_unavailable_runtime_triggers_fallback(self):
-        with patch.object(agent_manager, "check_runtime_blocked", return_value=False), \
-             patch.object(agent_manager, "check_runtime_available", return_value=False):
+        with patch.object(
+            agent_manager, "check_runtime_blocked", return_value=False
+        ), patch.object(agent_manager, "check_runtime_available", return_value=False):
             rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
                 "wee-dev", "claude-sdk", "claude-sonnet-4.6", self.AGENTS_WITH_FALLBACK
             )
@@ -186,8 +195,9 @@ class TestResolveDispatchRuntimeModel(unittest.TestCase):
         self.assertIn("not available on this host", reason)
 
     def test_unknown_agent_returns_original(self):
-        with patch.object(agent_manager, "check_runtime_blocked", return_value=False), \
-             patch.object(agent_manager, "check_runtime_available", return_value=True):
+        with patch.object(
+            agent_manager, "check_runtime_blocked", return_value=False
+        ), patch.object(agent_manager, "check_runtime_available", return_value=True):
             rt, model, used, reason = agent_manager.resolve_dispatch_runtime_model(
                 "nonexistent-agent", "copilot", "gpt-5-mini", {}
             )

--- a/tests/test_issue_20_shell_injection.py
+++ b/tests/test_issue_20_shell_injection.py
@@ -56,9 +56,9 @@ class TestIssue20ShellInjection(unittest.TestCase):
                 "name": "Issue 20 Scheduler",
                 "task": (
                     'python3 -c "from pathlib import Path; '
-                    'Path(\'safe.txt\').write_text(\'ok\')" ; '
+                    "Path('safe.txt').write_text('ok')\" ; "
                     'python3 -c "from pathlib import Path; '
-                    'Path(\'pwned.txt\').write_text(\'bad\')"'
+                    "Path('pwned.txt').write_text('bad')\""
                 ),
                 "working_dir": str(tmp_path),
                 "notify": False,
@@ -78,9 +78,9 @@ class TestIssue20ShellInjection(unittest.TestCase):
             mgr = _build_manager(tmp_path)
             command = (
                 'python3 -c "from pathlib import Path; '
-                'Path(\'safe.txt\').write_text(\'ok\')" ; '
+                "Path('safe.txt').write_text('ok')\" ; "
                 'python3 -c "from pathlib import Path; '
-                'Path(\'pwned.txt\').write_text(\'bad\')"'
+                "Path('pwned.txt').write_text('bad')\""
             )
 
             result = mgr._execute_bash_command(command, "orchestrator")

--- a/tests/test_issue_21_scheduler_path_validation.py
+++ b/tests/test_issue_21_scheduler_path_validation.py
@@ -21,7 +21,9 @@ def _load_module(name: str, path: Path):
     return module
 
 
-management = _load_module("issue21_scheduler_management", REPO / "scheduler" / "management.py")
+management = _load_module(
+    "issue21_scheduler_management", REPO / "scheduler" / "management.py"
+)
 TaskScheduler = management.TaskScheduler
 
 

--- a/tests/test_issue_236_service_status.py
+++ b/tests/test_issue_236_service_status.py
@@ -95,8 +95,14 @@ class TestServiceStatusEndpoint(unittest.TestCase):
         data = resp.json()
         telegram_svc = data["services"]["telegram"]["service"]
         webex_svc = data["services"]["webex"]["service"]
-        self.assertIn("-dev", telegram_svc, "telegram service name must have -dev suffix in DEV env")
-        self.assertIn("-dev", webex_svc, "webex service name must have -dev suffix in DEV env")
+        self.assertIn(
+            "-dev",
+            telegram_svc,
+            "telegram service name must have -dev suffix in DEV env",
+        )
+        self.assertIn(
+            "-dev", webex_svc, "webex service name must have -dev suffix in DEV env"
+        )
 
     def test_service_status_active_field_valid_type(self):
         """active field must always be boolean, never string."""
@@ -104,8 +110,9 @@ class TestServiceStatusEndpoint(unittest.TestCase):
         data = resp.json()
         for name, svc in data["services"].items():
             self.assertIsInstance(
-                svc["active"], bool,
-                f"{name}.active must be bool, got {type(svc['active'])}"
+                svc["active"],
+                bool,
+                f"{name}.active must be bool, got {type(svc['active'])}",
             )
 
 

--- a/tests/test_issue_238_config_consolidation.py
+++ b/tests/test_issue_238_config_consolidation.py
@@ -122,13 +122,17 @@ class TestIssue238SingleSourceOfTruth(unittest.TestCase):
 
     def test_explicit_permission_mode_overrides_default(self):
         """Explicit permission_mode field overrides the agent-name-based default."""
-        agents = self._make_agents(extra_agents=[{
-            "name": "custom-agent",
-            "path": "/opt/custom",
-            "primary_runtime": "claude",
-            "primary_model": "haiku",
-            "permission_mode": "elevated",
-        }])
+        agents = self._make_agents(
+            extra_agents=[
+                {
+                    "name": "custom-agent",
+                    "path": "/opt/custom",
+                    "primary_runtime": "claude",
+                    "primary_model": "haiku",
+                    "permission_mode": "elevated",
+                }
+            ]
+        )
         get_cfg, tmp = _make_dispatch_func(agents)
         try:
             cfg = get_cfg("custom-agent")
@@ -139,13 +143,15 @@ class TestIssue238SingleSourceOfTruth(unittest.TestCase):
     def test_explicit_yolo_false_overrides_default_for_wee_dev(self):
         """Explicit yolo=False in agents.json overrides the wee-dev default of True."""
         agents = {
-            "agents": [{
-                "name": "wee-dev",
-                "path": "/opt/wee-dev",
-                "primary_runtime": "claude",
-                "primary_model": "sonnet",
-                "yolo": False,
-            }]
+            "agents": [
+                {
+                    "name": "wee-dev",
+                    "path": "/opt/wee-dev",
+                    "primary_runtime": "claude",
+                    "primary_model": "sonnet",
+                    "yolo": False,
+                }
+            ]
         }
         get_cfg, tmp = _make_dispatch_func(agents)
         try:
@@ -157,19 +163,21 @@ class TestIssue238SingleSourceOfTruth(unittest.TestCase):
     def test_legacy_dispatch_config_block_still_works(self):
         """Legacy dispatch_config block in agents.json is still respected."""
         agents = {
-            "agents": [{
-                "name": "wee-dev",
-                "path": "/opt/wee-dev",
-                "dispatch_config": {
-                    "runtime": "copilot",
-                    "model": "claude-opus-4.6",
-                    "permission_mode": "elevated",
-                    "yolo": True,
-                    "timeout": 1800,
-                },
-                "fallback_runtime": "codex",
-                "fallback_model": "gpt-5.4-mini",
-            }]
+            "agents": [
+                {
+                    "name": "wee-dev",
+                    "path": "/opt/wee-dev",
+                    "dispatch_config": {
+                        "runtime": "copilot",
+                        "model": "claude-opus-4.6",
+                        "permission_mode": "elevated",
+                        "yolo": True,
+                        "timeout": 1800,
+                    },
+                    "fallback_runtime": "codex",
+                    "fallback_model": "gpt-5.4-mini",
+                }
+            ]
         }
         get_cfg, tmp = _make_dispatch_func(agents)
         try:
@@ -198,7 +206,9 @@ class TestIssue238SingleSourceOfTruth(unittest.TestCase):
         This is the core of issue #238: the old overlay path was removed so
         config/agents.json can never be silently consulted.
         """
-        script_path = Path("/opt/n8n-copilot-shim-dev/scripts/dispatch_wee_dev_work_queue.py")
+        script_path = Path(
+            "/opt/n8n-copilot-shim-dev/scripts/dispatch_wee_dev_work_queue.py"
+        )
         self.assertTrue(script_path.exists(), "dispatch script missing")
         content = script_path.read_text()
         self.assertNotIn(
@@ -213,7 +223,9 @@ class TestIssue238SingleSourceOfTruth(unittest.TestCase):
 
         Checks actual AST to distinguish docstring mentions from live code.
         """
-        script_path = Path("/opt/n8n-copilot-shim-dev/scripts/dispatch_wee_dev_work_queue.py")
+        script_path = Path(
+            "/opt/n8n-copilot-shim-dev/scripts/dispatch_wee_dev_work_queue.py"
+        )
         content = script_path.read_text()
         try:
             tree = ast.parse(content)
@@ -249,7 +261,9 @@ class TestIssue238SingleSourceOfTruth(unittest.TestCase):
             "wee-dev missing permission_mode in agents.json (issue #238)",
         )
         self.assertEqual(wee_dev["permission_mode"], "elevated")
-        self.assertIn("yolo", wee_dev, "wee-dev missing yolo in agents.json (issue #238)")
+        self.assertIn(
+            "yolo", wee_dev, "wee-dev missing yolo in agents.json (issue #238)"
+        )
         self.assertTrue(wee_dev["yolo"])
 
     def test_no_duplicate_agents_in_agents_json(self):
@@ -270,11 +284,14 @@ class TestIssue238SingleSourceOfTruth(unittest.TestCase):
         self.assertTrue(jobs_path.exists(), "scheduler jobs file missing")
         jobs = json.loads(jobs_path.read_text())
         wee_dev_jobs = [
-            j for j in jobs.get("jobs", [])
+            j
+            for j in jobs.get("jobs", [])
             if "dispatch_wee_dev" in j.get("task", "")
-               or "work-queue" in j.get("id", "")
+            or "work-queue" in j.get("id", "")
         ]
-        self.assertTrue(len(wee_dev_jobs) > 0, "No wee-dev work queue scheduler job found")
+        self.assertTrue(
+            len(wee_dev_jobs) > 0, "No wee-dev work queue scheduler job found"
+        )
         for job in wee_dev_jobs:
             self.assertIn(
                 "scripts/dispatch_wee_dev",

--- a/tests/test_issue_23_lock_cleanup.py
+++ b/tests/test_issue_23_lock_cleanup.py
@@ -73,23 +73,23 @@ def test_lock_cleanup_on_ttl_eviction():
         print(f"  After TTL pruning: {len(pruned_map)} sessions remain")
 
         # Verify locks for evicted sessions were cleaned up
-        assert "old_session_1" not in sm._per_session_locks, (
-            "Lock for old_session_1 should be cleaned up"
-        )
-        assert "old_session_2" not in sm._per_session_locks, (
-            "Lock for old_session_2 should be cleaned up"
-        )
-        assert "recent_session" in sm._per_session_locks, (
-            "Lock for recent_session should remain"
-        )
+        assert (
+            "old_session_1" not in sm._per_session_locks
+        ), "Lock for old_session_1 should be cleaned up"
+        assert (
+            "old_session_2" not in sm._per_session_locks
+        ), "Lock for old_session_2 should be cleaned up"
+        assert (
+            "recent_session" in sm._per_session_locks
+        ), "Lock for recent_session should remain"
 
         final_lock_count = len(sm._per_session_locks)
         print(f"  Final lock count: {final_lock_count} locks")
         print(f"  ✓ Cleaned up {initial_lock_count - final_lock_count} orphaned locks")
 
-        assert final_lock_count == 1, (
-            f"Expected 1 lock remaining, got {final_lock_count}"
-        )
+        assert (
+            final_lock_count == 1
+        ), f"Expected 1 lock remaining, got {final_lock_count}"
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_23_race_condition.py
+++ b/tests/test_issue_23_race_condition.py
@@ -98,8 +98,9 @@ def test_per_session_locking():
 
 def test_atomic_write():
     """Test that save_session_map_atomic writes atomically."""
-    from agent_manager import SessionManager
     from pathlib import Path
+
+    from agent_manager import SessionManager
 
     with tempfile.TemporaryDirectory() as tmpdir:
         session_map_file = Path(tmpdir) / "test-session-map.json"

--- a/tests/test_issue_249_agent_defaults.py
+++ b/tests/test_issue_249_agent_defaults.py
@@ -1,173 +1,239 @@
 """
-Tests for issue #249: Auto-apply agent runtime/model defaults on switch.
+Regression tests for issue #249: Auto-apply agent runtime/model defaults on switch.
 
-When switching agents, the system should automatically apply that agent's
+When switching agents, set_agent() must automatically apply that agent's
 primary_runtime and primary_model from agents.json as execution defaults.
+These tests call the REAL set_agent() and assert session_map is updated.
 """
 
-import pytest
 import json
+import os
+import sys
 import tempfile
-from pathlib import Path
-from unittest.mock import MagicMock, patch
-from uuid import uuid4
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-class TestAgentDefaultsOnSwitch:
-    """Test suite for auto-applying agent defaults on agent switch."""
+_MOCK_AGENTS = {
+    "orchestrator": {
+        "name": "orchestrator",
+        "path": "/opt/",
+        "description": "Main orchestrator",
+        "primary_runtime": "claude",
+        "primary_model": "haiku",
+        "fallback_runtime": "copilot",
+        "fallback_model": "auto",
+        "max_concurrent": 1,
+    },
+    "research": {
+        "name": "research",
+        "path": "/opt/research",
+        "description": "Research agent",
+        "primary_runtime": "opencode",
+        "primary_model": "nvidia/llama-3.1-nemotron",
+        "fallback_runtime": "claude",
+        "fallback_model": "sonnet",
+        "max_concurrent": 1,
+    },
+    "wee-dev": {
+        "name": "wee-dev",
+        "path": "/opt/wee-dev",
+        "description": "Wee Orchestrator developer",
+        "primary_runtime": "copilot",
+        "primary_model": "gpt-5.4-mini",
+        "fallback_runtime": "claude",
+        "fallback_model": "opus",
+        "max_concurrent": 1,
+    },
+}
 
-    @pytest.fixture
-    def mock_agents_config(self):
-        """Create a mock agents configuration with primary_runtime/primary_model."""
-        return {
+
+def _make_manager():
+    """Create a real AgentSessionManager with a temporary session_map file."""
+    import agent_manager as am
+
+    mgr = am.SessionManager.__new__(am.SessionManager)
+    tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+    json.dump({}, tmp)
+    tmp.close()
+
+    from pathlib import Path
+
+    mgr.session_map_file = Path(tmp.name)
+    mgr._session_map_lock = threading.Lock()
+    mgr.AGENTS = dict(_MOCK_AGENTS)
+    return mgr, tmp.name
+
+
+class TestSetAgentAppliesDefaults:
+    """set_agent() must write primary_runtime and primary_model into session_map."""
+
+    def test_new_session_gets_agent_runtime_and_model(self):
+        """New session entry created by set_agent() uses agent's primary defaults."""
+        mgr, path = _make_manager()
+        try:
+            mgr.set_agent("sess-001", "research")
+            sm = mgr.load_session_map()
+            assert (
+                sm["sess-001"]["runtime"] == "opencode"
+            ), f"Expected 'opencode', got {sm['sess-001'].get('runtime')}"
+            assert (
+                sm["sess-001"]["model"] == "nvidia/llama-3.1-nemotron"
+            ), f"Expected 'nvidia/llama-3.1-nemotron', got {sm['sess-001'].get('model')}"
+            assert sm["sess-001"]["agent"] == "research"
+        finally:
+            os.unlink(path)
+
+    def test_existing_session_runtime_updated_on_agent_switch(self):
+        """Existing session's runtime is overwritten with new agent's primary_runtime."""
+        mgr, path = _make_manager()
+        try:
+            # Pre-populate with orchestrator settings
+            mgr.save_session_map(
+                {
+                    "sess-002": {
+                        "session_id": "old-id",
+                        "agent": "orchestrator",
+                        "runtime": "claude",
+                        "model": "haiku",
+                    }
+                }
+            )
+            mgr.set_agent("sess-002", "wee-dev")
+            sm = mgr.load_session_map()
+            assert (
+                sm["sess-002"]["runtime"] == "copilot"
+            ), f"Expected 'copilot', got {sm['sess-002'].get('runtime')}"
+            assert (
+                sm["sess-002"]["model"] == "gpt-5.4-mini"
+            ), f"Expected 'gpt-5.4-mini', got {sm['sess-002'].get('model')}"
+            assert sm["sess-002"]["agent"] == "wee-dev"
+        finally:
+            os.unlink(path)
+
+    def test_sequential_switches_apply_each_agents_defaults(self):
+        """Two successive agent switches both apply correct per-agent defaults."""
+        mgr, path = _make_manager()
+        try:
+            mgr.set_agent("sess-003", "research")
+            sm = mgr.load_session_map()
+            assert sm["sess-003"]["runtime"] == "opencode"
+            assert sm["sess-003"]["model"] == "nvidia/llama-3.1-nemotron"
+
+            mgr.set_agent("sess-003", "wee-dev")
+            sm = mgr.load_session_map()
+            assert sm["sess-003"]["runtime"] == "copilot"
+            assert sm["sess-003"]["model"] == "gpt-5.4-mini"
+        finally:
+            os.unlink(path)
+
+    def test_unknown_agent_returns_error_without_modifying_session(self):
+        """set_agent() returns an error string and leaves session_map unchanged."""
+        mgr, path = _make_manager()
+        try:
+            initial_map = {"sess-004": {"agent": "orchestrator", "runtime": "claude"}}
+            mgr.save_session_map(initial_map)
+
+            result = mgr.set_agent("sess-004", "nonexistent-agent")
+            assert "Unknown agent" in result or "nonexistent-agent" in result
+
+            sm = mgr.load_session_map()
+            assert sm["sess-004"]["runtime"] == "claude", "Session should be unchanged"
+        finally:
+            os.unlink(path)
+
+    def test_agent_without_primary_runtime_falls_back_to_copilot(self):
+        """Agent missing primary_runtime defaults to 'copilot'."""
+        mgr, path = _make_manager()
+        try:
+            mgr.AGENTS["minimal-agent"] = {
+                "name": "minimal-agent",
+                "path": "/opt/minimal",
+                "description": "Minimal agent with no runtime specified",
+            }
+            mgr.set_agent("sess-005", "minimal-agent")
+            sm = mgr.load_session_map()
+            assert (
+                sm["sess-005"]["runtime"] == "copilot"
+            ), f"Expected fallback 'copilot', got {sm['sess-005'].get('runtime')}"
+        finally:
+            os.unlink(path)
+
+    def test_agent_without_primary_model_falls_back_to_default(self):
+        """Agent missing primary_model defaults to 'gpt-5-mini'."""
+        mgr, path = _make_manager()
+        try:
+            mgr.AGENTS["minimal-agent"] = {
+                "name": "minimal-agent",
+                "path": "/opt/minimal",
+                "description": "Minimal agent with no model specified",
+                "primary_runtime": "copilot",
+            }
+            mgr.set_agent("sess-006", "minimal-agent")
+            sm = mgr.load_session_map()
+            assert (
+                sm["sess-006"]["model"] == "gpt-5-mini"
+            ), f"Expected fallback 'gpt-5-mini', got {sm['sess-006'].get('model')}"
+        finally:
+            os.unlink(path)
+
+
+class TestLoadAgentsConfigPreservesFields:
+    """_load_agents_config() must preserve primary_runtime/primary_model."""
+
+    def test_load_agents_config_preserves_primary_runtime_and_model(self):
+        """Config loaded from file must include primary_runtime and primary_model."""
+        import agent_manager as am
+
+        agents_data = {
             "agents": [
                 {
-                    "name": "orchestrator",
-                    "path": "/opt/",
-                    "description": "Main orchestrator",
+                    "name": "test-agent",
+                    "path": "/opt/test",
+                    "description": "Test",
                     "primary_runtime": "claude",
-                    "primary_model": "haiku",
-                    "fallback_runtime": "copilot",
-                    "fallback_model": "auto",
+                    "primary_model": "sonnet",
                     "max_concurrent": 1,
-                },
-                {
-                    "name": "research",
-                    "path": "/opt/research",
-                    "description": "Research agent",
-                    "primary_runtime": "opencode",
-                    "primary_model": "nvidia/llama-3.1-nemotron",
-                    "fallback_runtime": "claude",
-                    "fallback_model": "sonnet",
-                    "max_concurrent": 1,
-                },
-                {
-                    "name": "wee-dev",
-                    "path": "/opt/wee-dev",
-                    "description": "Wee Orchestrator developer",
-                    "primary_runtime": "copilot",
-                    "primary_model": "gpt-5.4-mini",
-                    "fallback_runtime": "claude",
-                    "fallback_model": "opus",
-                    "max_concurrent": 1,
-                },
+                }
             ]
         }
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            json.dump(agents_data, f)
+            config_path = f.name
 
-    def test_agent_switch_applies_primary_runtime_and_model(self, mock_agents_config):
-        """Test that switching agents applies primary_runtime and primary_model."""
-        expected_agent = "research"
-        expected_runtime = "opencode"
-        expected_model = "nvidia/llama-3.1-nemotron"
+        try:
+            mgr = am.SessionManager.__new__(am.SessionManager)
+            agents = mgr._load_agents_config(config_path)
+            assert "test-agent" in agents
+            assert agents["test-agent"]["primary_runtime"] == "claude"
+            assert agents["test-agent"]["primary_model"] == "sonnet"
+        finally:
+            os.unlink(config_path)
 
-        session_data = mock_agents_config["agents"][1]
-        assert session_data["name"] == expected_agent
-        assert session_data["primary_runtime"] == expected_runtime
-        assert session_data["primary_model"] == expected_model
 
-    def test_multiple_agent_switches_apply_each_agents_defaults(self, mock_agents_config):
-        """Test that multiple switches each apply the correct agent's defaults."""
-        research_agent = next(a for a in mock_agents_config["agents"] if a["name"] == "research")
-        assert research_agent["primary_runtime"] == "opencode"
-        assert research_agent["primary_model"] == "nvidia/llama-3.1-nemotron"
+class TestAgentsAPIEndpoint:
+    """GET /api/v1/agents must include primary_runtime and primary_model per agent."""
 
-        wee_dev_agent = next(a for a in mock_agents_config["agents"] if a["name"] == "wee-dev")
-        assert wee_dev_agent["primary_runtime"] == "copilot"
-        assert wee_dev_agent["primary_model"] == "gpt-5.4-mini"
-
-    def test_session_state_updated_on_agent_switch(self):
-        """Test that session_map is updated with new agent's defaults on switch."""
-        session_id = str(uuid4())
-        session_map = {}
-
-        session_map[session_id] = {
-            "session_id": str(uuid4()),
-            "agent": "orchestrator",
-            "runtime": "claude",
-            "model": "haiku",
-        }
-
-        session_map[session_id]["agent"] = "research"
-        session_map[session_id]["runtime"] = "opencode"
-        session_map[session_id]["model"] = "nvidia/llama-3.1-nemotron"
-        session_map[session_id]["session_id"] = str(uuid4())
-
-        assert session_map[session_id]["agent"] == "research"
-        assert session_map[session_id]["runtime"] == "opencode"
-        assert session_map[session_id]["model"] == "nvidia/llama-3.1-nemotron"
-
-    def test_new_session_on_agent_switch_uses_agent_defaults(self):
-        """Test that new sessions created on agent switch use agent's defaults."""
-        session_id = str(uuid4())
-        agent_name = "wee-dev"
-        agent_defaults = {
-            "primary_runtime": "copilot",
-            "primary_model": "gpt-5.4-mini",
-        }
-
-        session_map = {
-            session_id: {
-                "session_id": str(uuid4()),
-                "agent": agent_name,
-                "runtime": agent_defaults["primary_runtime"],
-                "model": agent_defaults["primary_model"],
+    def test_agents_endpoint_returns_primary_runtime_and_model(self):
+        """API response for each agent must include primary_runtime and primary_model."""
+        api_response = [
+            {
+                "name": a["name"],
+                "description": a["description"],
+                "path": a["path"],
+                "primary_runtime": a.get("primary_runtime"),
+                "primary_model": a.get("primary_model"),
             }
-        }
+            for a in _MOCK_AGENTS.values()
+        ]
 
-        assert session_map[session_id]["runtime"] == "copilot"
-        assert session_map[session_id]["model"] == "gpt-5.4-mini"
-
-
-class TestAgentConfigLoading:
-    """Test suite for agent configuration loading."""
-
-    def test_load_agents_config_preserves_all_fields(self):
-        """Test that _load_agents_config doesn't lose fields during parsing."""
-        agent_config = {
-            "name": "test",
-            "path": "/opt/test",
-            "description": "Test",
-            "primary_runtime": "claude",
-            "primary_model": "sonnet",
-            "fallback_runtime": "copilot",
-            "fallback_model": "auto",
-            "max_concurrent": 1,
-            "permissions": {"mode": "restricted"},
-        }
-
-        required_fields = {
-            "name": "test",
-            "path": "/opt/test",
-            "description": "Test",
-            "primary_runtime": "claude",
-            "primary_model": "sonnet",
-            "max_concurrent": 1,
-        }
-
-        for key, value in required_fields.items():
-            assert agent_config.get(key) == value
-
-
-class TestWebUIAgentSwitch:
-    """Test suite for WebUI agent switching behavior."""
-
-    def test_webui_agent_switcher_receives_defaults(self, mock_agents_config):
-        """Test that WebUI receives primary_runtime and primary_model for each agent."""
-        api_response = []
-        for agent in mock_agents_config["agents"]:
-            api_response.append({
-                "name": agent["name"],
-                "description": agent["description"],
-                "path": agent["path"],
-                "primary_runtime": agent.get("primary_runtime"),
-                "primary_model": agent.get("primary_model"),
-            })
-
-        assert len(api_response) == 3
         for item in api_response:
-            assert "name" in item
-            assert "description" in item
-            assert "primary_runtime" in item
-            assert "primary_model" in item
-            assert item["primary_runtime"] is not None
-            assert item["primary_model"] is not None
+            assert (
+                item["primary_runtime"] is not None
+            ), f"Agent {item['name']} missing primary_runtime"
+            assert (
+                item["primary_model"] is not None
+            ), f"Agent {item['name']} missing primary_model"

--- a/tests/test_issue_249_agent_defaults.py
+++ b/tests/test_issue_249_agent_defaults.py
@@ -12,7 +12,6 @@ import sys
 import tempfile
 import threading
 
-import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -82,13 +81,14 @@ class TestSetAgentAppliesDefaults:
             ), f"Expected 'opencode', got {sm['sess-001'].get('runtime')}"
             assert (
                 sm["sess-001"]["model"] == "nvidia/llama-3.1-nemotron"
-            ), f"Expected 'nvidia/llama-3.1-nemotron', got {sm['sess-001'].get('model')}"
+            ), f"Expected 'nvidia/llama-3.1-nemotron', got " \
+                f"{sm['sess-001'].get('model')}"
             assert sm["sess-001"]["agent"] == "research"
         finally:
             os.unlink(path)
 
     def test_existing_session_runtime_updated_on_agent_switch(self):
-        """Existing session's runtime is overwritten with new agent's primary_runtime."""
+        """Existing session runtime is overwritten with new agent's primary_runtime."""
         mgr, path = _make_manager()
         try:
             # Pre-populate with orchestrator settings
@@ -218,7 +218,7 @@ class TestAgentsAPIEndpoint:
     """GET /api/v1/agents must include primary_runtime and primary_model per agent."""
 
     def test_agents_endpoint_returns_primary_runtime_and_model(self):
-        """API response for each agent must include primary_runtime and primary_model."""
+        """Each agent in API response must include primary_runtime and primary_model."""
         api_response = [
             {
                 "name": a["name"],

--- a/tests/test_issue_249_agent_defaults.py
+++ b/tests/test_issue_249_agent_defaults.py
@@ -1,0 +1,173 @@
+"""
+Tests for issue #249: Auto-apply agent runtime/model defaults on switch.
+
+When switching agents, the system should automatically apply that agent's
+primary_runtime and primary_model from agents.json as execution defaults.
+"""
+
+import pytest
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+
+class TestAgentDefaultsOnSwitch:
+    """Test suite for auto-applying agent defaults on agent switch."""
+
+    @pytest.fixture
+    def mock_agents_config(self):
+        """Create a mock agents configuration with primary_runtime/primary_model."""
+        return {
+            "agents": [
+                {
+                    "name": "orchestrator",
+                    "path": "/opt/",
+                    "description": "Main orchestrator",
+                    "primary_runtime": "claude",
+                    "primary_model": "haiku",
+                    "fallback_runtime": "copilot",
+                    "fallback_model": "auto",
+                    "max_concurrent": 1,
+                },
+                {
+                    "name": "research",
+                    "path": "/opt/research",
+                    "description": "Research agent",
+                    "primary_runtime": "opencode",
+                    "primary_model": "nvidia/llama-3.1-nemotron",
+                    "fallback_runtime": "claude",
+                    "fallback_model": "sonnet",
+                    "max_concurrent": 1,
+                },
+                {
+                    "name": "wee-dev",
+                    "path": "/opt/wee-dev",
+                    "description": "Wee Orchestrator developer",
+                    "primary_runtime": "copilot",
+                    "primary_model": "gpt-5.4-mini",
+                    "fallback_runtime": "claude",
+                    "fallback_model": "opus",
+                    "max_concurrent": 1,
+                },
+            ]
+        }
+
+    def test_agent_switch_applies_primary_runtime_and_model(self, mock_agents_config):
+        """Test that switching agents applies primary_runtime and primary_model."""
+        expected_agent = "research"
+        expected_runtime = "opencode"
+        expected_model = "nvidia/llama-3.1-nemotron"
+
+        session_data = mock_agents_config["agents"][1]
+        assert session_data["name"] == expected_agent
+        assert session_data["primary_runtime"] == expected_runtime
+        assert session_data["primary_model"] == expected_model
+
+    def test_multiple_agent_switches_apply_each_agents_defaults(self, mock_agents_config):
+        """Test that multiple switches each apply the correct agent's defaults."""
+        research_agent = next(a for a in mock_agents_config["agents"] if a["name"] == "research")
+        assert research_agent["primary_runtime"] == "opencode"
+        assert research_agent["primary_model"] == "nvidia/llama-3.1-nemotron"
+
+        wee_dev_agent = next(a for a in mock_agents_config["agents"] if a["name"] == "wee-dev")
+        assert wee_dev_agent["primary_runtime"] == "copilot"
+        assert wee_dev_agent["primary_model"] == "gpt-5.4-mini"
+
+    def test_session_state_updated_on_agent_switch(self):
+        """Test that session_map is updated with new agent's defaults on switch."""
+        session_id = str(uuid4())
+        session_map = {}
+
+        session_map[session_id] = {
+            "session_id": str(uuid4()),
+            "agent": "orchestrator",
+            "runtime": "claude",
+            "model": "haiku",
+        }
+
+        session_map[session_id]["agent"] = "research"
+        session_map[session_id]["runtime"] = "opencode"
+        session_map[session_id]["model"] = "nvidia/llama-3.1-nemotron"
+        session_map[session_id]["session_id"] = str(uuid4())
+
+        assert session_map[session_id]["agent"] == "research"
+        assert session_map[session_id]["runtime"] == "opencode"
+        assert session_map[session_id]["model"] == "nvidia/llama-3.1-nemotron"
+
+    def test_new_session_on_agent_switch_uses_agent_defaults(self):
+        """Test that new sessions created on agent switch use agent's defaults."""
+        session_id = str(uuid4())
+        agent_name = "wee-dev"
+        agent_defaults = {
+            "primary_runtime": "copilot",
+            "primary_model": "gpt-5.4-mini",
+        }
+
+        session_map = {
+            session_id: {
+                "session_id": str(uuid4()),
+                "agent": agent_name,
+                "runtime": agent_defaults["primary_runtime"],
+                "model": agent_defaults["primary_model"],
+            }
+        }
+
+        assert session_map[session_id]["runtime"] == "copilot"
+        assert session_map[session_id]["model"] == "gpt-5.4-mini"
+
+
+class TestAgentConfigLoading:
+    """Test suite for agent configuration loading."""
+
+    def test_load_agents_config_preserves_all_fields(self):
+        """Test that _load_agents_config doesn't lose fields during parsing."""
+        agent_config = {
+            "name": "test",
+            "path": "/opt/test",
+            "description": "Test",
+            "primary_runtime": "claude",
+            "primary_model": "sonnet",
+            "fallback_runtime": "copilot",
+            "fallback_model": "auto",
+            "max_concurrent": 1,
+            "permissions": {"mode": "restricted"},
+        }
+
+        required_fields = {
+            "name": "test",
+            "path": "/opt/test",
+            "description": "Test",
+            "primary_runtime": "claude",
+            "primary_model": "sonnet",
+            "max_concurrent": 1,
+        }
+
+        for key, value in required_fields.items():
+            assert agent_config.get(key) == value
+
+
+class TestWebUIAgentSwitch:
+    """Test suite for WebUI agent switching behavior."""
+
+    def test_webui_agent_switcher_receives_defaults(self, mock_agents_config):
+        """Test that WebUI receives primary_runtime and primary_model for each agent."""
+        api_response = []
+        for agent in mock_agents_config["agents"]:
+            api_response.append({
+                "name": agent["name"],
+                "description": agent["description"],
+                "path": agent["path"],
+                "primary_runtime": agent.get("primary_runtime"),
+                "primary_model": agent.get("primary_model"),
+            })
+
+        assert len(api_response) == 3
+        for item in api_response:
+            assert "name" in item
+            assert "description" in item
+            assert "primary_runtime" in item
+            assert "primary_model" in item
+            assert item["primary_runtime"] is not None
+            assert item["primary_model"] is not None

--- a/tests/test_issue_24_connector_rate_limiting.py
+++ b/tests/test_issue_24_connector_rate_limiting.py
@@ -159,8 +159,9 @@ def test_issue_24_webex_command_messages_are_rate_limited(webex_connector):
     }
 
     with (
-        patch.object(webex_connector, "_execute_command", return_value="command ok")
-        as execute_mock,
+        patch.object(
+            webex_connector, "_execute_command", return_value="command ok"
+        ) as execute_mock,
         patch.object(webex_connector, "send_message") as send_message_mock,
     ):
         webex_connector.handle_message(message)

--- a/tests/test_issue_251_bg_tasks_rate_limit.py
+++ b/tests/test_issue_251_bg_tasks_rate_limit.py
@@ -56,7 +56,6 @@ class TestIssue251ListBgTasksCapability(unittest.TestCase):
             "list_background_tasks must be available in background mode",
         )
 
-
     def test_capability_available_in_api_mode(self):
         """Capability must be available in api mode (wee_executor runs without WEE_TASK_ID)."""
         we = self._import_executor()

--- a/tests/test_issue_25_graceful_shutdown.py
+++ b/tests/test_issue_25_graceful_shutdown.py
@@ -109,9 +109,7 @@ def test_issue_25_telegram_sigterm_waits_for_active_request(telegram_connector):
         assert telegram_connector.shutdown_event.is_set()
         assert telegram_connector.running is False
         assert (
-            telegram_connector._wait_for_active_requests(
-                "telegram test", timeout=0.01
-            )
+            telegram_connector._wait_for_active_requests("telegram test", timeout=0.01)
             is False
         )
 
@@ -122,9 +120,7 @@ def test_issue_25_telegram_sigterm_waits_for_active_request(telegram_connector):
         worker.join(timeout=1)
 
         assert (
-            telegram_connector._wait_for_active_requests(
-                "telegram test", timeout=0.1
-            )
+            telegram_connector._wait_for_active_requests("telegram test", timeout=0.1)
             is True
         )
         send_response_mock.assert_called_once_with(1001, "done", None)
@@ -191,8 +187,7 @@ def test_issue_25_webex_sigterm_stops_consuming_and_waits_for_active_request(
         worker.join(timeout=1)
 
         assert (
-            webex_connector._wait_for_active_requests("webex test", timeout=0.1)
-            is True
+            webex_connector._wait_for_active_requests("webex test", timeout=0.1) is True
         )
         send_response_mock.assert_called_once_with("room-1", "done", None)
         send_message_mock.assert_not_called()
@@ -335,9 +330,7 @@ def test_issue_25_webex_ack_happens_after_processing(webex_connector):
         callback_holder["callback"] = on_message_callback
 
     def fake_start_consuming():
-        callback_holder["callback"](
-            channel, method, None, json.dumps(message).encode()
-        )
+        callback_holder["callback"](channel, method, None, json.dumps(message).encode())
         webex_connector.running = False
 
     channel.basic_consume.side_effect = fake_basic_consume
@@ -347,7 +340,9 @@ def test_issue_25_webex_ack_happens_after_processing(webex_connector):
         patch.object(webex_connector, "connect_rabbitmq", return_value=True),
         patch.object(webex_connector, "start_cleanup_background_task"),
         patch.object(webex_connector, "disconnect_rabbitmq"),
-        patch.object(webex_connector, "handle_message", return_value=True) as handle_mock,
+        patch.object(
+            webex_connector, "handle_message", return_value=True
+        ) as handle_mock,
     ):
         webex_connector.listen_to_queue()
 
@@ -375,9 +370,7 @@ def test_issue_25_webex_shutdown_requeues_undispatched_message(webex_connector):
         callback_holder["callback"] = on_message_callback
 
     def fake_start_consuming():
-        callback_holder["callback"](
-            channel, method, None, json.dumps(message).encode()
-        )
+        callback_holder["callback"](channel, method, None, json.dumps(message).encode())
         webex_connector.running = False
 
     channel.basic_consume.side_effect = fake_basic_consume
@@ -530,9 +523,7 @@ def test_issue_25_webex_audio_transcription_failure_is_acked(webex_connector):
         callback_holder["callback"] = on_message_callback
 
     def fake_start_consuming():
-        callback_holder["callback"](
-            channel, method, None, json.dumps(message).encode()
-        )
+        callback_holder["callback"](channel, method, None, json.dumps(message).encode())
         webex_connector.running = False
 
     channel.basic_consume.side_effect = fake_basic_consume

--- a/tests/test_issue_27_file_handle_leak.py
+++ b/tests/test_issue_27_file_handle_leak.py
@@ -6,11 +6,12 @@ in the retry path without closing it.
 
 The fix: reuse the already-open file handle via f.seek(0).
 """
+
+import builtins
 import io
-import tempfile
 import os
 import sys
-import builtins
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_issue_28_timing_safe_key.py
+++ b/tests/test_issue_28_timing_safe_key.py
@@ -3,10 +3,11 @@
 Verifies that validate_shared_key() uses hmac.compare_digest() instead of ==,
 which prevents timing side-channel attacks on the Bearer token comparison.
 """
+
 import hmac
 import inspect
-import sys
 import os
+import sys
 
 sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 
@@ -16,12 +17,12 @@ from agent_manager import AuthManager
 def test_issue_28_validate_shared_key_uses_compare_digest():
     """validate_shared_key must use hmac.compare_digest, not ==."""
     source = inspect.getsource(AuthManager.validate_shared_key)
-    assert "hmac.compare_digest" in source, (
-        "validate_shared_key must use hmac.compare_digest() for timing-safe comparison"
-    )
-    assert "==" not in source, (
-        "validate_shared_key must NOT use == for key comparison (timing side-channel)"
-    )
+    assert (
+        "hmac.compare_digest" in source
+    ), "validate_shared_key must use hmac.compare_digest() for timing-safe comparison"
+    assert (
+        "==" not in source
+    ), "validate_shared_key must NOT use == for key comparison (timing side-channel)"
 
 
 def test_issue_28_valid_key_accepted():

--- a/tests/test_memory_native.py
+++ b/tests/test_memory_native.py
@@ -270,9 +270,9 @@ class TestNoPromptPrefix:
         """prepend_memory is not exposed by memory.inject."""
         import memory.inject as mi
 
-        assert not hasattr(mi, "prepend_memory"), (
-            "prepend_memory should be removed — memory is injected at session start"
-        )
+        assert not hasattr(
+            mi, "prepend_memory"
+        ), "prepend_memory should be removed — memory is injected at session start"
 
     def test_memory_injected_flag_prevents_double_injection(self, tmp_path):
         """Simulates the flag check in build_agent_context_prompt."""
@@ -306,12 +306,12 @@ class TestNoPromptPrefix:
         from agent_manager import SessionManager
 
         source = inspect.getsource(SessionManager.build_agent_context_prompt)
-        assert "memory_injected" in source, (
-            "build_agent_context_prompt must check memory_injected flag"
-        )
-        assert "get_memory_context" in source, (
-            "build_agent_context_prompt must call get_memory_context"
-        )
+        assert (
+            "memory_injected" in source
+        ), "build_agent_context_prompt must check memory_injected flag"
+        assert (
+            "get_memory_context" in source
+        ), "build_agent_context_prompt must call get_memory_context"
 
 
 # ── detect_compaction ─────────────────────────────────────────────────────
@@ -404,9 +404,9 @@ class TestMemoryDailyAPI:
     @pytest.fixture
     def client(self):
         """Create test client for the API."""
-        from agent_manager import create_api_app
-
         from fastapi.testclient import TestClient
+
+        from agent_manager import create_api_app
 
         app = create_api_app()
         return TestClient(app)
@@ -438,9 +438,7 @@ class TestMemoryDailyAPI:
 
     def test_daily_note_success(self, client, auth_headers, tmp_path):
         """Creates daily note for default (orchestrator) agent."""
-        with patch.dict(
-            os.environ, {"WEE_MEMORY_DIR": str(tmp_path)}, clear=False
-        ):
+        with patch.dict(os.environ, {"WEE_MEMORY_DIR": str(tmp_path)}, clear=False):
             resp = client.post(
                 "/api/v1/memory/daily",
                 json={"content": "API test note"},
@@ -454,9 +452,7 @@ class TestMemoryDailyAPI:
 
     def test_daily_note_with_agent(self, client, auth_headers, tmp_path):
         """Creates daily note for a specific agent."""
-        with patch.dict(
-            os.environ, {"WEE_MEMORY_DIR": str(tmp_path)}, clear=False
-        ):
+        with patch.dict(os.environ, {"WEE_MEMORY_DIR": str(tmp_path)}, clear=False):
             resp = client.post(
                 "/api/v1/memory/daily",
                 json={"content": "Agent note", "agent": "wee-dev"},

--- a/tests/test_notification_global_mute.py
+++ b/tests/test_notification_global_mute.py
@@ -295,9 +295,7 @@ def test_api_notifications_off_sets_global_mute():
             if isinstance(global_entry, dict)
             else "all"
         )
-        assert (
-            global_pref == "off"
-        ), (
+        assert global_pref == "off", (
             f"Expected _global preference 'off', got '{global_pref}'."
             f" Full prefs: {json.dumps(prefs)}"
         )

--- a/tests/test_query_endpoint.py
+++ b/tests/test_query_endpoint.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -18,7 +18,9 @@ class TestQueryEndpoint(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         from unittest.mock import patch as _p
+
         from fastapi.testclient import TestClient
+
         import agent_manager
 
         cls._telegram_patch = _p.object(
@@ -202,7 +204,9 @@ class TestQueryEndpointErrorDetection(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         from unittest.mock import patch as _p
+
         from fastapi.testclient import TestClient
+
         import agent_manager
 
         cls._telegram_patch = _p.object(
@@ -406,7 +410,9 @@ class TestQueryEndpointCodeGen(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         from unittest.mock import patch as _p
+
         from fastapi.testclient import TestClient
+
         import agent_manager
 
         cls._telegram_patch = _p.object(

--- a/tests/test_scheduler_clock_drift.py
+++ b/tests/test_scheduler_clock_drift.py
@@ -134,9 +134,9 @@ class TestDriftDetection:
         executor._last_check_mono = time.monotonic() - 1
         executor._detect_clock_drift()
 
-        assert executor._wall_clock_debt > 50, (
-            f"Expected debt >50s after backward jump, got {executor._wall_clock_debt}"
-        )
+        assert (
+            executor._wall_clock_debt > 50
+        ), f"Expected debt >50s after backward jump, got {executor._wall_clock_debt}"
 
     def test_forward_drift_reduces_debt(self, executor):
         """Forward drift should reduce existing wall_clock_debt (Issue #71)."""
@@ -147,9 +147,9 @@ class TestDriftDetection:
         executor._last_check_mono = time.monotonic() - 1
         executor._detect_clock_drift()
 
-        assert executor._wall_clock_debt < 50, (
-            f"Expected debt to reduce after forward drift, got {executor._wall_clock_debt}"
-        )
+        assert (
+            executor._wall_clock_debt < 50
+        ), f"Expected debt to reduce after forward drift, got {executor._wall_clock_debt}"
 
     def test_debt_capped_at_maximum(self, executor):
         """Wall-clock debt should not exceed _DRIFT_COMPENSATION_CAP."""
@@ -160,9 +160,9 @@ class TestDriftDetection:
         executor._last_check_mono = time.monotonic() - 1
         executor._detect_clock_drift()
 
-        assert executor._wall_clock_debt <= _DRIFT_COMPENSATION_CAP, (
-            f"Debt {executor._wall_clock_debt} exceeds cap {_DRIFT_COMPENSATION_CAP}"
-        )
+        assert (
+            executor._wall_clock_debt <= _DRIFT_COMPENSATION_CAP
+        ), f"Debt {executor._wall_clock_debt} exceeds cap {_DRIFT_COMPENSATION_CAP}"
 
     def test_debt_does_not_go_negative(self, executor):
         """Forward drift should not push debt below zero."""
@@ -173,9 +173,9 @@ class TestDriftDetection:
         executor._last_check_mono = time.monotonic() - 1
         executor._detect_clock_drift()
 
-        assert executor._wall_clock_debt >= 0.0, (
-            f"Debt went negative: {executor._wall_clock_debt}"
-        )
+        assert (
+            executor._wall_clock_debt >= 0.0
+        ), f"Debt went negative: {executor._wall_clock_debt}"
 
     def test_drift_events_tracked(self, executor):
         """Significant drift events should be recorded in _drift_events."""
@@ -472,9 +472,7 @@ class TestCheckAndExecuteClockDrift:
         )
         assert new_next > datetime.now(timezone.utc)
 
-    def test_backward_jump_cooldown_prevents_rerun(
-        self, executor, tmp_scheduler_dir
-    ):
+    def test_backward_jump_cooldown_prevents_rerun(self, executor, tmp_scheduler_dir):
         """Simulate backward clock jump: job already ran, should NOT re-execute."""
         _, jobs_file, _, _ = tmp_scheduler_dir
         job = _make_job(job_id="backward-test")
@@ -542,6 +540,6 @@ class TestNoUtcnow:
     def test_no_utcnow_in_executor(self):
         executor_path = _REPO_ROOT / "scheduler" / "executor.py"
         content = executor_path.read_text()
-        assert "datetime.utcnow()" not in content, (
-            "datetime.utcnow() is deprecated - use datetime.now(timezone.utc)"
-        )
+        assert (
+            "datetime.utcnow()" not in content
+        ), "datetime.utcnow() is deprecated - use datetime.now(timezone.utc)"

--- a/tests/test_scheduler_command_mode.py
+++ b/tests/test_scheduler_command_mode.py
@@ -2,13 +2,14 @@
 
 Tests _execute_task routing logic and the misconfiguration warning.
 """
+
 import logging
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 
-sys.path.insert(0, '/opt/n8n-copilot-shim-dev')
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 os.environ.setdefault("API_SHARED_KEY", "test_key_123")
 
 from scheduler.executor import TaskSchedulerExecutor
@@ -29,8 +30,9 @@ class TestCommandModeRouting(unittest.TestCase):
         executor = self._make_executor()
         job = {"id": "cmd-job", "mode": "command", "task": "echo hello"}
 
-        with patch.object(executor, '_execute_command_mode', return_value="ok") as mock_cmd, \
-             patch.object(executor, '_execute_ai_mode') as mock_ai:
+        with patch.object(
+            executor, "_execute_command_mode", return_value="ok"
+        ) as mock_cmd, patch.object(executor, "_execute_ai_mode") as mock_ai:
             result = executor._execute_task(job)
 
         mock_cmd.assert_called_once_with(job)
@@ -42,8 +44,9 @@ class TestCommandModeRouting(unittest.TestCase):
         executor = self._make_executor()
         job = {"id": "ai-job", "mode": "ai", "task": "do something"}
 
-        with patch.object(executor, '_execute_command_mode') as mock_cmd, \
-             patch.object(executor, '_execute_ai_mode', return_value="ai_result") as mock_ai:
+        with patch.object(executor, "_execute_command_mode") as mock_cmd, patch.object(
+            executor, "_execute_ai_mode", return_value="ai_result"
+        ) as mock_ai:
             result = executor._execute_task(job)
 
         mock_cmd.assert_not_called()
@@ -55,8 +58,9 @@ class TestCommandModeRouting(unittest.TestCase):
         executor = self._make_executor()
         job = {"id": "no-mode-job", "task": "do something"}
 
-        with patch.object(executor, '_execute_command_mode') as mock_cmd, \
-             patch.object(executor, '_execute_ai_mode', return_value="result") as mock_ai:
+        with patch.object(executor, "_execute_command_mode") as mock_cmd, patch.object(
+            executor, "_execute_ai_mode", return_value="result"
+        ) as mock_ai:
             executor._execute_task(job)
 
         mock_cmd.assert_not_called()
@@ -73,9 +77,11 @@ class TestCommandModeRouting(unittest.TestCase):
             "task": "python3 /opt/bin/dispatch.py",
         }
 
-        with patch.object(executor, '_execute_command_mode', return_value="ok"), \
-             patch.object(executor, '_execute_ai_mode') as mock_ai, \
-             self.assertLogs(level="WARNING") as log_ctx:
+        with patch.object(
+            executor, "_execute_command_mode", return_value="ok"
+        ), patch.object(executor, "_execute_ai_mode") as mock_ai, self.assertLogs(
+            level="WARNING"
+        ) as log_ctx:
             executor._execute_task(job)
 
         mock_ai.assert_not_called()
@@ -89,8 +95,9 @@ class TestCommandModeRouting(unittest.TestCase):
         executor = self._make_executor()
         job = {"id": "j2", "mode": "command", "runtime": "copilot", "task": "ls"}
 
-        with patch.object(executor, '_execute_command_mode', return_value="ok"), \
-             self.assertLogs(level="WARNING"):
+        with patch.object(
+            executor, "_execute_command_mode", return_value="ok"
+        ), self.assertLogs(level="WARNING"):
             executor._execute_task(job)
 
     def test_command_mode_without_runtime_no_warning(self):
@@ -98,7 +105,7 @@ class TestCommandModeRouting(unittest.TestCase):
         executor = self._make_executor()
         job = {"id": "clean-job", "mode": "command", "task": "echo hi"}
 
-        with patch.object(executor, '_execute_command_mode', return_value="ok"):
+        with patch.object(executor, "_execute_command_mode", return_value="ok"):
             with self.assertNoLogs("test", level="WARNING"):
                 executor._execute_task(job)
 
@@ -112,8 +119,9 @@ class TestCommandModeRouting(unittest.TestCase):
             "task": "echo test",
         }
 
-        with patch.object(executor, '_execute_command_mode', return_value="cmd_output"), \
-             self.assertLogs(level="WARNING"):
+        with patch.object(
+            executor, "_execute_command_mode", return_value="cmd_output"
+        ), self.assertLogs(level="WARNING"):
             result = executor._execute_task(job)
 
         self.assertEqual(result, "cmd_output")

--- a/tests/test_scheduler_timezone.py
+++ b/tests/test_scheduler_timezone.py
@@ -33,6 +33,7 @@ UTC_TZ = ZoneInfo("UTC")
 class TestGetLocalTzName(unittest.TestCase):
     def _strip_tz_env(self):
         import os
+
         return {k: v for k, v in os.environ.items() if k != "TZ"}
 
     def test_tz_env_var_takes_priority(self):

--- a/tests/test_sdk_permissions.py
+++ b/tests/test_sdk_permissions.py
@@ -10,12 +10,12 @@ Tests verify:
 - claude-sdk: sandboxed mode maps to plan
 """
 
+import asyncio
 import os
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock, patch, AsyncMock
-import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)) + "/..")
 os.environ.setdefault("API_SHARED_KEY", "test_key_123")
@@ -24,6 +24,7 @@ os.environ.setdefault("API_SHARED_KEY", "test_key_123")
 def _get_session_mgr():
     """Create a minimal SessionManager for testing."""
     from agent_manager import SessionManager
+
     mgr = SessionManager.__new__(SessionManager)
     mgr.mode = None
     mgr.command_timeout = 300
@@ -68,6 +69,7 @@ class TestCopilotSDKPermissions(unittest.TestCase):
 
         # Track create_session calls
         create_calls = []
+
         async def fake_create_session(**kwargs):
             create_calls.append(kwargs)
             return session_mock
@@ -128,12 +130,19 @@ class TestCopilotSDKPermissions(unittest.TestCase):
         session_module.ElicitationContext = dict
         session_module.ElicitationResult = dict
 
-        with patch.dict("sys.modules", {
-            "copilot": perm_module,
-            "copilot.session": session_module,
-        }):
-            with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
-                with patch.object(mgr, "build_agent_context_prompt", return_value="test prompt"):
+        with patch.dict(
+            "sys.modules",
+            {
+                "copilot": perm_module,
+                "copilot.session": session_module,
+            },
+        ):
+            with patch.object(
+                mgr, "get_or_create_session_data", return_value=session_data
+            ):
+                with patch.object(
+                    mgr, "build_agent_context_prompt", return_value="test prompt"
+                ):
                     mgr.run_copilot_sdk(
                         prompt="test",
                         model="gpt-4o",
@@ -152,7 +161,9 @@ class TestCopilotSDKPermissions(unittest.TestCase):
         captured = {}
         self._run_sdk_with_mock("elevated", captured)
         configs = captured["subprocess_configs"]
-        self.assertEqual(len(configs), 1, "SubprocessConfig should be created for elevated mode")
+        self.assertEqual(
+            len(configs), 1, "SubprocessConfig should be created for elevated mode"
+        )
         self.assertIn("--allow-all-paths", configs[0].cli_args)
 
     def test_elevated_mode_passes_yolo_flag(self):
@@ -160,7 +171,9 @@ class TestCopilotSDKPermissions(unittest.TestCase):
         captured = {}
         self._run_sdk_with_mock("elevated", captured)
         configs = captured["subprocess_configs"]
-        self.assertEqual(len(configs), 1, "SubprocessConfig should be created for elevated mode")
+        self.assertEqual(
+            len(configs), 1, "SubprocessConfig should be created for elevated mode"
+        )
         self.assertIn("--yolo", configs[0].cli_args)
 
     def test_restricted_mode_no_dangerous_flags(self):
@@ -168,7 +181,11 @@ class TestCopilotSDKPermissions(unittest.TestCase):
         captured = {}
         self._run_sdk_with_mock("restricted", captured)
         configs = captured["subprocess_configs"]
-        self.assertEqual(len(configs), 0, "SubprocessConfig should NOT be created for restricted mode")
+        self.assertEqual(
+            len(configs),
+            0,
+            "SubprocessConfig should NOT be created for restricted mode",
+        )
 
     def test_elevated_mode_sets_user_input_handler(self):
         """Elevated mode must provide on_user_input_request to auto-approve prompts."""
@@ -198,6 +215,7 @@ class TestCopilotSDKPermissions(unittest.TestCase):
 
     def test_auto_approve_user_input_handler_returns_yes(self):
         """Auto-approve user input handler returns first choice or 'yes'."""
+
         # Simulate what the handler does
         def _auto_approve(request, invocation):
             if request.get("choices"):
@@ -217,6 +235,7 @@ class TestCopilotSDKPermissions(unittest.TestCase):
 
     def test_auto_approve_elicitation_returns_accept(self):
         """Auto-approve elicitation handler returns action=accept."""
+
         def _auto_elicit(context):
             return {"action": "accept"}
 
@@ -237,19 +256,25 @@ class TestClaudeSDKPermissions(unittest.TestCase):
         resolved_modes = []
 
         original_resolve = mgr._resolve_permission_mode
+
         def tracking_resolve(sd, pm="restricted"):
             result = original_resolve(sd, pm)
-            resolved_modes.append({"session_data": sd, "prompt_mode": pm, "result": result})
+            resolved_modes.append(
+                {"session_data": sd, "prompt_mode": pm, "result": result}
+            )
             return result
+
         mgr._resolve_permission_mode = tracking_resolve
 
         # Mock claude SDK
         claude_sdk_module = types.ModuleType("claude_ai.sdk")
         mock_query = AsyncMock()
+
         # Return empty async iterator
         async def empty_agen(*args, **kwargs):
             return
             yield  # make it an async generator
+
         claude_sdk_module.query = empty_agen
         claude_sdk_module.ClaudeAgentOptions = MagicMock(return_value=MagicMock())
         claude_sdk_module.AssistantMessage = type("AssistantMessage", (), {})
@@ -258,8 +283,12 @@ class TestClaudeSDKPermissions(unittest.TestCase):
         claude_sdk_module.ToolResultBlock = type("ToolResultBlock", (), {})
 
         with patch.dict("sys.modules", {"claude_ai.sdk": claude_sdk_module}):
-            with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
-                with patch.object(mgr, "build_agent_context_prompt", return_value="test prompt"):
+            with patch.object(
+                mgr, "get_or_create_session_data", return_value=session_data
+            ):
+                with patch.object(
+                    mgr, "build_agent_context_prompt", return_value="test prompt"
+                ):
                     try:
                         mgr.run_claude_sdk(
                             prompt="test",
@@ -274,21 +303,32 @@ class TestClaudeSDKPermissions(unittest.TestCase):
                     except Exception:
                         pass  # Expected — we care about the args, not the result
 
-        self.assertTrue(len(resolved_modes) > 0, "_resolve_permission_mode must have been called")
+        self.assertTrue(
+            len(resolved_modes) > 0, "_resolve_permission_mode must have been called"
+        )
         call = resolved_modes[0]
         # session_data must be a dict (the real session data), not a string (mode value)
-        self.assertIsInstance(call["session_data"], dict,
-            "_resolve_permission_mode first arg must be session_data dict, not a string mode")
-        self.assertIsInstance(call["prompt_mode"], str,
-            "_resolve_permission_mode second arg must be a string mode")
+        self.assertIsInstance(
+            call["session_data"],
+            dict,
+            "_resolve_permission_mode first arg must be session_data dict, not a string mode",
+        )
+        self.assertIsInstance(
+            call["prompt_mode"],
+            str,
+            "_resolve_permission_mode second arg must be a string mode",
+        )
 
     def test_elevated_session_resolves_to_elevated_mode(self):
         """When session has elevated permissions, claude-sdk must use bypassPermissions."""
         mgr = _get_session_mgr()
         session_data = {"permissions": {"mode": "elevated"}}
         result = mgr._resolve_permission_mode(session_data, "restricted")
-        self.assertEqual(result, "elevated",
-            "Session with elevated permissions must resolve to elevated mode")
+        self.assertEqual(
+            result,
+            "elevated",
+            "Session with elevated permissions must resolve to elevated mode",
+        )
 
     def test_restricted_session_resolves_to_restricted_mode(self):
         """When session has restricted permissions, claude-sdk must use default SDK mode."""
@@ -300,17 +340,22 @@ class TestClaudeSDKPermissions(unittest.TestCase):
     def test_permission_mode_mapping_elevated_to_bypass(self):
         """Elevated mode must map to bypassPermissions for claude-sdk."""
         # This mirrors the logic in run_claude_sdk
-        for mode, expected in [("elevated", "bypassPermissions"),
-                                ("sandboxed", "plan"),
-                                ("restricted", "default")]:
+        for mode, expected in [
+            ("elevated", "bypassPermissions"),
+            ("sandboxed", "plan"),
+            ("restricted", "default"),
+        ]:
             if mode == "elevated":
                 sdk_perm = "bypassPermissions"
             elif mode == "sandboxed":
                 sdk_perm = "plan"
             else:
                 sdk_perm = "default"
-            self.assertEqual(sdk_perm, expected,
-                f"Mode {mode!r} must map to {expected!r} for claude-sdk")
+            self.assertEqual(
+                sdk_perm,
+                expected,
+                f"Mode {mode!r} must map to {expected!r} for claude-sdk",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_streaming_tools.py
+++ b/tests/test_sdk_streaming_tools.py
@@ -22,6 +22,7 @@ os.environ.setdefault("API_SHARED_KEY", "test_key_123")
 
 # ─── Shared helpers ───
 
+
 def _make_stream_buffer():
     """Create a mock stream buffer that records pushes."""
     pushes = []
@@ -33,6 +34,7 @@ def _make_stream_buffer():
 def _get_session_mgr():
     """Create a minimal SessionManager for testing (same as existing test pattern)."""
     from agent_manager import SessionManager
+
     mgr = SessionManager.__new__(SessionManager)
     mgr.mode = None
     mgr.command_timeout = 300
@@ -58,6 +60,7 @@ def _get_session_mgr():
 # ═══════════════════════════════════════════════════════
 #  COPILOT-SDK Streaming + Tool Call Tests
 # ═══════════════════════════════════════════════════════
+
 
 class TestCopilotSdkStreaming(unittest.TestCase):
     """Test copilot-sdk streaming chunks are pushed to stream buffer."""
@@ -111,7 +114,9 @@ class TestCopilotSdkStreaming(unittest.TestCase):
 
         mock_session.send_and_wait = AsyncMock(side_effect=send_and_wait_with_events)
 
-        with patch.object(mgr, "build_agent_context_prompt", return_value="test prompt"):
+        with patch.object(
+            mgr, "build_agent_context_prompt", return_value="test prompt"
+        ):
             result = mgr.run_copilot_sdk(
                 "test prompt", "gpt-5", "orchestrator", None, False, "sess1"
             )
@@ -399,28 +404,56 @@ class TestCopilotSdkToolCalls(unittest.TestCase):
 
 # --- Fake claude_agent_sdk types ---
 
-_TextBlock = type("TextBlock", (), {
-    "__init__": lambda self, text="": setattr(self, "text", text),
-})
-_AssistantMessage = type("AssistantMessage", (), {
-    "__init__": lambda self, content=None: setattr(self, "content", content or []),
-})
-_ResultMessage = type("ResultMessage", (), {
-    "__init__": lambda self, session_id="": setattr(self, "session_id", session_id),
-})
-_ToolUseBlock = type("ToolUseBlock", (), {
-    "__init__": lambda self, id="", name="", input=None: (
-        setattr(self, "id", id) or setattr(self, "name", name) or setattr(self, "input", input)
-    ),
-})
-_ToolResultBlock = type("ToolResultBlock", (), {
-    "__init__": lambda self, tool_use_id="", content=None, is_error=False: (
-        setattr(self, "tool_use_id", tool_use_id) or setattr(self, "content", content) or setattr(self, "is_error", is_error)
-    ),
-})
-_ClaudeAgentOptions = type("ClaudeAgentOptions", (), {
-    "__init__": lambda self, **kw: self.__dict__.update(kw),
-})
+_TextBlock = type(
+    "TextBlock",
+    (),
+    {
+        "__init__": lambda self, text="": setattr(self, "text", text),
+    },
+)
+_AssistantMessage = type(
+    "AssistantMessage",
+    (),
+    {
+        "__init__": lambda self, content=None: setattr(self, "content", content or []),
+    },
+)
+_ResultMessage = type(
+    "ResultMessage",
+    (),
+    {
+        "__init__": lambda self, session_id="": setattr(self, "session_id", session_id),
+    },
+)
+_ToolUseBlock = type(
+    "ToolUseBlock",
+    (),
+    {
+        "__init__": lambda self, id="", name="", input=None: (
+            setattr(self, "id", id)
+            or setattr(self, "name", name)
+            or setattr(self, "input", input)
+        ),
+    },
+)
+_ToolResultBlock = type(
+    "ToolResultBlock",
+    (),
+    {
+        "__init__": lambda self, tool_use_id="", content=None, is_error=False: (
+            setattr(self, "tool_use_id", tool_use_id)
+            or setattr(self, "content", content)
+            or setattr(self, "is_error", is_error)
+        ),
+    },
+)
+_ClaudeAgentOptions = type(
+    "ClaudeAgentOptions",
+    (),
+    {
+        "__init__": lambda self, **kw: self.__dict__.update(kw),
+    },
+)
 
 
 def _build_fake_claude_module(query_fn=None):
@@ -444,6 +477,7 @@ def _build_fake_claude_module(query_fn=None):
 def _make_claude_manager():
     """Create a minimal SessionManager for claude-sdk testing."""
     from agent_manager import SessionManager
+
     mgr = SessionManager.__new__(SessionManager)
     mgr.session_state_dir = MagicMock()
     mgr.session_map_file = MagicMock()
@@ -455,13 +489,15 @@ def _make_claude_manager():
     mgr.AGENTS = {
         "orchestrator": {"path": "/opt/n8n-copilot-shim-dev", "name": "orchestrator"},
     }
-    mgr.get_or_create_session_data = MagicMock(return_value={
-        "channel": "api",
-        "runtime": "claude-sdk",
-        "model": "haiku",
-        "session_id": None,
-        "mode": None,
-    })
+    mgr.get_or_create_session_data = MagicMock(
+        return_value={
+            "channel": "api",
+            "runtime": "claude-sdk",
+            "model": "haiku",
+            "session_id": None,
+            "mode": None,
+        }
+    )
     mgr.build_agent_context_prompt = MagicMock(return_value="[context] test prompt")
     mgr._parse_mode_command = MagicMock(return_value=("test prompt", None))
     mgr._resolve_permission_mode = MagicMock(side_effect=lambda m, s: m)
@@ -567,7 +603,9 @@ class TestClaudeSdkToolCalls(unittest.TestCase):
         stream_buf, pushes = _make_stream_buffer()
         mgr._stream_buffers = {"sess1": stream_buf}
 
-        tool_block = _ToolUseBlock(id="tu_123", name="read_file", input={"path": "/tmp/x"})
+        tool_block = _ToolUseBlock(
+            id="tu_123", name="read_file", input={"path": "/tmp/x"}
+        )
         text_block = _TextBlock("I'll read that file")
         msg = _AssistantMessage([text_block, tool_block])
 
@@ -683,16 +721,17 @@ class TestClaudeSdkToolCalls(unittest.TestCase):
 
         fake_mod = _build_fake_claude_module(mock_query)
         with patch.dict("sys.modules", {"claude_agent_sdk": fake_mod}):
-            mgr.run_claude_sdk(
-                "test", "haiku", "orchestrator", None, False, "sess1"
-            )
+            mgr.run_claude_sdk("test", "haiku", "orchestrator", None, False, "sess1")
 
-        mgr.update_session_field.assert_any_call("sess1", "session_id", "new-session-abc")
+        mgr.update_session_field.assert_any_call(
+            "sess1", "session_id", "new-session-abc"
+        )
 
 
 # ═══════════════════════════════════════════════════════
 #  Tool Event Structure Validation
 # ═══════════════════════════════════════════════════════
+
 
 class TestToolEventStructure(unittest.TestCase):
     """Validate required fields in tool call events for both runtimes."""

--- a/tests/test_secrets_api.py
+++ b/tests/test_secrets_api.py
@@ -225,12 +225,15 @@ class TestSecretsAPI(unittest.TestCase):
         for bad_name in ["bad name", "bad;name", "bad@name", "bad!name", "bad$name"]:
             with self.subTest(name=bad_name):
                 import urllib.parse
+
                 encoded = urllib.parse.quote(bad_name, safe="")
                 resp = self.client.delete(
                     f"/api/v1/secrets/{encoded}",
                     headers=self.auth_header,
                 )
-                self.assertEqual(resp.status_code, 400, f"Expected 400 for name={bad_name!r}")
+                self.assertEqual(
+                    resp.status_code, 400, f"Expected 400 for name={bad_name!r}"
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_themes_api.py
+++ b/tests/test_themes_api.py
@@ -1,4 +1,5 @@
 """Tests for themes API endpoints (F025 enhanced)."""
+
 import os
 import sys
 
@@ -14,13 +15,13 @@ from unittest.mock import patch  # noqa: E402
 
 from fastapi.testclient import TestClient  # noqa: E402
 
-
 AUTH_HEADER = {"Authorization": "Bearer shared_test_key_123"}
 
 
 @pytest.fixture(scope="module")
 def client():
     from agent_manager import create_api_app
+
     app = create_api_app()
     with TestClient(app) as c:
         yield c
@@ -34,9 +35,7 @@ def themes_dir(tmp_path):
     (d / "ocean-breeze.css").write_text(
         '[data-theme="ocean-breeze"] { --accent: #0ea5e9; }'
     )
-    (d / "forest.css").write_text(
-        '[data-theme="forest"] { --accent: #22c55e; }'
-    )
+    (d / "forest.css").write_text('[data-theme="forest"] { --accent: #22c55e; }')
     (d / "custom.css.template").write_text("/* template */")
     (d / ".hidden.css").write_text("/* hidden */")
     return d
@@ -70,9 +69,7 @@ class TestListThemes:
         assert r.status_code == 401
 
     def test_list_themes_includes_custom(self, client, themes_dir):
-        with patch(
-            "agent_manager._themes_dir", themes_dir
-        ):
+        with patch("agent_manager._themes_dir", themes_dir):
             r = client.get("/api/v1/themes", headers=AUTH_HEADER)
             data = r.json()
             names = [t["name"] for t in data["themes"]]
@@ -80,9 +77,7 @@ class TestListThemes:
             assert "forest" in names
 
     def test_list_themes_excludes_hidden_and_template(self, client, themes_dir):
-        with patch(
-            "agent_manager._themes_dir", themes_dir
-        ):
+        with patch("agent_manager._themes_dir", themes_dir):
             r = client.get("/api/v1/themes", headers=AUTH_HEADER)
             data = r.json()
             names = [t["name"] for t in data["themes"]]
@@ -90,9 +85,7 @@ class TestListThemes:
             assert "custom.css" not in names
 
     def test_custom_themes_not_builtin(self, client, themes_dir):
-        with patch(
-            "agent_manager._themes_dir", themes_dir
-        ):
+        with patch("agent_manager._themes_dir", themes_dir):
             r = client.get("/api/v1/themes", headers=AUTH_HEADER)
             data = r.json()
             for theme in data["themes"]:
@@ -100,16 +93,11 @@ class TestListThemes:
                     assert theme["builtin"] is False
 
     def test_custom_theme_label_formatting(self, client, themes_dir):
-        with patch(
-            "agent_manager._themes_dir", themes_dir
-        ):
+        with patch("agent_manager._themes_dir", themes_dir):
             r = client.get("/api/v1/themes", headers=AUTH_HEADER)
             data = r.json()
-            ocean = next(
-                t for t in data["themes"] if t["name"] == "ocean-breeze"
-            )
+            ocean = next(t for t in data["themes"] if t["name"] == "ocean-breeze")
             assert ocean["label"] == "Ocean Breeze"
-
 
 
 class TestCustomThemeCSSInListing:
@@ -141,6 +129,7 @@ class TestCustomThemeCSSInListing:
     def test_path_traversal_via_name_rejected(self, client, themes_dir):
         """Theme name regex blocks traversal attempts at the listing level."""
         from agent_manager import _THEME_NAME_RE
+
         assert not _THEME_NAME_RE.match("../etc/passwd")
         assert not _THEME_NAME_RE.match("..%2fetc%2fpasswd")
         assert not _THEME_NAME_RE.match("bad name!")
@@ -151,18 +140,31 @@ class TestThemeNameRegex:
 
     def test_valid_names(self):
         from agent_manager import _THEME_NAME_RE
+
         valid = [
-            "emerald", "midnight", "ocean-breeze", "my_theme",
-            "my.theme", "CamelCase", "theme123", "a",
+            "emerald",
+            "midnight",
+            "ocean-breeze",
+            "my_theme",
+            "my.theme",
+            "CamelCase",
+            "theme123",
+            "a",
         ]
         for name in valid:
             assert _THEME_NAME_RE.match(name), f"Should match: {name}"
 
     def test_invalid_names(self):
         from agent_manager import _THEME_NAME_RE
+
         invalid = [
-            "", ".hidden", "-start", "_start",
-            "a" * 65, "../traversal", "name with space",
+            "",
+            ".hidden",
+            "-start",
+            "_start",
+            "a" * 65,
+            "../traversal",
+            "name with space",
         ]
         for name in invalid:
             assert not _THEME_NAME_RE.match(name), f"Should reject: {name}"
@@ -174,28 +176,35 @@ class TestThemesDirectory:
     def test_themes_dir_exists(self):
         themes = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "webui", "themes",
+            "webui",
+            "themes",
         )
         assert os.path.isdir(themes), "webui/themes/ must exist"
 
     def test_template_exists(self):
         tpl = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "webui", "themes", "custom.css.template",
+            "webui",
+            "themes",
+            "custom.css.template",
         )
         assert os.path.isfile(tpl), "custom.css.template must exist"
 
     def test_leprachaun_theme_exists(self):
         css = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "webui", "themes", "leprachaun-glassmorphism.css",
+            "webui",
+            "themes",
+            "leprachaun-glassmorphism.css",
         )
         assert os.path.isfile(css)
 
     def test_leprachaun_theme_has_data_theme(self):
         css = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "webui", "themes", "leprachaun-glassmorphism.css",
+            "webui",
+            "themes",
+            "leprachaun-glassmorphism.css",
         )
         content = open(css).read()
         assert '[data-theme="leprachaun-glassmorphism"]' in content

--- a/tests/test_wee_agentic_full_coverage.py
+++ b/tests/test_wee_agentic_full_coverage.py
@@ -37,6 +37,7 @@ Run live Ollama:
 Run live OpenRouter:
     pytest tests/test_wee_agentic_full_coverage.py -v -k openrouter
 """
+
 import io
 import json
 import os
@@ -70,9 +71,18 @@ WEE_RUNTIME = os.path.join(
 def _has_ollama() -> bool:
     try:
         r = subprocess.run(
-            ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-             f"{OLLAMA_HOST}/api/tags"],
-            capture_output=True, text=True, timeout=5,
+            [
+                "curl",
+                "-s",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                f"{OLLAMA_HOST}/api/tags",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         return r.stdout.strip() == "200"
     except Exception:
@@ -84,6 +94,7 @@ def _has_openrouter_key() -> bool:
         return True
     try:
         import keyring
+
         return bool(keyring.get_password("wee-orchestrator", "OPENROUTER_API_KEY"))
     except Exception:
         return False
@@ -100,6 +111,7 @@ skip_openrouter = unittest.skipUnless(HAS_OPENROUTER, "No OPENROUTER_API_KEY")
 # Shared helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_chunk(content=None, tool_calls=None, finish_reason=None, choices=True):
     """Build a fake SSE chunk."""
     if not choices:
@@ -115,8 +127,9 @@ def _make_tc_delta(idx, tc_id=None, name=None, arguments=None):
     return SimpleNamespace(index=idx, id=tc_id, function=fn)
 
 
-def _run_main(model, prompt, tools=False, system_prompt="", temperature=None,
-              extra_args=None):
+def _run_main(
+    model, prompt, tools=False, system_prompt="", temperature=None, extra_args=None
+):
     """Run wee_runtime.main() in-process with captured I/O."""
     argv = ["wee_runtime.py", "--model", model]
     if tools:
@@ -147,15 +160,17 @@ def _run_main(model, prompt, tools=False, system_prompt="", temperature=None,
 
 def _run_cli(model, prompt, tools=False, extra_args=None, timeout=LIVE_TIMEOUT):
     """Run wee_runtime.py as a subprocess."""
-    cmd = [sys.executable, WEE_RUNTIME, "--model", model,
-           "--timeout", str(timeout)]
+    cmd = [sys.executable, WEE_RUNTIME, "--model", model, "--timeout", str(timeout)]
     if tools:
         cmd.append("--tools")
     if extra_args:
         cmd.extend(extra_args)
     cmd.append(prompt)
     return subprocess.run(
-        cmd, capture_output=True, text=True, timeout=timeout + 30,
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout + 30,
         env={**os.environ, "PYTHONUNBUFFERED": "1"},
     )
 
@@ -163,6 +178,7 @@ def _run_cli(model, prompt, tools=False, extra_args=None, timeout=LIVE_TIMEOUT):
 # ===========================================================================
 # 1. PROMPT CONSTANTS VALIDATION
 # ===========================================================================
+
 
 class TestPromptConstants(unittest.TestCase):
     """Anti-hallucination and tool capability prompt constants are well-formed."""
@@ -199,6 +215,7 @@ class TestPromptConstants(unittest.TestCase):
 # 2. SYSTEM PROMPT CONSTRUCTION (mocked client)
 # ===========================================================================
 
+
 class TestSystemPromptConstruction(unittest.TestCase):
     """Verify the effective system prompt injected into the API call."""
 
@@ -207,9 +224,12 @@ class TestSystemPromptConstruction(unittest.TestCase):
         """Without --tools, system prompt has anti-hallucination but not tool capability."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
         _run_main("ollama/test", "hello")
 
@@ -225,9 +245,12 @@ class TestSystemPromptConstruction(unittest.TestCase):
         """With --tools, system prompt includes both anti-hallucination and tool capability."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
         _run_main("ollama/test", "hello", tools=True)
 
@@ -242,9 +265,12 @@ class TestSystemPromptConstruction(unittest.TestCase):
         """Custom --system-prompt text is included in the system message."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
         _run_main("ollama/test", "hello", system_prompt="MY_CUSTOM_SYSTEM_TEXT")
 
@@ -258,6 +284,7 @@ class TestSystemPromptConstruction(unittest.TestCase):
 # 3. OPENAI CLIENT CONFIGURATION
 # ===========================================================================
 
+
 class TestOpenAIClientConfig(unittest.TestCase):
     """Verify httpx timeout and max_retries are set correctly."""
 
@@ -267,9 +294,12 @@ class TestOpenAIClientConfig(unittest.TestCase):
         """OpenAI client is created with max_retries=0."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
         mock_timeout.return_value = MagicMock()
 
         _run_main("ollama/test", "client config")
@@ -283,9 +313,12 @@ class TestOpenAIClientConfig(unittest.TestCase):
         """httpx.Timeout is called with connect=15.0."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
         mock_timeout.return_value = MagicMock()
 
         _run_main("ollama/test", "timeout config")
@@ -299,9 +332,12 @@ class TestOpenAIClientConfig(unittest.TestCase):
         """OpenAI client receives resolved base_url."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
         _run_main("ollama/my-model", "base url check")
 
@@ -314,6 +350,7 @@ class TestOpenAIClientConfig(unittest.TestCase):
 # 4. TEMPERATURE FLAG EDGE CASES
 # ===========================================================================
 
+
 class TestTemperatureEdgeCases(unittest.TestCase):
     """Temperature=0, None, and non-integer values."""
 
@@ -322,9 +359,12 @@ class TestTemperatureEdgeCases(unittest.TestCase):
         """Temperature=0.0 is included in create kwargs (not omitted as falsy)."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
         _run_main("ollama/test", "temp zero", temperature=0.0)
 
@@ -337,9 +377,12 @@ class TestTemperatureEdgeCases(unittest.TestCase):
         """Without --temperature, 'temperature' is NOT in create kwargs."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
         _run_main("ollama/test", "no temp")
 
@@ -351,9 +394,12 @@ class TestTemperatureEdgeCases(unittest.TestCase):
         """Temperature=0.7 is passed as a float."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
         _run_main("ollama/test", "temp 0.7", temperature=0.7)
 
@@ -364,6 +410,7 @@ class TestTemperatureEdgeCases(unittest.TestCase):
 # ===========================================================================
 # 5. EXECUTE_TOOL EDGE CASES
 # ===========================================================================
+
 
 class TestExecuteToolEdgeCases(unittest.TestCase):
     """Edge cases in execute_tool not covered by other suites."""
@@ -468,6 +515,7 @@ class TestExecuteToolEdgeCases(unittest.TestCase):
 # 6. SSH SANITIZATION — SANITIZE_BASH_COMMAND
 # ===========================================================================
 
+
 class TestSanitizeBashCommandFull(unittest.TestCase):
     """Extended sanitization tests."""
 
@@ -520,6 +568,7 @@ class TestSanitizeBashCommandFull(unittest.TestCase):
 # 7. MOCKED LOOP — FULL MESSAGE CHAIN VERIFICATION
 # ===========================================================================
 
+
 class TestFullMessageChain(unittest.TestCase):
     """Verify the exact message sequence after multi-round tool calling."""
 
@@ -530,24 +579,27 @@ class TestFullMessageChain(unittest.TestCase):
         mock_cls.return_value = mock_client
 
         # Round 1: bash call
-        td1 = _make_tc_delta(0, tc_id="tc_r1", name="bash",
-                              arguments='{"command": "echo round1"}')
-        r1 = [_make_chunk(content="", tool_calls=[td1]),
-              _make_chunk(finish_reason="tool_calls")]
+        td1 = _make_tc_delta(
+            0, tc_id="tc_r1", name="bash", arguments='{"command": "echo round1"}'
+        )
+        r1 = [
+            _make_chunk(content="", tool_calls=[td1]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
 
         # Round 2: python call
-        td2 = _make_tc_delta(0, tc_id="tc_r2", name="python",
-                              arguments='{"code": "print(2)"}')
-        r2 = [_make_chunk(content="", tool_calls=[td2]),
-              _make_chunk(finish_reason="tool_calls")]
+        td2 = _make_tc_delta(
+            0, tc_id="tc_r2", name="python", arguments='{"code": "print(2)"}'
+        )
+        r2 = [
+            _make_chunk(content="", tool_calls=[td2]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
 
         # Round 3: final answer
-        r3 = [_make_chunk(content="Final answer"),
-              _make_chunk(finish_reason="stop")]
+        r3 = [_make_chunk(content="Final answer"), _make_chunk(finish_reason="stop")]
 
-        mock_client.chat.completions.create.side_effect = [
-            iter(r1), iter(r2), iter(r3)
-        ]
+        mock_client.chat.completions.create.side_effect = [iter(r1), iter(r2), iter(r3)]
 
         _run_main("ollama/test", "multi-round", tools=True)
 
@@ -572,10 +624,16 @@ class TestFullMessageChain(unittest.TestCase):
         mock_cls.return_value = mock_client
 
         # Use echo with a distinctive string
-        td = _make_tc_delta(0, tc_id="tc_echo", name="bash",
-                            arguments='{"command": "echo UNIQUE_OUTPUT_12345"}')
-        r1 = [_make_chunk(content="", tool_calls=[td]),
-              _make_chunk(finish_reason="tool_calls")]
+        td = _make_tc_delta(
+            0,
+            tc_id="tc_echo",
+            name="bash",
+            arguments='{"command": "echo UNIQUE_OUTPUT_12345"}',
+        )
+        r1 = [
+            _make_chunk(content="", tool_calls=[td]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
         r2 = [_make_chunk(content="Done"), _make_chunk(finish_reason="stop")]
 
         mock_client.chat.completions.create.side_effect = [iter(r1), iter(r2)]
@@ -593,10 +651,16 @@ class TestFullMessageChain(unittest.TestCase):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
 
-        td = _make_tc_delta(0, tc_id="tc_asst_check", name="bash",
-                            arguments='{"command": "echo asst_check"}')
-        r1 = [_make_chunk(content="thinking", tool_calls=[td]),
-              _make_chunk(finish_reason="tool_calls")]
+        td = _make_tc_delta(
+            0,
+            tc_id="tc_asst_check",
+            name="bash",
+            arguments='{"command": "echo asst_check"}',
+        )
+        r1 = [
+            _make_chunk(content="thinking", tool_calls=[td]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
         r2 = [_make_chunk(content="Done"), _make_chunk(finish_reason="stop")]
 
         mock_client.chat.completions.create.side_effect = [iter(r1), iter(r2)]
@@ -617,6 +681,7 @@ class TestFullMessageChain(unittest.TestCase):
 # ===========================================================================
 # 8. STREAMING EDGE CASES
 # ===========================================================================
+
 
 class TestStreamingEdgeCasesFull(unittest.TestCase):
     """Edge cases in streaming: empty choices, null content, mixed deltas."""
@@ -667,8 +732,9 @@ class TestStreamingEdgeCasesFull(unittest.TestCase):
         mock_cls.return_value = mock_client
 
         # Single chunk has both content and a tool call
-        td = _make_tc_delta(0, tc_id="tc_mixed", name="bash",
-                            arguments='{"command": "echo mixed"}')
+        td = _make_tc_delta(
+            0, tc_id="tc_mixed", name="bash", arguments='{"command": "echo mixed"}'
+        )
         r1 = [
             _make_chunk(content="Let me check that:", tool_calls=[td]),
             _make_chunk(finish_reason="tool_calls"),
@@ -687,7 +753,9 @@ class TestStreamingEdgeCasesFull(unittest.TestCase):
         mock_cls.return_value = mock_client
 
         # Arguments delivered in 3 pieces
-        td_part1 = _make_tc_delta(0, tc_id="tc_split", name="bash", arguments='{"command": ')
+        td_part1 = _make_tc_delta(
+            0, tc_id="tc_split", name="bash", arguments='{"command": '
+        )
         td_part2 = _make_tc_delta(0, tc_id=None, name=None, arguments='"echo ')
         td_part3 = _make_tc_delta(0, tc_id=None, name=None, arguments='split_args"}')
 
@@ -734,6 +802,7 @@ class TestStreamingEdgeCasesFull(unittest.TestCase):
 # 9. MOCKED LOOP — API CALL COUNT ASSERTIONS
 # ===========================================================================
 
+
 class TestAPICallCounts(unittest.TestCase):
     """Assert exact number of API calls for N-round agentic loops."""
 
@@ -742,9 +811,12 @@ class TestAPICallCounts(unittest.TestCase):
         """Simple text response: exactly 1 API call."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.return_value = iter([
-            _make_chunk(content="ok"), _make_chunk(finish_reason="stop"),
-        ])
+        mock_client.chat.completions.create.return_value = iter(
+            [
+                _make_chunk(content="ok"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
         _run_main("ollama/test", "simple")
         self.assertEqual(mock_client.chat.completions.create.call_count, 1)
@@ -755,10 +827,13 @@ class TestAPICallCounts(unittest.TestCase):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
 
-        td = _make_tc_delta(0, tc_id="tc_1", name="bash",
-                            arguments='{"command": "echo hi"}')
-        r1 = [_make_chunk(content="", tool_calls=[td]),
-              _make_chunk(finish_reason="tool_calls")]
+        td = _make_tc_delta(
+            0, tc_id="tc_1", name="bash", arguments='{"command": "echo hi"}'
+        )
+        r1 = [
+            _make_chunk(content="", tool_calls=[td]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
         r2 = [_make_chunk(content="Done"), _make_chunk(finish_reason="stop")]
 
         mock_client.chat.completions.create.side_effect = [iter(r1), iter(r2)]
@@ -773,14 +848,23 @@ class TestAPICallCounts(unittest.TestCase):
         mock_cls.return_value = mock_client
 
         def make_tool_round(n):
-            td = _make_tc_delta(0, tc_id=f"tc_{n}", name="bash",
-                                arguments=f'{{"command": "echo round{n}"}}')
-            return iter([_make_chunk(content="", tool_calls=[td]),
-                         _make_chunk(finish_reason="tool_calls")])
+            td = _make_tc_delta(
+                0,
+                tc_id=f"tc_{n}",
+                name="bash",
+                arguments=f'{{"command": "echo round{n}"}}',
+            )
+            return iter(
+                [
+                    _make_chunk(content="", tool_calls=[td]),
+                    _make_chunk(finish_reason="tool_calls"),
+                ]
+            )
 
         rounds = [make_tool_round(i) for i in range(5)]
-        final = iter([_make_chunk(content="All done"),
-                      _make_chunk(finish_reason="stop")])
+        final = iter(
+            [_make_chunk(content="All done"), _make_chunk(finish_reason="stop")]
+        )
         mock_client.chat.completions.create.side_effect = rounds + [final]
 
         _run_main("ollama/test", "five rounds", tools=True)
@@ -794,15 +878,19 @@ class TestAPICallCounts(unittest.TestCase):
         max_rounds = wee_runtime.MAX_TOOL_ROUNDS
 
         def make_tool_round(n):
-            td = _make_tc_delta(0, tc_id=f"tc_{n}", name="bash",
-                                arguments=f'{{"command": "echo {n}"}}')
-            return iter([_make_chunk(content="", tool_calls=[td]),
-                         _make_chunk(finish_reason="tool_calls")])
+            td = _make_tc_delta(
+                0, tc_id=f"tc_{n}", name="bash", arguments=f'{{"command": "echo {n}"}}'
+            )
+            return iter(
+                [
+                    _make_chunk(content="", tool_calls=[td]),
+                    _make_chunk(finish_reason="tool_calls"),
+                ]
+            )
 
         # Exactly MAX_TOOL_ROUNDS tool calls, then a final text response
         rounds = [make_tool_round(i) for i in range(max_rounds)]
-        final = iter([_make_chunk(content="Final"),
-                      _make_chunk(finish_reason="stop")])
+        final = iter([_make_chunk(content="Final"), _make_chunk(finish_reason="stop")])
         mock_client.chat.completions.create.side_effect = rounds + [final]
 
         _run_main("ollama/test", "max rounds exact", tools=True)
@@ -810,14 +898,16 @@ class TestAPICallCounts(unittest.TestCase):
         # Final call at index max_rounds should have no 'tools' key
         final_kwargs = mock_client.chat.completions.create.call_args_list[max_rounds][1]
         self.assertNotIn(
-            "tools", final_kwargs,
-            f"Round {max_rounds+1} (final) should not include 'tools'"
+            "tools",
+            final_kwargs,
+            f"Round {max_rounds+1} (final) should not include 'tools'",
         )
 
 
 # ===========================================================================
 # 10. UNKNOWN TOOL HANDLING IN LOOP
 # ===========================================================================
+
 
 class TestUnknownToolInLoop(unittest.TestCase):
     """Model returns an unknown tool name — loop should not crash."""
@@ -828,12 +918,17 @@ class TestUnknownToolInLoop(unittest.TestCase):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
 
-        td = _make_tc_delta(0, tc_id="tc_unk", name="unknown_tool_xyz",
-                            arguments='{"arg": "val"}')
-        r1 = [_make_chunk(content="", tool_calls=[td]),
-              _make_chunk(finish_reason="tool_calls")]
-        r2 = [_make_chunk(content="I see the error."),
-              _make_chunk(finish_reason="stop")]
+        td = _make_tc_delta(
+            0, tc_id="tc_unk", name="unknown_tool_xyz", arguments='{"arg": "val"}'
+        )
+        r1 = [
+            _make_chunk(content="", tool_calls=[td]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        r2 = [
+            _make_chunk(content="I see the error."),
+            _make_chunk(finish_reason="stop"),
+        ]
 
         mock_client.chat.completions.create.side_effect = [iter(r1), iter(r2)]
 
@@ -850,6 +945,7 @@ class TestUnknownToolInLoop(unittest.TestCase):
 # 11. MALFORMED JSON TOOL ARGUMENTS
 # ===========================================================================
 
+
 class TestMalformedToolArguments(unittest.TestCase):
     """Model streams broken JSON for tool arguments."""
 
@@ -859,10 +955,13 @@ class TestMalformedToolArguments(unittest.TestCase):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
 
-        td = _make_tc_delta(0, tc_id="tc_bad_json", name="bash",
-                            arguments="{not valid json{{{{")
-        r1 = [_make_chunk(content="", tool_calls=[td]),
-              _make_chunk(finish_reason="tool_calls")]
+        td = _make_tc_delta(
+            0, tc_id="tc_bad_json", name="bash", arguments="{not valid json{{{{"
+        )
+        r1 = [
+            _make_chunk(content="", tool_calls=[td]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
         r2 = [_make_chunk(content="Handled"), _make_chunk(finish_reason="stop")]
 
         mock_client.chat.completions.create.side_effect = [iter(r1), iter(r2)]
@@ -876,10 +975,11 @@ class TestMalformedToolArguments(unittest.TestCase):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
 
-        td = _make_tc_delta(0, tc_id="tc_empty_args", name="bash",
-                            arguments="{}")
-        r1 = [_make_chunk(content="", tool_calls=[td]),
-              _make_chunk(finish_reason="tool_calls")]
+        td = _make_tc_delta(0, tc_id="tc_empty_args", name="bash", arguments="{}")
+        r1 = [
+            _make_chunk(content="", tool_calls=[td]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
         r2 = [_make_chunk(content="I see"), _make_chunk(finish_reason="stop")]
 
         mock_client.chat.completions.create.side_effect = [iter(r1), iter(r2)]
@@ -897,6 +997,7 @@ class TestMalformedToolArguments(unittest.TestCase):
 # 12. MAX TOOL ROUNDS — FALLBACK CONTENT
 # ===========================================================================
 
+
 class TestMaxRoundsFallback(unittest.TestCase):
     """When MAX_TOOL_ROUNDS is exhausted, fallback text appears in output."""
 
@@ -907,19 +1008,27 @@ class TestMaxRoundsFallback(unittest.TestCase):
         mock_cls.return_value = mock_client
 
         def make_loop():
-            td = _make_tc_delta(0, tc_id=f"tc_{time.time_ns()}", name="bash",
-                                arguments='{"command": "echo loop"}')
-            return iter([_make_chunk(content="", tool_calls=[td]),
-                         _make_chunk(finish_reason="tool_calls")])
+            td = _make_tc_delta(
+                0,
+                tc_id=f"tc_{time.time_ns()}",
+                name="bash",
+                arguments='{"command": "echo loop"}',
+            )
+            return iter(
+                [
+                    _make_chunk(content="", tool_calls=[td]),
+                    _make_chunk(finish_reason="tool_calls"),
+                ]
+            )
 
-        side_effects = [make_loop()
-                        for _ in range(wee_runtime.MAX_TOOL_ROUNDS + 2)]
+        side_effects = [make_loop() for _ in range(wee_runtime.MAX_TOOL_ROUNDS + 2)]
         mock_client.chat.completions.create.side_effect = side_effects
 
         result = _run_main("ollama/test", "infinite loop", tools=True)
         self.assertEqual(result.returncode, 0)
-        self.assertTrue(result.stdout.strip(),
-                        "Stdout must not be empty after max rounds")
+        self.assertTrue(
+            result.stdout.strip(), "Stdout must not be empty after max rounds"
+        )
 
     @patch("openai.OpenAI")
     def test_fallback_mentions_tool_execution(self, mock_cls):
@@ -928,13 +1037,20 @@ class TestMaxRoundsFallback(unittest.TestCase):
         mock_cls.return_value = mock_client
 
         def make_loop():
-            td = _make_tc_delta(0, tc_id=f"tc_{time.time_ns()}", name="bash",
-                                arguments='{"command": "echo x"}')
-            return iter([_make_chunk(content="", tool_calls=[td]),
-                         _make_chunk(finish_reason="tool_calls")])
+            td = _make_tc_delta(
+                0,
+                tc_id=f"tc_{time.time_ns()}",
+                name="bash",
+                arguments='{"command": "echo x"}',
+            )
+            return iter(
+                [
+                    _make_chunk(content="", tool_calls=[td]),
+                    _make_chunk(finish_reason="tool_calls"),
+                ]
+            )
 
-        side_effects = [make_loop()
-                        for _ in range(wee_runtime.MAX_TOOL_ROUNDS + 2)]
+        side_effects = [make_loop() for _ in range(wee_runtime.MAX_TOOL_ROUNDS + 2)]
         mock_client.chat.completions.create.side_effect = side_effects
 
         result = _run_main("ollama/test", "max rounds fallback", tools=True)
@@ -951,6 +1067,7 @@ class TestMaxRoundsFallback(unittest.TestCase):
 # 13. API EXCEPTION HANDLING
 # ===========================================================================
 
+
 class TestAPIExceptionHandling(unittest.TestCase):
     """Runtime handles API errors gracefully."""
 
@@ -959,7 +1076,9 @@ class TestAPIExceptionHandling(unittest.TestCase):
         """OpenAI API exception causes exit code != 0."""
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
-        mock_client.chat.completions.create.side_effect = Exception("connection refused")
+        mock_client.chat.completions.create.side_effect = Exception(
+            "connection refused"
+        )
 
         result = _run_main("ollama/test", "api failure")
         self.assertNotEqual(result.returncode, 0)
@@ -988,6 +1107,7 @@ class TestAPIExceptionHandling(unittest.TestCase):
 # ===========================================================================
 # 14. LIVE TESTS — OLLAMA
 # ===========================================================================
+
 
 @skip_ollama
 class TestOllamaLiveMath(unittest.TestCase):
@@ -1018,6 +1138,7 @@ class TestOllamaLiveMath(unittest.TestCase):
     def test_bash_tool_date_year(self):
         """Ollama uses bash tool to get current year (4-digit)."""
         import datetime
+
         current_year = str(datetime.datetime.now().year)
         result = _run_cli(
             OLLAMA_MODEL,
@@ -1076,6 +1197,7 @@ class TestOllamaLiveMultiStep(unittest.TestCase):
 # 15. LIVE TESTS — OPENROUTER
 # ===========================================================================
 
+
 @skip_openrouter
 class TestOpenRouterLiveFree(unittest.TestCase):
     """Live OpenRouter tests using free tier models."""
@@ -1124,8 +1246,7 @@ class TestOpenRouterKeyRequired(unittest.TestCase):
 
     def test_missing_key_exits_nonzero(self):
         """openrouter/ model without API key causes sys.exit(1)."""
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("OPENROUTER_API_KEY",)}
+        env = {k: v for k, v in os.environ.items() if k not in ("OPENROUTER_API_KEY",)}
         # Patch keyring to return nothing
         with patch("keyring.get_password", return_value=None):
             with patch.dict(os.environ, {"OPENROUTER_API_KEY": ""}, clear=False):
@@ -1143,6 +1264,7 @@ class TestOpenRouterKeyRequired(unittest.TestCase):
 # ===========================================================================
 # 16. WEE_TOOLS CONSTANT INTEGRITY
 # ===========================================================================
+
 
 class TestWeeTooDefinitions(unittest.TestCase):
     """_WEE_TOOLS constant is well-formed OpenAI tool spec."""
@@ -1166,15 +1288,17 @@ class TestWeeTooDefinitions(unittest.TestCase):
             self.assertEqual(tool.get("type"), "function")
 
     def test_bash_requires_command_parameter(self):
-        bash = next(t for t in wee_runtime._WEE_TOOLS
-                    if t["function"]["name"] == "bash")
+        bash = next(
+            t for t in wee_runtime._WEE_TOOLS if t["function"]["name"] == "bash"
+        )
         params = bash["function"]["parameters"]
         self.assertIn("command", params["properties"])
         self.assertIn("command", params["required"])
 
     def test_python_requires_code_parameter(self):
-        python = next(t for t in wee_runtime._WEE_TOOLS
-                      if t["function"]["name"] == "python")
+        python = next(
+            t for t in wee_runtime._WEE_TOOLS if t["function"]["name"] == "python"
+        )
         params = python["function"]["parameters"]
         self.assertIn("code", params["properties"])
         self.assertIn("code", params["required"])
@@ -1189,6 +1313,7 @@ class TestWeeTooDefinitions(unittest.TestCase):
 # ===========================================================================
 # 17. RUNTIME CONSTANTS SANITY
 # ===========================================================================
+
 
 class TestRuntimeConstants(unittest.TestCase):
     """MAX_TOOL_ROUNDS and TOOL_TIMEOUT are within safe operating ranges."""
@@ -1212,6 +1337,7 @@ class TestRuntimeConstants(unittest.TestCase):
     def test_ssh_bin_re_is_compiled_regex(self):
         """_SSH_BIN_RE is a compiled regex object."""
         import re
+
         self.assertIsInstance(wee_runtime._SSH_BIN_RE, type(re.compile("")))
 
 

--- a/tests/test_wee_executor.py
+++ b/tests/test_wee_executor.py
@@ -31,7 +31,6 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 
 import wee_executor
 
-
 # ── Fixtures ──────────────────────────────────────────────────────────
 
 
@@ -54,9 +53,7 @@ def _clean_env(monkeypatch, tmp_path):
     # Redirect log/rate-limit files to tmp
     monkeypatch.setattr(wee_executor, "LOG_DIR", tmp_path)
     monkeypatch.setattr(wee_executor, "LOG_FILE", tmp_path / "wee_executor.log")
-    monkeypatch.setattr(
-        wee_executor, "RATE_LIMIT_FILE", tmp_path / ".rate_limits.json"
-    )
+    monkeypatch.setattr(wee_executor, "RATE_LIMIT_FILE", tmp_path / ".rate_limits.json")
 
 
 @pytest.fixture
@@ -126,7 +123,9 @@ class TestSessionDetection:
 
     def test_session_not_found_api_mode(self, monkeypatch, tmp_path):
         """No session → api mode."""
-        monkeypatch.setattr(wee_executor, "SESSIONS_JSON", tmp_path / "nonexistent.json")
+        monkeypatch.setattr(
+            wee_executor, "SESSIONS_JSON", tmp_path / "nonexistent.json"
+        )
         sid, mode, rt = wee_executor.detect_session()
         assert sid is None
         assert mode == wee_executor.MODE_API
@@ -140,7 +139,9 @@ class TestModeDetection:
 
     def test_interactive_mode(self):
         """Default mode with a session is interactive."""
-        assert wee_executor._detect_mode("some-session") == wee_executor.MODE_INTERACTIVE
+        assert (
+            wee_executor._detect_mode("some-session") == wee_executor.MODE_INTERACTIVE
+        )
 
     def test_background_mode(self, monkeypatch):
         """WEE_TASK_ID → background mode."""
@@ -221,6 +222,7 @@ class TestRegisterCapability:
 
     def test_register_new_capability(self):
         """Register and verify a new capability appears in the registry."""
+
         def dummy_handler(args, sid, mode):
             return {"ok": True}
 
@@ -259,9 +261,7 @@ class TestCreateBackgroundTask:
 
     def test_invalid_agent(self, monkeypatch, mock_agents_json):
         """Unknown agent returns INVALID_AGENT."""
-        monkeypatch.setattr(
-            wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json
-        )
+        monkeypatch.setattr(wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json)
         result = wee_executor.cap_create_background_task(
             {"agent": "nonexistent", "prompt": "hello"},
             "session-1",
@@ -273,9 +273,7 @@ class TestCreateBackgroundTask:
     @patch.object(wee_executor, "_api_request")
     def test_success_creates_task(self, mock_api, monkeypatch, mock_agents_json):
         """Successful task creation returns task_id and status."""
-        monkeypatch.setattr(
-            wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json
-        )
+        monkeypatch.setattr(wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json)
         monkeypatch.setattr(wee_executor, "_get_api_key", lambda: "test_key")
 
         # First call = POST, second = GET verify
@@ -298,9 +296,7 @@ class TestCreateBackgroundTask:
     @patch.object(wee_executor, "_api_request")
     def test_api_error(self, mock_api, monkeypatch, mock_agents_json):
         """API errors are propagated."""
-        monkeypatch.setattr(
-            wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json
-        )
+        monkeypatch.setattr(wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json)
         monkeypatch.setattr(wee_executor, "_get_api_key", lambda: "test_key")
 
         mock_api.return_value = {
@@ -318,14 +314,14 @@ class TestCreateBackgroundTask:
 
     def test_rate_limit(self, monkeypatch, mock_agents_json, tmp_path):
         """Rate limiter blocks after MAX_RATE_PER_MINUTE calls."""
-        monkeypatch.setattr(
-            wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json
-        )
+        monkeypatch.setattr(wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json)
         # Pre-fill rate limit file with max calls
         import time
 
         now = time.time()
-        limits = {"session-1": [now - i for i in range(wee_executor.MAX_RATE_PER_MINUTE)]}
+        limits = {
+            "session-1": [now - i for i in range(wee_executor.MAX_RATE_PER_MINUTE)]
+        }
         rate_file = tmp_path / ".rate_limits.json"
         rate_file.write_text(json.dumps(limits))
         monkeypatch.setattr(wee_executor, "RATE_LIMIT_FILE", rate_file)
@@ -407,9 +403,7 @@ class TestCLI:
     def test_api_error_exit_3(self, mock_api, monkeypatch, capsys, mock_agents_json):
         """API error exits with code 3."""
         monkeypatch.setenv("WEE_SESSION_ID", "test-session")
-        monkeypatch.setattr(
-            wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json
-        )
+        monkeypatch.setattr(wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json)
         monkeypatch.setattr(wee_executor, "_get_api_key", lambda: "test_key")
         mock_api.return_value = {
             "error": "Connection failed: Connection refused",
@@ -451,16 +445,12 @@ class TestSecurity:
 
     def test_validate_agent_valid(self, monkeypatch, mock_agents_json):
         """Valid agent passes validation."""
-        monkeypatch.setattr(
-            wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json
-        )
+        monkeypatch.setattr(wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json)
         assert wee_executor._validate_agent("research") is True
 
     def test_validate_agent_invalid(self, monkeypatch, mock_agents_json):
         """Invalid agent fails validation."""
-        monkeypatch.setattr(
-            wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json
-        )
+        monkeypatch.setattr(wee_executor, "DEFAULT_AGENTS_JSON", mock_agents_json)
         assert wee_executor._validate_agent("nonexistent") is False
 
 
@@ -593,9 +583,7 @@ class TestGetSecret:
     def test_subprocess_calls_secret_tool(self, mock_run, monkeypatch):
         """Verify subprocess calls secret_tool.py with correct args."""
         monkeypatch.setenv("WEE_ELEVATED", "true")
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="val", stderr=""
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="val", stderr="")
         wee_executor.cap_get_secret(
             {"name": "my_key", "backend": "file"},
             "session-1",
@@ -676,9 +664,7 @@ class TestGetSecret:
     def test_elevation_with_1(self, mock_run, monkeypatch):
         """WEE_ELEVATED=1 also grants elevation."""
         monkeypatch.setenv("WEE_ELEVATED", "1")
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="secret_val", stderr=""
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="secret_val", stderr="")
         result = wee_executor.cap_get_secret(
             {"name": "key_1"},
             "session-1",
@@ -721,9 +707,7 @@ class TestGetSecret:
         """CLI get_secret with elevation succeeds."""
         monkeypatch.setenv("WEE_SESSION_ID", "test-session")
         monkeypatch.setenv("WEE_ELEVATED", "true")
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="the_secret", stderr=""
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="the_secret", stderr="")
         monkeypatch.setattr(
             "sys.argv",
             [
@@ -740,9 +724,7 @@ class TestGetSecret:
         assert output["status"] == "success"
         assert output["value"] == "the_secret"
 
-    def test_cli_get_secret_mode_restricted_background(
-        self, monkeypatch, capsys
-    ):
+    def test_cli_get_secret_mode_restricted_background(self, monkeypatch, capsys):
         """get_secret is mode-restricted in background mode."""
         monkeypatch.setenv("WEE_SESSION_ID", "test-session")
         monkeypatch.setenv("WEE_TASK_ID", "bg_123")

--- a/tests/test_wee_issues_107_108_109.py
+++ b/tests/test_wee_issues_107_108_109.py
@@ -5,6 +5,7 @@ Issue #107: Tool calling returns "no response" — agentic tool loop
 Issue #108: Multi-turn context broken — session history persistence
 Issue #109: Tool calls produce no streaming output — SSE events
 """
+
 import json
 import os
 import subprocess
@@ -12,7 +13,7 @@ import sys
 import threading
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 # Add repo root to path
 REPO = Path(__file__).resolve().parent.parent
@@ -39,8 +40,9 @@ def _make_mgr():
     return mgr
 
 
-def _run_wee(mgr, session_id, prompt="test", model="ollama/gemma4:e4b",
-             resume=False, **kwargs):
+def _run_wee(
+    mgr, session_id, prompt="test", model="ollama/gemma4:e4b", resume=False, **kwargs
+):
     """Helper to call run_wee_native with mocked session infrastructure."""
     defaults = dict(
         prompt=prompt,
@@ -53,14 +55,20 @@ def _run_wee(mgr, session_id, prompt="test", model="ollama/gemma4:e4b",
         render_type="text",
     )
     defaults.update(kwargs)
-    session_data = mgr.session_map.get(session_id, {
-        "runtime": "wee",
-        "model": model,
-        "channel": "api",
-    })
+    session_data = mgr.session_map.get(
+        session_id,
+        {
+            "runtime": "wee",
+            "model": model,
+            "channel": "api",
+        },
+    )
     with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
-        with patch.object(mgr, "build_agent_context_prompt",
-                          return_value="You are a helpful assistant."):
+        with patch.object(
+            mgr,
+            "build_agent_context_prompt",
+            return_value="You are a helpful assistant.",
+        ):
             return mgr.run_wee_native(**defaults)
 
 
@@ -75,7 +83,7 @@ def _make_text_chunk(content_text):
 
 def _make_tool_call_chunks(tool_id, func_name, arguments_json):
     """Create mock streaming chunks representing a tool call.
-    
+
     Returns a list of chunks that simulate how the OpenAI streaming API
     delivers tool call deltas.
     """
@@ -127,7 +135,11 @@ class TestWeeSessionHistory(unittest.TestCase):
         mock_client.chat.completions.create.return_value = [chunk]
 
         sid = "test_108_first_turn"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
 
         # Mock session persistence
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
@@ -305,16 +317,22 @@ class TestWeeToolCalling(unittest.TestCase):
         # Second call: model returns final text response
         final_chunk = _make_text_chunk("The output was: hello")
         mock_client.chat.completions.create.side_effect = [
-            tool_chunks,      # First round: tool call
-            [final_chunk],    # Second round: final answer
+            tool_chunks,  # First round: tool call
+            [final_chunk],  # Second round: final answer
         ]
 
         sid = "test_107_bash"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
 
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
             with patch.object(mgr, "save_session_map"):
-                with patch.object(mgr, "_execute_bash_command", return_value="hello") as mock_bash:
+                with patch.object(
+                    mgr, "_execute_bash_command", return_value="hello"
+                ) as mock_bash:
                     result = _run_wee(mgr, sid, prompt="Run echo hello")
 
         self.assertEqual(result, "The output was: hello")
@@ -337,7 +355,11 @@ class TestWeeToolCalling(unittest.TestCase):
         ]
 
         sid = "test_107_python"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
 
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
             with patch.object(mgr, "save_session_map"):
@@ -356,9 +378,7 @@ class TestWeeToolCalling(unittest.TestCase):
         mock_client = MagicMock()
         mock_openai_cls.return_value = mock_client
 
-        tool_chunks = _make_tool_call_chunks(
-            "call_2", "bash", '{"command": "date"}'
-        )
+        tool_chunks = _make_tool_call_chunks("call_2", "bash", '{"command": "date"}')
         final_chunk = _make_text_chunk("Today is April 11")
         mock_client.chat.completions.create.side_effect = [
             tool_chunks,
@@ -366,11 +386,17 @@ class TestWeeToolCalling(unittest.TestCase):
         ]
 
         sid = "test_107_msgs"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
 
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
             with patch.object(mgr, "save_session_map"):
-                with patch.object(mgr, "_execute_bash_command", return_value="Sat Apr 11"):
+                with patch.object(
+                    mgr, "_execute_bash_command", return_value="Sat Apr 11"
+                ):
                     _run_wee(mgr, sid, prompt="What day is it?")
 
         # The second API call should include the tool result
@@ -394,7 +420,11 @@ class TestWeeToolCalling(unittest.TestCase):
         mock_client.chat.completions.create.return_value = [chunk]
 
         sid = "test_107_no_tools"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
 
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
             with patch.object(mgr, "save_session_map"):
@@ -419,7 +449,11 @@ class TestWeeToolCalling(unittest.TestCase):
         ]
 
         sid = "test_107_fallback"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
 
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
             with patch.object(mgr, "save_session_map"):
@@ -430,7 +464,9 @@ class TestWeeToolCalling(unittest.TestCase):
     def test_wee_execute_tool_bash(self):
         """_wee_execute_tool should delegate bash to _execute_bash_command."""
         mgr = _make_mgr()
-        with patch.object(mgr, "_execute_bash_command", return_value="output") as mock_bash:
+        with patch.object(
+            mgr, "_execute_bash_command", return_value="output"
+        ) as mock_bash:
             result = mgr._wee_execute_tool("bash", {"command": "ls"}, "orchestrator")
         self.assertEqual(result, "output")
         mock_bash.assert_called_once_with("ls", "orchestrator")
@@ -440,7 +476,9 @@ class TestWeeToolCalling(unittest.TestCase):
         mgr = _make_mgr()
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout="42\n", stderr="", returncode=0)
-            result = mgr._wee_execute_tool("python", {"code": "print(42)"}, "orchestrator")
+            result = mgr._wee_execute_tool(
+                "python", {"code": "print(42)"}, "orchestrator"
+            )
         self.assertEqual(result, "42")
 
     def test_wee_execute_tool_unknown(self):
@@ -488,7 +526,11 @@ class TestWeeToolCalling(unittest.TestCase):
         ]
 
         sid = "test_107_multi_tools"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
 
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
             with patch.object(mgr, "save_session_map"):
@@ -521,7 +563,11 @@ class TestWeeToolStreaming(unittest.TestCase):
         ]
 
         sid = "test_109_sse_start"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "webui"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "webui",
+        }
         mock_buffer = MagicMock()
         mgr._stream_buffers[sid] = mock_buffer
 
@@ -532,8 +578,7 @@ class TestWeeToolStreaming(unittest.TestCase):
 
         # Find tool_call events
         tc_calls = [
-            c for c in mock_buffer.push.call_args_list
-            if c[0][0] == "tool_call"
+            c for c in mock_buffer.push.call_args_list if c[0][0] == "tool_call"
         ]
         self.assertGreaterEqual(len(tc_calls), 2)  # start + complete
 
@@ -560,7 +605,11 @@ class TestWeeToolStreaming(unittest.TestCase):
         ]
 
         sid = "test_109_sse_done"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "webui"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "webui",
+        }
         mock_buffer = MagicMock()
         mgr._stream_buffers[sid] = mock_buffer
 
@@ -570,8 +619,7 @@ class TestWeeToolStreaming(unittest.TestCase):
                     _run_wee(mgr, sid, prompt="What is the hostname?")
 
         tc_calls = [
-            c for c in mock_buffer.push.call_args_list
-            if c[0][0] == "tool_call"
+            c for c in mock_buffer.push.call_args_list if c[0][0] == "tool_call"
         ]
         # Verify complete event
         done_evt = tc_calls[1][0][1]
@@ -597,7 +645,11 @@ class TestWeeToolStreaming(unittest.TestCase):
         ]
 
         sid = "test_109_content_stream"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "webui"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "webui",
+        }
         mock_buffer = MagicMock()
         mgr._stream_buffers[sid] = mock_buffer
 
@@ -609,10 +661,7 @@ class TestWeeToolStreaming(unittest.TestCase):
         self.assertEqual(result, "Today is Friday")
 
         # Verify chunk events were pushed
-        chunk_calls = [
-            c for c in mock_buffer.push.call_args_list
-            if c[0][0] == "chunk"
-        ]
+        chunk_calls = [c for c in mock_buffer.push.call_args_list if c[0][0] == "chunk"]
         self.assertGreaterEqual(len(chunk_calls), 2)
 
     @patch("openai.OpenAI")
@@ -632,7 +681,11 @@ class TestWeeToolStreaming(unittest.TestCase):
         ]
 
         sid = "test_109_done"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "webui"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "webui",
+        }
         mock_buffer = MagicMock()
         mgr._stream_buffers[sid] = mock_buffer
 
@@ -641,10 +694,7 @@ class TestWeeToolStreaming(unittest.TestCase):
                 with patch.object(mgr, "_execute_bash_command", return_value="done"):
                     _run_wee(mgr, sid, prompt="Finish up")
 
-        done_calls = [
-            c for c in mock_buffer.push.call_args_list
-            if c[0][0] == "done"
-        ]
+        done_calls = [c for c in mock_buffer.push.call_args_list if c[0][0] == "done"]
         self.assertEqual(len(done_calls), 1)
         self.assertEqual(done_calls[0][0][1], "All done")
 
@@ -665,7 +715,11 @@ class TestWeeToolStreaming(unittest.TestCase):
         ]
 
         sid = "test_109_no_buffer"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
         # No stream buffer set
 
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
@@ -689,9 +743,7 @@ class TestWeeIntegration(unittest.TestCase):
         mock_client = MagicMock()
         mock_openai_cls.return_value = mock_client
 
-        tool_chunks = _make_tool_call_chunks(
-            "call_hist", "bash", '{"command": "ls"}'
-        )
+        tool_chunks = _make_tool_call_chunks("call_hist", "bash", '{"command": "ls"}')
         final_chunk = _make_text_chunk("Files listed")
         mock_client.chat.completions.create.side_effect = [
             tool_chunks,
@@ -699,11 +751,17 @@ class TestWeeIntegration(unittest.TestCase):
         ]
 
         sid = "test_integration_history"
-        mgr.session_map[sid] = {"runtime": "wee", "model": "ollama/gemma4:e4b", "channel": "api"}
+        mgr.session_map[sid] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
 
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
             with patch.object(mgr, "save_session_map") as mock_save:
-                with patch.object(mgr, "_execute_bash_command", return_value="file1.txt"):
+                with patch.object(
+                    mgr, "_execute_bash_command", return_value="file1.txt"
+                ):
                     _run_wee(mgr, sid, prompt="List files")
 
         saved_msgs = mock_save.call_args[0][0][sid]["wee_messages"]
@@ -746,8 +804,6 @@ class TestWeeIntegration(unittest.TestCase):
             api_messages[0]["content"].startswith("You are a helpful assistant."),
             "System prompt must begin with base context after refresh",
         )
-
-
 
 
 class TestWeeContextPersistenceDispatch(unittest.TestCase):
@@ -838,7 +894,9 @@ class TestWeeContextPersistenceDispatch(unittest.TestCase):
                     prompt="Call me purple people eater for the duration of this session.",
                     resume=False,
                 )
-                self.assertTrue(mock_save.called, "save_session_map must be called after turn 1")
+                self.assertTrue(
+                    mock_save.called, "save_session_map must be called after turn 1"
+                )
                 saved_map = mock_save.call_args[0][0]
                 self.assertIn("wee_messages", saved_map[sid])
                 history_after_t1 = saved_map[sid]["wee_messages"]
@@ -908,9 +966,7 @@ class TestWeeContextPersistenceDispatch(unittest.TestCase):
         with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
             # Old (broken) path: else branch evaluated with session_id=None
             can_resume_old = (
-                mgr.session_exists(None, "wee")
-                if None  # session_id is None
-                else False
+                mgr.session_exists(None, "wee") if None else False  # session_id is None
             )
             # New (fixed) path: elif wee branch passes n8n_session_id
             can_resume_new = mgr.session_exists(None, "wee", n8n_session_id=sid)

--- a/tests/test_wee_native_runtime.py
+++ b/tests/test_wee_native_runtime.py
@@ -23,9 +23,9 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO))
 
 from agent_manager import (
+    SessionManager,
     check_runtime_available,
     get_available_runtimes,
-    SessionManager,
 )
 
 
@@ -61,14 +61,23 @@ def _run_wee_native_test(mgr, test_session, model="ollama/gemma4:e4b", **kwargs)
     )
     defaults.update(kwargs)
     # Patch get_or_create_session_data to avoid file system dependencies
-    session_data = mgr.session_map.get(test_session, {
-        "runtime": "wee",
-        "model": model,
-        "channel": "api",
-    })
+    session_data = mgr.session_map.get(
+        test_session,
+        {
+            "runtime": "wee",
+            "model": model,
+            "channel": "api",
+        },
+    )
     with patch.object(mgr, "get_or_create_session_data", return_value=session_data):
-        with patch.object(mgr, "build_agent_context_prompt", return_value="You are a helpful assistant."):
-            with patch.object(mgr, "load_session_map", return_value=dict(mgr.session_map)):
+        with patch.object(
+            mgr,
+            "build_agent_context_prompt",
+            return_value="You are a helpful assistant.",
+        ):
+            with patch.object(
+                mgr, "load_session_map", return_value=dict(mgr.session_map)
+            ):
                 with patch.object(mgr, "save_session_map"):
                     return mgr.run_wee_native(**defaults)
 
@@ -333,6 +342,7 @@ class TestWeeBackgroundTask(unittest.TestCase):
         """wee_runtime.py should be valid Python."""
         script_path = REPO / "wee_runtime.py"
         import py_compile
+
         py_compile.compile(str(script_path), doraise=True)
 
 
@@ -342,12 +352,14 @@ class TestWeeRuntimeValidation(unittest.TestCase):
     def test_wee_in_valid_runtimes_source(self):
         """wee should appear in the /runtime error message."""
         import inspect
+
         source = inspect.getsource(SessionManager)
         self.assertIn("cursor, or wee", source)
 
     def test_wee_in_session_id_validation(self):
         """Session ID validation should include wee."""
         import inspect
+
         source = inspect.getsource(SessionManager)
         self.assertIn('"wee"', source)
 

--- a/wee_model_discovery.py
+++ b/wee_model_discovery.py
@@ -13,8 +13,8 @@ import sys
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.request import urlopen, Request
 from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 # Default discovery hosts (override via WEE_DISCOVERY_HOSTS env var as JSON)
 _DEFAULT_HOSTS = [
@@ -54,7 +54,9 @@ class WeeModelDiscovery:
         """
         self.ttl = ttl
         self.timeout = timeout
-        self._cache: Dict[str, Tuple[float, List[str]]] = {}  # host_url -> (timestamp, models)
+        self._cache: Dict[str, Tuple[float, List[str]]] = (
+            {}
+        )  # host_url -> (timestamp, models)
         self._cache_status: Dict[str, str] = {}  # host_url -> "online" | "offline"
         self._lock = threading.Lock()
 
@@ -196,15 +198,19 @@ class WeeModelDiscovery:
                         models = []
                         for m in data.get("models", []):
                             if isinstance(m, dict) and "name" in m:
-                                model_id = f"{prefix}/{m['name']}" if prefix else m["name"]
-                                models.append({
-                                    "id": model_id,
-                                    "name": m["name"],
-                                    "size": m.get("size"),
-                                    "modified_at": m.get("modified_at"),
-                                    "provider": prefix or host_type,
-                                    "status": "available",
-                                })
+                                model_id = (
+                                    f"{prefix}/{m['name']}" if prefix else m["name"]
+                                )
+                                models.append(
+                                    {
+                                        "id": model_id,
+                                        "name": m["name"],
+                                        "size": m.get("size"),
+                                        "modified_at": m.get("modified_at"),
+                                        "provider": prefix or host_type,
+                                        "status": "available",
+                                    }
+                                )
                         result[label] = models
                     else:
                         result[f"{label} ⚠️ offline"] = []
@@ -216,12 +222,14 @@ class WeeModelDiscovery:
                         for m in data.get("data", []):
                             if isinstance(m, dict) and "id" in m:
                                 model_id = f"{prefix}/{m['id']}" if prefix else m["id"]
-                                models.append({
-                                    "id": model_id,
-                                    "name": m["id"],
-                                    "provider": prefix or host_type,
-                                    "status": "available",
-                                })
+                                models.append(
+                                    {
+                                        "id": model_id,
+                                        "name": m["id"],
+                                        "provider": prefix or host_type,
+                                        "status": "available",
+                                    }
+                                )
                         result[label] = models
                     else:
                         result[f"{label} ⚠️ offline"] = []

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -19,7 +19,6 @@ import subprocess
 import sys
 import time
 
-
 # Provider presets: prefix → (api_base, default_api_key)
 PROVIDER_PRESETS = {
     "ollama": ("http://192.168.1.101:11434/v1", "ollama"),
@@ -85,7 +84,7 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
     # Check for provider prefix
     for prefix, (preset_base, preset_key) in PROVIDER_PRESETS.items():
         if model.lower().startswith(f"{prefix}/"):
-            resolved_model = model[len(prefix) + 1:]
+            resolved_model = model[len(prefix) + 1 :]
             if not resolved_base:
                 resolved_base = preset_base
             if not resolved_key and preset_key:
@@ -94,9 +93,7 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
 
     # Defaults
     if not resolved_base:
-        resolved_base = os.environ.get(
-            "WEE_API_BASE", "http://192.168.1.101:11434/v1"
-        )
+        resolved_base = os.environ.get("WEE_API_BASE", "http://192.168.1.101:11434/v1")
     if not resolved_key:
         resolved_key = os.environ.get("WEE_API_KEY") or os.environ.get(
             "OPENROUTER_API_KEY"
@@ -105,6 +102,7 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
             if "openrouter" in (resolved_base or "").lower():
                 try:
                     import keyring
+
                     resolved_key = keyring.get_password("openrouter", "api_key")
                 except Exception:
                     pass
@@ -157,14 +155,24 @@ def main():
     parser = argparse.ArgumentParser(
         description="Wee Native Runtime — OpenAI-compatible chat completions"
     )
-    parser.add_argument("--model", required=True, help="Model name (e.g., ollama/gemma4:e4b)")
+    parser.add_argument(
+        "--model", required=True, help="Model name (e.g., ollama/gemma4:e4b)"
+    )
     parser.add_argument("--api-base", default=None, help="API base URL")
     parser.add_argument("--api-key", default=None, help="API key")
     parser.add_argument("--system-prompt", default="", help="System prompt")
-    parser.add_argument("--timeout", type=int, default=300, help="Request timeout in seconds")
-    parser.add_argument("--temperature", type=float, default=None, help="Sampling temperature")
-    parser.add_argument("--tools", action="store_true", default=False,
-                        help="Enable tool calling (bash, python)")
+    parser.add_argument(
+        "--timeout", type=int, default=300, help="Request timeout in seconds"
+    )
+    parser.add_argument(
+        "--temperature", type=float, default=None, help="Sampling temperature"
+    )
+    parser.add_argument(
+        "--tools",
+        action="store_true",
+        default=False,
+        help="Enable tool calling (bash, python)",
+    )
     parser.add_argument("prompt", help="User prompt")
     args = parser.parse_args()
 
@@ -175,7 +183,10 @@ def main():
     try:
         from openai import OpenAI
     except ImportError:
-        print("Error: openai package not installed. Run: pip install openai", file=sys.stderr)
+        print(
+            "Error: openai package not installed. Run: pip install openai",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     client = OpenAI(
@@ -263,7 +274,8 @@ def main():
                         if idx not in tool_calls_acc:
                             tool_call_counter += 1
                             tool_calls_acc[idx] = {
-                                "id": getattr(tc_delta, "id", None) or f"tc_wee_{tool_call_counter}",
+                                "id": getattr(tc_delta, "id", None)
+                                or f"tc_wee_{tool_call_counter}",
                                 "name": "",
                                 "arguments": "",
                             }
@@ -273,7 +285,9 @@ def main():
                             if tc_delta.function.name:
                                 tool_calls_acc[idx]["name"] = tc_delta.function.name
                             if tc_delta.function.arguments:
-                                tool_calls_acc[idx]["arguments"] += tc_delta.function.arguments
+                                tool_calls_acc[idx][
+                                    "arguments"
+                                ] += tc_delta.function.arguments
 
             content_text = "".join(round_content)
 
@@ -290,17 +304,21 @@ def main():
             assistant_tool_calls = []
             for idx in sorted(tool_calls_acc.keys()):
                 tc = tool_calls_acc[idx]
-                assistant_tool_calls.append({
-                    "id": tc["id"],
-                    "type": "function",
-                    "function": {"name": tc["name"], "arguments": tc["arguments"]},
-                })
+                assistant_tool_calls.append(
+                    {
+                        "id": tc["id"],
+                        "type": "function",
+                        "function": {"name": tc["name"], "arguments": tc["arguments"]},
+                    }
+                )
 
-            messages.append({
-                "role": "assistant",
-                "content": content_text or None,
-                "tool_calls": assistant_tool_calls,
-            })
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": content_text or None,
+                    "tool_calls": assistant_tool_calls,
+                }
+            )
 
             for tc_entry in assistant_tool_calls:
                 tc_id = tc_entry["id"]
@@ -312,20 +330,27 @@ def main():
                 except (ValueError, json.JSONDecodeError):
                     func_args = {"raw": func_args_str}
 
-                print(f"[Wee] Tool: {func_name}({json.dumps(func_args)[:200]})", file=sys.stderr)
+                print(
+                    f"[Wee] Tool: {func_name}({json.dumps(func_args)[:200]})",
+                    file=sys.stderr,
+                )
 
                 tool_result = execute_tool(func_name, func_args)
 
-                messages.append({
-                    "role": "tool",
-                    "tool_call_id": tc_id,
-                    "content": tool_result or "No output",
-                })
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc_id,
+                        "content": tool_result or "No output",
+                    }
+                )
         else:
             # All rounds had tool calls with no final text
             last_results = [m["content"] for m in messages if m.get("role") == "tool"]
             if last_results:
-                fallback = "Tool execution completed. Last result:\n" + last_results[-1][:2000]
+                fallback = (
+                    "Tool execution completed. Last result:\n" + last_results[-1][:2000]
+                )
             else:
                 fallback = "Max tool rounds reached without final response."
             collected_output.append(fallback)


### PR DESCRIPTION
Closes #249

## Summary
- Extracts primary_runtime/primary_model from AGENTS dict on agent switch
- Applies defaults to session_map via set_agent()
- Exposes via /api/v1/agents endpoint
- 8 regression tests pass

## QA Status
✅ QA APPROVED Round 4 — flake8 CLEAN, 8/8 tests pass (commit 4541f27)