### PR TITLE
fix(webex): add rabbitmq_queue_passive flag for CONSUME-only AMQP brokers

### DIFF
--- a/config_schemas.py
+++ b/config_schemas.py
@@ -214,6 +214,7 @@ _WEBEX_KNOWN = {
     "rabbitmq_ssl_verify",
     "rabbitmq_host_ip",
     "rabbitmq_payload_key",
+    "rabbitmq_queue_passive",
     "allowed_users",
     "user_pairings",
     "enable_auto_pair",
@@ -243,6 +244,7 @@ class WebEXConfigSchema(BaseModel):
     rabbitmq_ssl_verify: Optional[bool] = True
     rabbitmq_host_ip: Optional[str] = None
     rabbitmq_payload_key: Optional[str] = None
+    rabbitmq_queue_passive: bool = False
     allowed_users: List[str] = Field(default_factory=list)
     user_pairings: Dict[str, Any] = Field(default_factory=dict)
     enable_auto_pair: bool = False

--- a/tests/test_issue_267_webex_passive_queue.py
+++ b/tests/test_issue_267_webex_passive_queue.py
@@ -1,4 +1,5 @@
-"""Regression test for Issue #267: webex_connector.py queue_declare() without passive flag.
+"""Regression test for Issue #267: webex_connector.py queue_declare()
+without passive flag.
 
 On hosted AMQP brokers where the bot user only has CONSUME permission, calling
 queue_declare() without passive=True raises ACCESS_REFUSED and kills the connection.
@@ -12,16 +13,14 @@ import json
 import os
 import sys
 import tempfile
-import threading
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _stub_modules():
     """Inject lightweight stubs for heavy imports so webex_connector can load."""
@@ -63,7 +62,7 @@ def _make_config(queue_passive=None, tmp_path=None):
 
 def _make_connector(queue_passive=None):
     """Return a WebEXConnector with mocked config for queue_declare tests."""
-    from webex_connector import WebEXConnector, WebEXConfig
+    from webex_connector import WebEXConfig, WebEXConnector
 
     connector = WebEXConnector.__new__(WebEXConnector)
     connector.config = MagicMock(spec=WebEXConfig)
@@ -101,10 +100,13 @@ def _run_connect(connector, mock_channel):
     mock_connection.is_closed = False
     mock_connection.channel.return_value = mock_channel
 
-    with patch("webex_connector.pika.BlockingConnection", return_value=mock_connection), \
-         patch("webex_connector.pika.ConnectionParameters"), \
-         patch("webex_connector.pika.PlainCredentials"), \
-         patch("webex_connector.pika.SSLOptions"):
+    with patch(
+        "webex_connector.pika.BlockingConnection", return_value=mock_connection
+    ), patch("webex_connector.pika.ConnectionParameters"), patch(
+        "webex_connector.pika.PlainCredentials"
+    ), patch(
+        "webex_connector.pika.SSLOptions"
+    ):
         connector.shutdown_event.wait.return_value = False
         result = connector.connect_rabbitmq()
 
@@ -172,16 +174,17 @@ class TestIssue267PassiveQueueDeclare:
         mock_channel = MagicMock()
         mock_channel.queue_declare.side_effect = pika.exceptions.ChannelClosedByBroker(
             403,
-            "ACCESS_REFUSED - access to queue 'webex' in vhost '/' refused for user 'bot'",
+            "ACCESS_REFUSED - access to queue 'webex' in vhost '/' refused for user 'bot'",  # noqa: E501
         )
 
         result, _ = _run_connect(connector, mock_channel)
-        assert result is False, (
-            "Connection must fail when queue_declare raises ACCESS_REFUSED"
-        )
+        assert (
+            result is False
+        ), "Connection must fail when queue_declare raises ACCESS_REFUSED"
 
     def test_passive_declare_succeeds_on_consume_only_broker(self):
-        """passive=True + no ACCESS_REFUSED → connect succeeds on CONSUME-only broker."""
+        """passive=True + no ACCESS_REFUSED → connect succeeds on CONSUME-only
+        broker."""
         connector = _make_connector(queue_passive=True)
         mock_channel = MagicMock()
         mock_channel.queue_declare.return_value = MagicMock()  # passive declare OK
@@ -208,12 +211,12 @@ class TestIssue267DefaultConfigKey:
 
         cfg = WebEXConfig(str(config_file))
 
-        assert "rabbitmq_queue_passive" in cfg.config, (
-            "rabbitmq_queue_passive must be present in default config"
-        )
-        assert cfg.config["rabbitmq_queue_passive"] is False, (
-            "Default must be False to preserve existing (non-passive) behavior"
-        )
+        assert (
+            "rabbitmq_queue_passive" in cfg.config
+        ), "rabbitmq_queue_passive must be present in default config"
+        assert (
+            cfg.config["rabbitmq_queue_passive"] is False
+        ), "Default must be False to preserve existing (non-passive) behavior"
 
     def test_passive_key_persisted_from_file(self, tmp_path):
         """rabbitmq_queue_passive=true in config file is read and respected."""

--- a/tests/test_issue_267_webex_passive_queue.py
+++ b/tests/test_issue_267_webex_passive_queue.py
@@ -1,0 +1,233 @@
+"""Regression test for Issue #267: webex_connector.py queue_declare() without passive flag.
+
+On hosted AMQP brokers where the bot user only has CONSUME permission, calling
+queue_declare() without passive=True raises ACCESS_REFUSED and kills the connection.
+
+The fix adds a rabbitmq_queue_passive config flag. When True, queue_declare() is
+called with passive=True (assert-only, no create attempt). Default is False to
+preserve existing behavior.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _stub_modules():
+    """Inject lightweight stubs for heavy imports so webex_connector can load."""
+    for mod in ("agent_manager", "audio_transcriber"):
+        if mod not in sys.modules:
+            sys.modules[mod] = MagicMock()
+
+
+_stub_modules()
+
+
+def _make_config(queue_passive=None, tmp_path=None):
+    """Write a minimal webex_config.json and return a WebEXConfig object."""
+    from webex_connector import WebEXConfig
+
+    cfg_data = {
+        "token": "test-token",
+        "rabbitmq_host": "localhost",
+        "rabbitmq_port": 5672,
+        "rabbitmq_user": "guest",
+        "rabbitmq_password": "guest",
+        "rabbitmq_queue": "webex",
+        "rabbitmq_vhost": "/",
+    }
+    if queue_passive is not None:
+        cfg_data["rabbitmq_queue_passive"] = queue_passive
+
+    if tmp_path is None:
+        tmp_dir = tempfile.mkdtemp()
+        config_path = os.path.join(tmp_dir, "webex_config.json")
+    else:
+        config_path = os.path.join(str(tmp_path), "webex_config.json")
+
+    with open(config_path, "w") as f:
+        json.dump(cfg_data, f)
+
+    return WebEXConfig(config_path)
+
+
+def _make_connector(queue_passive=None):
+    """Return a WebEXConnector with mocked config for queue_declare tests."""
+    from webex_connector import WebEXConnector, WebEXConfig
+
+    connector = WebEXConnector.__new__(WebEXConnector)
+    connector.config = MagicMock(spec=WebEXConfig)
+    cfg = {
+        "rabbitmq_host": "localhost",
+        "rabbitmq_host_ip": None,
+        "rabbitmq_port": 5672,
+        "rabbitmq_user": "guest",
+        "rabbitmq_password": "guest",
+        "rabbitmq_vhost": "/",
+        "rabbitmq_queue": "webex",
+        "rabbitmq_ssl": False,
+        "rabbitmq_ssl_verify": True,
+    }
+    if queue_passive is not None:
+        cfg["rabbitmq_queue_passive"] = queue_passive
+    connector.config.config = cfg
+    connector.shutdown_event = MagicMock()
+    connector.shutdown_event.is_set.return_value = False
+    connector.rabbitmq_connection = None
+    connector.rabbitmq_channel = None
+    return connector
+
+
+def _run_connect(connector, mock_channel):
+    """Invoke connect_rabbitmq() with a fully mocked pika stack.
+
+    connect_rabbitmq() spawns a daemon thread that calls pika.BlockingConnection
+    and then signals a threading.Event. We patch BlockingConnection so it returns
+    a mock connection immediately.
+    """
+    import pika as real_pika  # noqa: F401 — we patch at module level below
+
+    mock_connection = MagicMock()
+    mock_connection.is_closed = False
+    mock_connection.channel.return_value = mock_channel
+
+    with patch("webex_connector.pika.BlockingConnection", return_value=mock_connection), \
+         patch("webex_connector.pika.ConnectionParameters"), \
+         patch("webex_connector.pika.PlainCredentials"), \
+         patch("webex_connector.pika.SSLOptions"):
+        connector.shutdown_event.wait.return_value = False
+        result = connector.connect_rabbitmq()
+
+    return result, mock_channel
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestIssue267PassiveQueueDeclare:
+    """Verify queue_declare() uses passive flag according to config."""
+
+    def test_default_config_uses_active_declare(self):
+        """Without rabbitmq_queue_passive, queue_declare is called with durable=True."""
+        connector = _make_connector()  # no passive key → .get() returns False
+        mock_channel = MagicMock()
+
+        result, ch = _run_connect(connector, mock_channel)
+
+        assert result is True
+        ch.queue_declare.assert_called_once_with(queue="webex", durable=True)
+
+    def test_passive_false_uses_active_declare(self):
+        """rabbitmq_queue_passive=False → queue_declare with durable=True."""
+        connector = _make_connector(queue_passive=False)
+        mock_channel = MagicMock()
+
+        result, ch = _run_connect(connector, mock_channel)
+
+        assert result is True
+        ch.queue_declare.assert_called_once_with(queue="webex", durable=True)
+
+    def test_passive_true_uses_passive_declare(self):
+        """rabbitmq_queue_passive=True → queue_declare with passive=True only.
+
+        This is the core fix for Issue #267: hosted brokers with CONSUME-only
+        permissions reject any queue_declare that includes durable= or other
+        config args. passive=True performs a read-only assertion.
+        """
+        connector = _make_connector(queue_passive=True)
+        mock_channel = MagicMock()
+
+        result, ch = _run_connect(connector, mock_channel)
+
+        assert result is True
+        ch.queue_declare.assert_called_once_with(queue="webex", passive=True)
+        # Critically: durable must NOT be passed alongside passive
+        _, kwargs = ch.queue_declare.call_args
+        assert "durable" not in kwargs, (
+            "durable must not be passed with passive=True — "
+            "would raise ACCESS_REFUSED on a CONSUME-only broker"
+        )
+
+    def test_access_refused_without_passive_fails(self):
+        """Active declare raises ACCESS_REFUSED → connect_rabbitmq returns False.
+
+        This reproduces the pre-fix failure path: without passive=True, a
+        CONSUME-only broker returns 403 ACCESS_REFUSED on queue_declare.
+        """
+        import pika.exceptions
+
+        connector = _make_connector(queue_passive=False)
+        mock_channel = MagicMock()
+        mock_channel.queue_declare.side_effect = pika.exceptions.ChannelClosedByBroker(
+            403,
+            "ACCESS_REFUSED - access to queue 'webex' in vhost '/' refused for user 'bot'",
+        )
+
+        result, _ = _run_connect(connector, mock_channel)
+        assert result is False, (
+            "Connection must fail when queue_declare raises ACCESS_REFUSED"
+        )
+
+    def test_passive_declare_succeeds_on_consume_only_broker(self):
+        """passive=True + no ACCESS_REFUSED → connect succeeds on CONSUME-only broker."""
+        connector = _make_connector(queue_passive=True)
+        mock_channel = MagicMock()
+        mock_channel.queue_declare.return_value = MagicMock()  # passive declare OK
+
+        result, ch = _run_connect(connector, mock_channel)
+
+        assert result is True
+        ch.queue_declare.assert_called_once_with(queue="webex", passive=True)
+
+
+class TestIssue267DefaultConfigKey:
+    """Verify rabbitmq_queue_passive is present in _default_config with safe default."""
+
+    def test_default_config_has_passive_key_false(self, tmp_path):
+        """_default_config must include rabbitmq_queue_passive defaulting to False.
+
+        Default must be False to preserve existing behavior for operators who
+        haven't set the flag explicitly.
+        """
+        from webex_connector import WebEXConfig
+
+        config_file = tmp_path / "webex_config.json"
+        config_file.write_text(json.dumps({}))  # empty — triggers _default_config
+
+        cfg = WebEXConfig(str(config_file))
+
+        assert "rabbitmq_queue_passive" in cfg.config, (
+            "rabbitmq_queue_passive must be present in default config"
+        )
+        assert cfg.config["rabbitmq_queue_passive"] is False, (
+            "Default must be False to preserve existing (non-passive) behavior"
+        )
+
+    def test_passive_key_persisted_from_file(self, tmp_path):
+        """rabbitmq_queue_passive=true in config file is read and respected."""
+        from webex_connector import WebEXConfig
+
+        config_file = tmp_path / "webex_config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "token": "t",
+                    "rabbitmq_queue_passive": True,
+                }
+            )
+        )
+
+        cfg = WebEXConfig(str(config_file))
+        assert cfg.config.get("rabbitmq_queue_passive") is True

--- a/webex_connector.py
+++ b/webex_connector.py
@@ -45,7 +45,7 @@ class WebEXConfig(BaseConfig):
             "rabbitmq_password": os.environ.get("RABBITMQ_PASSWORD", ""),
             "rabbitmq_queue": os.environ.get("RABBITMQ_QUEUE", "webex"),
             "rabbitmq_vhost": "/",
-            "rabbitmq_queue_passive": False,  # Set True for brokers where bot only has CONSUME permission
+            "rabbitmq_queue_passive": False,  # Set True for brokers where bot only has CONSUME permission  # noqa: E501
             "allowed_users": [],  # List of WebEX person IDs allowed to chat
             "user_pairings": {},  # Maps WebEX person ID to session info
             "enable_auto_pair": False,  # Auto-pair new users

--- a/webex_connector.py
+++ b/webex_connector.py
@@ -45,6 +45,7 @@ class WebEXConfig(BaseConfig):
             "rabbitmq_password": os.environ.get("RABBITMQ_PASSWORD", ""),
             "rabbitmq_queue": os.environ.get("RABBITMQ_QUEUE", "webex"),
             "rabbitmq_vhost": "/",
+            "rabbitmq_queue_passive": False,  # Set True for brokers where bot only has CONSUME permission
             "allowed_users": [],  # List of WebEX person IDs allowed to chat
             "user_pairings": {},  # Maps WebEX person ID to session info
             "enable_auto_pair": False,  # Auto-pair new users
@@ -285,9 +286,15 @@ class WebEXConnector(BaseConnector):
                         result["connected"] = False
                         return
 
-                    channel.queue_declare(
-                        queue=self.config.config["rabbitmq_queue"], durable=True
-                    )
+                    passive = self.config.config.get("rabbitmq_queue_passive", False)
+                    if passive:
+                        channel.queue_declare(
+                            queue=self.config.config["rabbitmq_queue"], passive=True
+                        )
+                    else:
+                        channel.queue_declare(
+                            queue=self.config.config["rabbitmq_queue"], durable=True
+                        )
                     channel.basic_qos(prefetch_count=1)
 
                     if self.shutdown_event.is_set():


### PR DESCRIPTION
## Summary

- Adds `rabbitmq_queue_passive` config flag to `WebEXConfig` (default `false`, preserves current behavior)
- When `true`, `queue_declare()` is called with `passive=True` — performs a read-only assertion instead of trying to create/modify the queue
- Registers the new key in `config_schemas.py` `WebEXConfigSchema` so it validates correctly and defaults properly
- Adds 7 regression tests covering: default behavior, explicit false/true, ACCESS_REFUSED simulation, and config schema

## Root cause

`connect_rabbitmq()` called `channel.queue_declare(queue=..., durable=True)` unconditionally. On managed AMQP gateways (e.g. `ascension-amqp-aas.cisco.com` / Cisco CX-HOSTED-BOTS-PROD) where the bot user has only CONSUME permission, the broker responds with `ACCESS_REFUSED (403)` and kills the connection.

## Config usage

```json
{
  "rabbitmq_queue_passive": true
}
```

Set this in `webex_config.json` when connecting to hosted AMQP brokers where you don't have queue configure/create permissions.

## Test plan
- [x] `tests/test_issue_267_webex_passive_queue.py` — 7 tests, all passing
- [x] Default behavior unchanged (passive=false by default)
- [x] ACCESS_REFUSED simulation test confirms pre-fix failure path
- [x] passive=true succeeds on mocked CONSUME-only broker

Closes #267

🤖 Generated with [Claude Code](https://claude.ai/claude-code)