### PR TITLE
feat: change wee runtime icon to four leaf clover 🍀

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -871,7 +871,7 @@ def get_available_runtimes() -> List[Dict[str, str]]:
         {"id": "codex", "label": "codex"},
         {"id": "devin", "label": "devin"},
         {"id": "cursor", "label": "cursor", "icon": "🖱️"},
-        {"id": "wee", "label": "wee", "icon": "🌿"},
+        {"id": "wee", "label": "wee", "icon": "🍀"},
     ]
 
     available = [rt for rt in all_runtimes if check_runtime_available(rt["id"])]

--- a/tests/test_wee_native_runtime.py
+++ b/tests/test_wee_native_runtime.py
@@ -96,7 +96,7 @@ class TestWeeRuntimeRegistration(unittest.TestCase):
         runtimes = get_available_runtimes()
         wee_entry = next((r for r in runtimes if r["id"] == "wee"), None)
         self.assertIsNotNone(wee_entry)
-        self.assertEqual(wee_entry["icon"], "\U0001f33f")  # leaf
+        self.assertEqual(wee_entry["icon"], "\0001F340")  # leaf
 
     def test_wee_check_runtime_available(self):
         """check_runtime_available('wee') should return True (openai installed)."""

--- a/tests/test_wee_native_runtime.py
+++ b/tests/test_wee_native_runtime.py
@@ -96,7 +96,7 @@ class TestWeeRuntimeRegistration(unittest.TestCase):
         runtimes = get_available_runtimes()
         wee_entry = next((r for r in runtimes if r["id"] == "wee"), None)
         self.assertIsNotNone(wee_entry)
-        self.assertEqual(wee_entry["icon"], "\0001F340")  # leaf
+        self.assertEqual(wee_entry["icon"], "🍀")  # four leaf clover
 
     def test_wee_check_runtime_available(self):
         """check_runtime_available('wee') should return True (openai installed)."""


### PR DESCRIPTION
Closes #254

Changes the wee runtime icon from 🌿 to 🍀 in  in .

The icon is returned by the  endpoint and displayed in the WebUI runtime selector.