### PR TITLE
feat: add SearXNG search tool to Wee Runtime

### DIFF
--- a/tests/test_issue_255_search.py
+++ b/tests/test_issue_255_search.py
@@ -100,26 +100,30 @@ class TestExecuteSearch(unittest.TestCase):
 
     @patch("urllib.request.urlopen")
     def test_text_format_returns_summary(self, mock_urlopen):
-        mock_urlopen.return_value = self._fake_urlopen([
-            {
-                "title": "Claude AI",
-                "url": "https://example.com/claude",
-                "content": "Claude is an AI.",
-            },
-        ])
+        mock_urlopen.return_value = self._fake_urlopen(
+            [
+                {
+                    "title": "Claude AI",
+                    "url": "https://example.com/claude",
+                    "content": "Claude is an AI.",
+                },
+            ]
+        )
         result = _execute_search({"q": "Claude AI", "format": "text"})
         self.assertIn("Claude AI", result)
         self.assertIn("example.com", result)
 
     @patch("urllib.request.urlopen")
     def test_json_format_returns_valid_json(self, mock_urlopen):
-        mock_urlopen.return_value = self._fake_urlopen([
-            {
-                "title": "Claude AI",
-                "url": "https://example.com/claude",
-                "content": "Claude is an AI.",
-            },
-        ])
+        mock_urlopen.return_value = self._fake_urlopen(
+            [
+                {
+                    "title": "Claude AI",
+                    "url": "https://example.com/claude",
+                    "content": "Claude is an AI.",
+                },
+            ]
+        )
         result = _execute_search({"q": "Claude AI", "format": "json"})
         parsed = json.loads(result)
         self.assertIsInstance(parsed, list)
@@ -162,6 +166,7 @@ class TestExecuteSearch(unittest.TestCase):
     @patch("urllib.request.urlopen")
     def test_unavailable_searxng_returns_error_not_exception(self, mock_urlopen):
         import urllib.error
+
         mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
         result = _execute_search({"q": "test"})
         self.assertIn("Search unavailable", result)
@@ -183,6 +188,7 @@ class TestExecuteSearch(unittest.TestCase):
     def test_env_var_overrides_searxng_url(self):
         """WEE_SEARXNG_URL env var should be used if set."""
         import urllib.error
+
         with patch.dict(os.environ, {"WEE_SEARXNG_URL": "http://custom-host:9999"}):
             with patch("urllib.request.urlopen") as mock_urlopen:
                 mock_urlopen.side_effect = urllib.error.URLError("refused")

--- a/tests/test_issue_255_search.py
+++ b/tests/test_issue_255_search.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Tests for Issue #255: SearXNG search tool in Wee Runtime.
+
+Tests verify:
+- search tool is present in _WEE_TOOLS with correct schema
+- _execute_search returns graceful error when SearXNG is unavailable
+- _execute_search returns text format results correctly
+- _execute_search returns JSON format results correctly
+- _execute_search enforces count limit
+- execute_tool dispatches 'search' to _execute_search
+- _ANTI_HALLUCINATION_PROMPT and _WEE_TOOL_CAPABILITY_PROMPT are importable
+"""
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from wee_runtime import (
+    _ANTI_HALLUCINATION_PROMPT,
+    _WEE_TOOL_CAPABILITY_PROMPT,
+    _WEE_TOOLS,
+    _execute_search,
+    execute_tool,
+)
+
+
+class TestSearchToolDefinition(unittest.TestCase):
+    """Verify search tool schema is registered in _WEE_TOOLS."""
+
+    def _get_tool(self, name):
+        for t in _WEE_TOOLS:
+            if t["function"]["name"] == name:
+                return t
+        return None
+
+    def test_search_tool_exists(self):
+        tool = self._get_tool("search")
+        self.assertIsNotNone(tool, "search tool missing from _WEE_TOOLS")
+
+    def test_search_tool_type(self):
+        tool = self._get_tool("search")
+        self.assertEqual(tool["type"], "function")
+
+    def test_search_tool_has_q_parameter(self):
+        tool = self._get_tool("search")
+        props = tool["function"]["parameters"]["properties"]
+        self.assertIn("q", props)
+        self.assertEqual(props["q"]["type"], "string")
+
+    def test_search_tool_q_is_required(self):
+        tool = self._get_tool("search")
+        required = tool["function"]["parameters"].get("required", [])
+        self.assertIn("q", required)
+
+    def test_search_tool_has_count_parameter(self):
+        tool = self._get_tool("search")
+        props = tool["function"]["parameters"]["properties"]
+        self.assertIn("count", props)
+        self.assertEqual(props["count"]["type"], "integer")
+
+    def test_search_tool_has_format_parameter(self):
+        tool = self._get_tool("search")
+        props = tool["function"]["parameters"]["properties"]
+        self.assertIn("format", props)
+        self.assertIn("json", props["format"]["enum"])
+        self.assertIn("text", props["format"]["enum"])
+
+    def test_all_three_tools_present(self):
+        names = [t["function"]["name"] for t in _WEE_TOOLS]
+        self.assertIn("bash", names)
+        self.assertIn("python", names)
+        self.assertIn("search", names)
+
+
+class TestExecuteSearch(unittest.TestCase):
+    """Test _execute_search() behavior."""
+
+    def _fake_urlopen(self, results):
+        """Return a context manager mock that yields SearXNG-like JSON."""
+        import io
+        payload = json.dumps({"results": results}).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = payload
+        return mock_resp
+
+    def test_empty_query_returns_error(self):
+        result = _execute_search({"q": ""})
+        self.assertIn("Error", result)
+        self.assertIn("required", result)
+
+    def test_missing_query_returns_error(self):
+        result = _execute_search({})
+        self.assertIn("Error", result)
+
+    @patch("urllib.request.urlopen")
+    def test_text_format_returns_summary(self, mock_urlopen):
+        mock_urlopen.return_value = self._fake_urlopen([
+            {"title": "Claude AI", "url": "https://example.com/claude", "content": "Claude is an AI."},
+        ])
+        result = _execute_search({"q": "Claude AI", "format": "text"})
+        self.assertIn("Claude AI", result)
+        self.assertIn("example.com", result)
+
+    @patch("urllib.request.urlopen")
+    def test_json_format_returns_valid_json(self, mock_urlopen):
+        mock_urlopen.return_value = self._fake_urlopen([
+            {"title": "Claude AI", "url": "https://example.com/claude", "content": "Claude is an AI."},
+        ])
+        result = _execute_search({"q": "Claude AI", "format": "json"})
+        parsed = json.loads(result)
+        self.assertIsInstance(parsed, list)
+        self.assertEqual(parsed[0]["title"], "Claude AI")
+        self.assertEqual(parsed[0]["url"], "https://example.com/claude")
+
+    @patch("urllib.request.urlopen")
+    def test_count_limits_results(self, mock_urlopen):
+        many_results = [
+            {"title": f"Result {i}", "url": f"https://example.com/{i}", "content": f"Content {i}"}
+            for i in range(10)
+        ]
+        mock_urlopen.return_value = self._fake_urlopen(many_results)
+        result = _execute_search({"q": "test", "count": 3, "format": "json"})
+        parsed = json.loads(result)
+        self.assertEqual(len(parsed), 3)
+
+    @patch("urllib.request.urlopen")
+    def test_count_capped_at_20(self, mock_urlopen):
+        # Even if user requests 100, we cap at 20 in the query
+        many_results = [
+            {"title": f"R{i}", "url": f"https://ex.com/{i}", "content": ""}
+            for i in range(25)
+        ]
+        mock_urlopen.return_value = self._fake_urlopen(many_results)
+        result = _execute_search({"q": "test", "count": 100, "format": "json"})
+        parsed = json.loads(result)
+        self.assertLessEqual(len(parsed), 20)
+
+    @patch("urllib.request.urlopen")
+    def test_no_results_returns_graceful_message(self, mock_urlopen):
+        mock_urlopen.return_value = self._fake_urlopen([])
+        result = _execute_search({"q": "xyzzy_nonexistent_query_12345"})
+        self.assertIn("No results", result)
+
+    @patch("urllib.request.urlopen")
+    def test_unavailable_searxng_returns_error_not_exception(self, mock_urlopen):
+        import urllib.error
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        result = _execute_search({"q": "test"})
+        self.assertIn("Search unavailable", result)
+        # Should NOT raise — graceful degradation
+        self.assertIsInstance(result, str)
+
+    def test_result_under_2000_chars(self):
+        """Result must stay under 2000 chars to avoid context bloat."""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            # Inject a result with very long content
+            big_results = [
+                {"title": "X" * 500, "url": "https://example.com", "content": "Y" * 500}
+                for _ in range(20)
+            ]
+            mock_urlopen.return_value = self._fake_urlopen(big_results)
+            result = _execute_search({"q": "test", "count": 20, "format": "text"})
+            self.assertLessEqual(len(result), 2000)
+
+    def test_env_var_overrides_searxng_url(self):
+        """WEE_SEARXNG_URL env var should be used if set."""
+        import urllib.error
+        with patch.dict(os.environ, {"WEE_SEARXNG_URL": "http://custom-host:9999"}):
+            with patch("urllib.request.urlopen") as mock_urlopen:
+                mock_urlopen.side_effect = urllib.error.URLError("refused")
+                result = _execute_search({"q": "test"})
+                # Verify the custom URL was used (appears in the error message)
+                self.assertIn("custom-host:9999", result)
+
+
+class TestExecuteToolDispatching(unittest.TestCase):
+    """Verify execute_tool() dispatches 'search' correctly."""
+
+    @patch("wee_runtime._execute_search")
+    def test_execute_tool_calls_execute_search(self, mock_search):
+        mock_search.return_value = "mocked result"
+        result = execute_tool("search", {"q": "test query"})
+        mock_search.assert_called_once_with({"q": "test query"})
+        self.assertEqual(result, "mocked result")
+
+    def test_execute_tool_unknown_name(self):
+        result = execute_tool("nonexistent_tool", {})
+        self.assertIn("Unknown tool", result)
+
+
+class TestImports(unittest.TestCase):
+    """Verify symbols imported by wee_cli.py exist in wee_runtime."""
+
+    def test_anti_hallucination_prompt_is_string(self):
+        self.assertIsInstance(_ANTI_HALLUCINATION_PROMPT, str)
+        self.assertGreater(len(_ANTI_HALLUCINATION_PROMPT), 10)
+
+    def test_tool_capability_prompt_is_string(self):
+        self.assertIsInstance(_WEE_TOOL_CAPABILITY_PROMPT, str)
+        self.assertGreater(len(_WEE_TOOL_CAPABILITY_PROMPT), 10)
+
+    def test_tool_capability_prompt_mentions_search(self):
+        self.assertIn("search", _WEE_TOOL_CAPABILITY_PROMPT.lower())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_issue_255_search.py
+++ b/tests/test_issue_255_search.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from wee_runtime import (
+from wee_runtime import (  # noqa: E402
     _ANTI_HALLUCINATION_PROMPT,
     _WEE_TOOL_CAPABILITY_PROMPT,
     _WEE_TOOLS,
@@ -82,7 +82,6 @@ class TestExecuteSearch(unittest.TestCase):
 
     def _fake_urlopen(self, results):
         """Return a context manager mock that yields SearXNG-like JSON."""
-        import io
         payload = json.dumps({"results": results}).encode("utf-8")
         mock_resp = MagicMock()
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
@@ -102,7 +101,11 @@ class TestExecuteSearch(unittest.TestCase):
     @patch("urllib.request.urlopen")
     def test_text_format_returns_summary(self, mock_urlopen):
         mock_urlopen.return_value = self._fake_urlopen([
-            {"title": "Claude AI", "url": "https://example.com/claude", "content": "Claude is an AI."},
+            {
+                "title": "Claude AI",
+                "url": "https://example.com/claude",
+                "content": "Claude is an AI.",
+            },
         ])
         result = _execute_search({"q": "Claude AI", "format": "text"})
         self.assertIn("Claude AI", result)
@@ -111,7 +114,11 @@ class TestExecuteSearch(unittest.TestCase):
     @patch("urllib.request.urlopen")
     def test_json_format_returns_valid_json(self, mock_urlopen):
         mock_urlopen.return_value = self._fake_urlopen([
-            {"title": "Claude AI", "url": "https://example.com/claude", "content": "Claude is an AI."},
+            {
+                "title": "Claude AI",
+                "url": "https://example.com/claude",
+                "content": "Claude is an AI.",
+            },
         ])
         result = _execute_search({"q": "Claude AI", "format": "json"})
         parsed = json.loads(result)
@@ -122,7 +129,11 @@ class TestExecuteSearch(unittest.TestCase):
     @patch("urllib.request.urlopen")
     def test_count_limits_results(self, mock_urlopen):
         many_results = [
-            {"title": f"Result {i}", "url": f"https://example.com/{i}", "content": f"Content {i}"}
+            {
+                "title": f"Result {i}",
+                "url": f"https://example.com/{i}",
+                "content": f"Content {i}",
+            }
             for i in range(10)
         ]
         mock_urlopen.return_value = self._fake_urlopen(many_results)

--- a/wee_cli.py
+++ b/wee_cli.py
@@ -373,6 +373,11 @@ Wee CLI Interactive Mode — Commands:
   /version        Show version
   /help           Show this help
   exit, quit      Exit interactive mode
+
+Available tools (use --tools / -t to enable):
+  bash    Execute shell commands
+  python  Execute Python 3 code
+  search  Web search via SearXNG (WEE_SEARXNG_URL, default: http://192.168.1.100:8888)
 """
 
 
@@ -607,7 +612,7 @@ def build_parser() -> argparse.ArgumentParser:
         "-t",
         action="store_true",
         default=False,
-        help="Enable tool calling (bash, python)",
+        help="Enable tool calling (bash, python, search)",
     )
     parser.add_argument(
         "--permission",

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -13,11 +13,15 @@ Usage:
 """
 
 import argparse
+import re
 import json
 import os
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 
 # Provider presets: prefix → (api_base, default_api_key)
 PROVIDER_PRESETS = {
@@ -59,6 +63,32 @@ _WEE_TOOLS = [
                     }
                 },
                 "required": ["code"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "Search the web using SearXNG meta-search engine and return results.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "q": {
+                        "type": "string",
+                        "description": "Search query",
+                    },
+                    "count": {
+                        "type": "integer",
+                        "description": "Number of results to return (default: 5, max: 20)",
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "text"],
+                        "description": "Output format: 'json' returns structured results, 'text' returns a plain summary",
+                    },
+                },
+                "required": ["q"],
             },
         },
     },
@@ -112,6 +142,79 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
     return resolved_model, resolved_base, resolved_key
 
 
+SEARCH_TIMEOUT = 30  # seconds for SearXNG queries
+SEARCH_MAX_CHARS = 2000  # max result chars to avoid context bloat
+
+
+def _execute_search(func_args: dict) -> str:
+    """Handle search tool calls via SearXNG (Issue #255).
+
+    Queries the self-hosted SearXNG instance and returns results in the
+    requested format. Returns an empty result gracefully on failure rather
+    than raising an exception, to avoid breaking the agentic loop.
+
+    Args:
+        func_args: Dict with 'q' (required), 'count' (optional, default 5),
+                   'format' (optional: 'json'|'text', default 'text').
+    """
+    import json as _json
+
+    query = (func_args.get("q") or "").strip()
+    if not query:
+        return "Error: search query ('q') is required"
+
+    count = min(int(func_args.get("count") or 5), 20)
+    output_format = (func_args.get("format") or "text").lower()
+
+    searxng_url = os.environ.get("WEE_SEARXNG_URL", "http://192.168.1.100:8888")
+    searxng_url = searxng_url.rstrip("/")
+
+    params = urllib.parse.urlencode({
+        "q": query,
+        "format": "json",
+        "categories": "general",
+        "language": "en",
+    })
+    url = f"{searxng_url}/search?{params}"
+
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Wee-Runtime/1.0"})
+        with urllib.request.urlopen(req, timeout=SEARCH_TIMEOUT) as resp:
+            data = _json.loads(resp.read().decode("utf-8", errors="replace"))
+    except urllib.error.URLError as e:
+        return f"Search unavailable ({searxng_url}): {e.reason}"
+    except Exception as e:
+        return f"Search error: {e}"
+
+    results = data.get("results", [])[:count]
+    if not results:
+        return "No results found."
+
+    if output_format == "json":
+        slim = [
+            {
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "snippet": (r.get("content", "") or "")[:300],
+            }
+            for r in results
+        ]
+        raw = _json.dumps(slim, ensure_ascii=False)
+        return raw[:SEARCH_MAX_CHARS]
+
+    # Plain text summary
+    lines = [f"Search results for: {query}"]
+    for i, r in enumerate(results, 1):
+        title = r.get("title", "(no title)")
+        url_r = r.get("url", "")
+        snippet = (r.get("content", "") or "").strip()[:200]
+        lines.append(f"\n{i}. {title}\n   {url_r}\n   {snippet}")
+
+    summary = "\n".join(lines)
+    return summary[:SEARCH_MAX_CHARS]
+
+
+
 def execute_tool(func_name: str, func_args: dict) -> str:
     """Execute a tool call and return its output (Issue #107)."""
     try:
@@ -143,12 +246,67 @@ def execute_tool(func_name: str, func_args: dict) -> str:
             if result.returncode != 0 and result.stderr:
                 output += f"\nSTDERR: {result.stderr}"
             return output.strip() or "(no output)"
+        elif func_name == "search":
+            return _execute_search(func_args)
         else:
             return f"Error: Unknown tool {func_name}"
     except subprocess.TimeoutExpired:
         return f"Error: Tool {func_name} timed out after {TOOL_TIMEOUT}s"
     except Exception as e:
         return f"Error executing tool {func_name}: {e}"
+
+
+
+# SSH command sanitisation (Issue #113)
+_SSH_BIN_RE = re.compile(r"\b(ssh|scp|sftp)\b")
+
+
+def sanitize_bash_command(command: str) -> str:
+    """Auto-inject SSH flags to prevent host key verification failures.
+
+    Injects -o StrictHostKeyChecking=accept-new after ssh/scp/sftp
+    when the flag is not already present.
+    """
+    if not command or not _SSH_BIN_RE.search(command):
+        return command
+    if "StrictHostKeyChecking" in command:
+        return command
+
+    def _inject(m):
+        return m.group(0) + " -o StrictHostKeyChecking=accept-new"
+
+    return _SSH_BIN_RE.sub(_inject, command, count=0)
+
+
+
+# Anti-hallucination system prompt addendum (Issue #113)
+_ANTI_HALLUCINATION_PROMPT = (
+    "\n\n[CRITICAL — Output Integrity Rules]\n"
+    "1. NEVER fabricate, invent, or hallucinate command output. If a command "
+    "fails or you cannot execute it, report the EXACT error message.\n"
+    "2. NEVER provide example or placeholder output and present it as real. "
+    'If you show an example, clearly label it as "EXAMPLE (not real output)".\n'
+    "3. When a tool call returns an error, relay the error verbatim to the user. "
+    "Do NOT attempt to guess what the successful output would have looked like.\n"
+    "4. For SSH commands: ALWAYS use -o StrictHostKeyChecking=accept-new to "
+    "avoid host-key verification failures on first connect.\n"
+)
+
+# Explicit tool capability prompt for models that ignore JSON tool schemas (Issue #111)
+_WEE_TOOL_CAPABILITY_PROMPT = (
+    "\n\n[Tool Capabilities]\n"
+    "You have the following tools available. Use them to fulfil user requests.\n\n"
+    '1. **bash** — Execute shell commands. Parameters: {"command": "<shell command>"}\n'
+    "   Use this for: file operations, system commands, SSH, curl, git, etc.\n"
+    '2. **python** — Execute Python code. Parameters: {"code": "<python code>"}\n'
+    "   Use this for: data processing, calculations, scripting, etc.\n"
+    '3. **search** — Web search via SearXNG. Parameters: {"q": "<query>", "count": 5, "format": "text|json"}\n'
+    "   Use this for: current events, web lookups, product info, general knowledge queries.\n\n"
+    "IMPORTANT: You are NOT sandboxed. You CAN and SHOULD use these tools to execute\n"
+    "commands, SSH into remote hosts, read/write files, and interact with the system.\n"
+    "NEVER claim you cannot execute commands or are in a sandbox"
+    " — use the tools above.\n"
+)
 
 
 def main():
@@ -171,7 +329,7 @@ def main():
         "--tools",
         action="store_true",
         default=False,
-        help="Enable tool calling (bash, python)",
+        help="Enable tool calling (bash, python, search, call_agent)",
     )
     parser.add_argument("prompt", help="User prompt")
     args = parser.parse_args()

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -70,8 +70,7 @@ _WEE_TOOLS = [
         "function": {
             "name": "search",
             "description": (
-                "Search the web using SearXNG meta-search engine"
-                " and return results."
+                "Search the web using SearXNG meta-search engine" " and return results."
             ),
             "parameters": {
                 "type": "object",
@@ -177,12 +176,14 @@ def _execute_search(func_args: dict) -> str:
     searxng_url = os.environ.get("WEE_SEARXNG_URL", "http://192.168.1.100:8888")
     searxng_url = searxng_url.rstrip("/")
 
-    params = urllib.parse.urlencode({
-        "q": query,
-        "format": "json",
-        "categories": "general",
-        "language": "en",
-    })
+    params = urllib.parse.urlencode(
+        {
+            "q": query,
+            "format": "json",
+            "categories": "general",
+            "language": "en",
+        }
+    )
     url = f"{searxng_url}/search?{params}"
 
     try:

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -13,12 +13,11 @@ Usage:
 """
 
 import argparse
-import re
 import json
 import os
+import re
 import subprocess
 import sys
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -70,7 +69,10 @@ _WEE_TOOLS = [
         "type": "function",
         "function": {
             "name": "search",
-            "description": "Search the web using SearXNG meta-search engine and return results.",
+            "description": (
+                "Search the web using SearXNG meta-search engine"
+                " and return results."
+            ),
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -80,12 +82,17 @@ _WEE_TOOLS = [
                     },
                     "count": {
                         "type": "integer",
-                        "description": "Number of results to return (default: 5, max: 20)",
+                        "description": (
+                            "Number of results to return (default: 5, max: 20)"
+                        ),
                     },
                     "format": {
                         "type": "string",
                         "enum": ["json", "text"],
-                        "description": "Output format: 'json' returns structured results, 'text' returns a plain summary",
+                        "description": (
+                            "Output format: 'json' returns structured results,"
+                            " 'text' returns a plain summary"
+                        ),
                     },
                 },
                 "required": ["q"],
@@ -93,6 +100,7 @@ _WEE_TOOLS = [
         },
     },
 ]
+
 
 MAX_TOOL_ROUNDS = 10
 TOOL_TIMEOUT = 120  # seconds per tool execution
@@ -104,7 +112,8 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
     Model format: [provider/]model_name
     Examples:
         ollama/gemma4:e4b  → api_base=ollama preset, model=gemma4:e4b
-        openrouter/meta-llama/llama-4-scout → api_base=openrouter, model=meta-llama/llama-4-scout
+        openrouter/meta-llama/llama-4-scout → api_base=openrouter,
+            model=meta-llama/llama-4-scout
         gemma4:e4b         → use explicit api_base or default to ollama
     """
     resolved_model = model
@@ -142,7 +151,7 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
     return resolved_model, resolved_base, resolved_key
 
 
-SEARCH_TIMEOUT = 30  # seconds for SearXNG queries
+SEARCH_TIMEOUT = 10  # seconds for SearXNG queries
 SEARCH_MAX_CHARS = 2000  # max result chars to avoid context bloat
 
 
@@ -157,13 +166,12 @@ def _execute_search(func_args: dict) -> str:
         func_args: Dict with 'q' (required), 'count' (optional, default 5),
                    'format' (optional: 'json'|'text', default 'text').
     """
-    import json as _json
-
     query = (func_args.get("q") or "").strip()
     if not query:
         return "Error: search query ('q') is required"
 
-    count = min(int(func_args.get("count") or 5), 20)
+    count_raw = func_args.get("count")
+    count = min(int(count_raw if count_raw is not None else 5), 20)
     output_format = (func_args.get("format") or "text").lower()
 
     searxng_url = os.environ.get("WEE_SEARXNG_URL", "http://192.168.1.100:8888")
@@ -180,7 +188,7 @@ def _execute_search(func_args: dict) -> str:
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "Wee-Runtime/1.0"})
         with urllib.request.urlopen(req, timeout=SEARCH_TIMEOUT) as resp:
-            data = _json.loads(resp.read().decode("utf-8", errors="replace"))
+            data = json.loads(resp.read().decode("utf-8", errors="replace"))
     except urllib.error.URLError as e:
         return f"Search unavailable ({searxng_url}): {e.reason}"
     except Exception as e:
@@ -199,7 +207,7 @@ def _execute_search(func_args: dict) -> str:
             }
             for r in results
         ]
-        raw = _json.dumps(slim, ensure_ascii=False)
+        raw = json.dumps(slim, ensure_ascii=False)
         return raw[:SEARCH_MAX_CHARS]
 
     # Plain text summary
@@ -212,7 +220,6 @@ def _execute_search(func_args: dict) -> str:
 
     summary = "\n".join(lines)
     return summary[:SEARCH_MAX_CHARS]
-
 
 
 def execute_tool(func_name: str, func_args: dict) -> str:
@@ -256,7 +263,6 @@ def execute_tool(func_name: str, func_args: dict) -> str:
         return f"Error executing tool {func_name}: {e}"
 
 
-
 # SSH command sanitisation (Issue #113)
 _SSH_BIN_RE = re.compile(r"\b(ssh|scp|sftp)\b")
 
@@ -276,7 +282,6 @@ def sanitize_bash_command(command: str) -> str:
         return m.group(0) + " -o StrictHostKeyChecking=accept-new"
 
     return _SSH_BIN_RE.sub(_inject, command, count=0)
-
 
 
 # Anti-hallucination system prompt addendum (Issue #113)
@@ -300,8 +305,10 @@ _WEE_TOOL_CAPABILITY_PROMPT = (
     "   Use this for: file operations, system commands, SSH, curl, git, etc.\n"
     '2. **python** — Execute Python code. Parameters: {"code": "<python code>"}\n'
     "   Use this for: data processing, calculations, scripting, etc.\n"
-    '3. **search** — Web search via SearXNG. Parameters: {"q": "<query>", "count": 5, "format": "text|json"}\n'
-    "   Use this for: current events, web lookups, product info, general knowledge queries.\n\n"
+    "3. **search** — Web search via SearXNG."
+    ' Parameters: {"q": "<query>", "count": 5, "format": "text|json"}\n'
+    "   Use this for: current events, web lookups, product info,"
+    " general knowledge queries.\n\n"
     "IMPORTANT: You are NOT sandboxed. You CAN and SHOULD use these tools to execute\n"
     "commands, SSH into remote hosts, read/write files, and interact with the system.\n"
     "NEVER claim you cannot execute commands or are in a sandbox"
@@ -329,7 +336,7 @@ def main():
         "--tools",
         action="store_true",
         default=False,
-        help="Enable tool calling (bash, python, search, call_agent)",
+        help="Enable tool calling (bash, python, search)",
     )
     parser.add_argument("prompt", help="User prompt")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

Implements native `search()` tool in Wee Runtime using SearXNG meta-search engine.

## Changes
- **wee_runtime.py**: Added `search` tool to `_WEE_TOOLS` with `q`, `count`, `format` params
- **wee_runtime.py**: Implemented `_execute_search()` that queries SearXNG JSON API
- **wee_runtime.py**: SearXNG URL via `WEE_SEARXNG_URL` env var (default: http://192.168.1.100:8888)
- **wee_runtime.py**: Added `_ANTI_HALLUCINATION_PROMPT`, `_WEE_TOOL_CAPABILITY_PROMPT`, `sanitize_bash_command`, `_SSH_BIN_RE` (imported by wee_cli and existing tests)
- **wee_cli.py**: Updated help text to list search as available tool
- **tests/test_issue_255_search.py**: 22 unit tests (all passing)

## Acceptance Criteria
- [x] `search` tool definition in `_WEE_TOOLS` with q, count, format params
- [x] Search handler queries SearXNG instance
- [x] SearXNG URL from `WEE_SEARXNG_URL` env var (default: http://192.168.1.100:8888)
- [x] Results in JSON array or plain text summary
- [x] Error handling: graceful fallback (no exception) on unavailability/timeout
- [x] wee_cli.py updated with search tool in help text
- [x] 22 unit tests passing

Closes #255