### PR TITLE
fix: nested payload unwrap support for WebEX gateways

### DIFF
--- a/tests/test_issue_268_nested_payload_unwrap.py
+++ b/tests/test_issue_268_nested_payload_unwrap.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
-import os
-sys.path.insert(0, '/opt/n8n-copilot-shim-dev')
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 
 from webex_connector import WebEXConnector
 
@@ -9,22 +9,18 @@ from webex_connector import WebEXConnector
 class TestNestedPayloadUnwrap:
     """Regression tests for issue #268: nested payload unwrap support."""
 
-    def test_unwrap_single_level_payload(self):
+    def test_issue_268_unwrap_single_level_payload(self):
         """Test unwrapping a single-level envelope."""
         payload = {
             "event": "messages",
-            "data": {
-                "personId": "ABC",
-                "roomId": "ROOM123",
-                "text": "hello"
-            }
+            "data": {"personId": "ABC", "roomId": "ROOM123", "text": "hello"},
         }
         result = WebEXConnector._unwrap_payload(payload, "data")
         assert result["personId"] == "ABC"
         assert result["roomId"] == "ROOM123"
         assert result["text"] == "hello"
 
-    def test_unwrap_double_wrapped_with_message_data(self):
+    def test_issue_268_unwrap_double_wrapped_with_message_data(self):
         """Test unwrapping double-wrapped payload with message_data."""
         payload = {
             "event": "messages",
@@ -34,65 +30,58 @@ class TestNestedPayloadUnwrap:
                 "roomId": "ROOM123",
                 "message_data": {
                     "text": "hello",
-                }
-            }
+                },
+            },
         }
         result = WebEXConnector._unwrap_payload(payload, "data")
         assert result["text"] == "hello"
         assert "personId" not in result
 
-    def test_unwrap_dotted_path(self):
+    def test_issue_268_unwrap_dotted_path(self):
         """Test unwrapping with dotted path notation."""
         payload = {
             "event": "messages",
-            "wrapper": {
-                "data": {
-                    "personId": "ABC",
-                    "message_data": {
-                        "text": "world"
-                    }
-                }
-            }
+            "wrapper": {"data": {"personId": "ABC", "message_data": {"text": "world"}}},
         }
         result = WebEXConnector._unwrap_payload(payload, "wrapper.data.message_data")
         assert result["text"] == "world"
 
-    def test_no_unwrap_when_no_key_provided(self):
+    def test_issue_268_no_unwrap_when_no_key_provided(self):
         """Test that payload is returned as-is when no key is provided."""
-        payload = {
-            "personId": "ABC",
-            "roomId": "ROOM123",
-            "text": "direct"
-        }
+        payload = {"personId": "ABC", "roomId": "ROOM123", "text": "direct"}
         result = WebEXConnector._unwrap_payload(payload)
         assert result == payload
 
-    def test_auto_unwrap_message_data_after_primary(self):
-        """Test auto-unwrapping of message_data after primary unwrap."""
+    def test_issue_268_no_unwrap_message_data_without_key(self):
+        """Test MAJOR regression: payload_key=None must not auto-unwrap message_data.
+
+        A payload that happens to contain a top-level 'message_data' dict must
+        be returned unchanged when no payload_key is configured.
+        """
         payload = {
-            "data": {
-                "nested": {
-                    "message_data": {
-                        "text": "nested"
-                    }
-                }
-            }
+            "personId": "ABC",
+            "text": "direct message",
+            "message_data": {"meta": "extra info"},
         }
+        result = WebEXConnector._unwrap_payload(payload)
+        assert result == payload
+        assert result["personId"] == "ABC"
+        assert result["text"] == "direct message"
+
+    def test_issue_268_auto_unwrap_message_data_after_primary(self):
+        """Test auto-unwrapping of message_data after primary unwrap."""
+        payload = {"data": {"nested": {"message_data": {"text": "nested"}}}}
         result = WebEXConnector._unwrap_payload(payload, "data.nested")
         assert result["text"] == "nested"
 
-    def test_stop_at_max_depth(self):
+    def test_issue_268_stop_at_max_depth(self):
         """Test that unwrapping stops at max_depth to prevent infinite loops."""
         payload = {
             "data": {
                 "message_data": {
                     "message_data": {
                         "message_data": {
-                            "message_data": {
-                                "message_data": {
-                                    "text": "too deep"
-                                }
-                            }
+                            "message_data": {"message_data": {"text": "too deep"}}
                         }
                     }
                 }
@@ -103,34 +92,24 @@ class TestNestedPayloadUnwrap:
         assert "text" not in result
         assert "message_data" in result
 
-    def test_partial_path_fallback(self):
+    def test_issue_268_partial_path_fallback(self):
         """Test fallback when dotted path doesn't fully exist."""
-        payload = {
-            "data": {
-                "personId": "ABC",
-                "roomId": "ROOM123",
-                "text": "fallback"
-            }
-        }
+        payload = {"data": {"personId": "ABC", "roomId": "ROOM123", "text": "fallback"}}
         # Path is "data.nonexistent" but only "data" exists
         result = WebEXConnector._unwrap_payload(payload, "data.nonexistent")
         # Should stop at "data" and return what's there
         assert result["personId"] == "ABC"
         assert result["text"] == "fallback"
 
-    def test_non_dict_payload_returns_as_is(self):
+    def test_issue_268_non_dict_payload_returns_as_is(self):
         """Test that non-dict payloads are returned unchanged."""
         payload = "not a dict"
         result = WebEXConnector._unwrap_payload(payload, "data")
         assert result == payload
 
-    def test_key_not_in_payload(self):
+    def test_issue_268_key_not_in_payload(self):
         """Test payload when specified key doesn't exist."""
-        payload = {
-            "event": "messages",
-            "personId": "ABC",
-            "text": "hello"
-        }
+        payload = {"event": "messages", "personId": "ABC", "text": "hello"}
         result = WebEXConnector._unwrap_payload(payload, "data")
         # Should return payload as-is since key not found
         assert result == payload

--- a/tests/test_issue_268_nested_payload_unwrap.py
+++ b/tests/test_issue_268_nested_payload_unwrap.py
@@ -1,0 +1,140 @@
+import pytest
+import sys
+import os
+sys.path.insert(0, '/opt/n8n-copilot-shim-dev')
+
+from webex_connector import WebEXConnector
+
+
+class TestNestedPayloadUnwrap:
+    """Regression tests for issue #268: nested payload unwrap support."""
+
+    def test_unwrap_single_level_payload(self):
+        """Test unwrapping a single-level envelope."""
+        payload = {
+            "event": "messages",
+            "data": {
+                "personId": "ABC",
+                "roomId": "ROOM123",
+                "text": "hello"
+            }
+        }
+        result = WebEXConnector._unwrap_payload(payload, "data")
+        assert result["personId"] == "ABC"
+        assert result["roomId"] == "ROOM123"
+        assert result["text"] == "hello"
+
+    def test_unwrap_double_wrapped_with_message_data(self):
+        """Test unwrapping double-wrapped payload with message_data."""
+        payload = {
+            "event": "messages",
+            "resource": "messages",
+            "data": {
+                "personId": "ABC",
+                "roomId": "ROOM123",
+                "message_data": {
+                    "text": "hello",
+                }
+            }
+        }
+        result = WebEXConnector._unwrap_payload(payload, "data")
+        assert result["text"] == "hello"
+        assert "personId" not in result
+
+    def test_unwrap_dotted_path(self):
+        """Test unwrapping with dotted path notation."""
+        payload = {
+            "event": "messages",
+            "wrapper": {
+                "data": {
+                    "personId": "ABC",
+                    "message_data": {
+                        "text": "world"
+                    }
+                }
+            }
+        }
+        result = WebEXConnector._unwrap_payload(payload, "wrapper.data.message_data")
+        assert result["text"] == "world"
+
+    def test_no_unwrap_when_no_key_provided(self):
+        """Test that payload is returned as-is when no key is provided."""
+        payload = {
+            "personId": "ABC",
+            "roomId": "ROOM123",
+            "text": "direct"
+        }
+        result = WebEXConnector._unwrap_payload(payload)
+        assert result == payload
+
+    def test_auto_unwrap_message_data_after_primary(self):
+        """Test auto-unwrapping of message_data after primary unwrap."""
+        payload = {
+            "data": {
+                "nested": {
+                    "message_data": {
+                        "text": "nested"
+                    }
+                }
+            }
+        }
+        result = WebEXConnector._unwrap_payload(payload, "data.nested")
+        assert result["text"] == "nested"
+
+    def test_stop_at_max_depth(self):
+        """Test that unwrapping stops at max_depth to prevent infinite loops."""
+        payload = {
+            "data": {
+                "message_data": {
+                    "message_data": {
+                        "message_data": {
+                            "message_data": {
+                                "message_data": {
+                                    "text": "too deep"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = WebEXConnector._unwrap_payload(payload, "data", max_depth=2)
+        # Should stop at depth 2, not reach the "text" field
+        assert "text" not in result
+        assert "message_data" in result
+
+    def test_partial_path_fallback(self):
+        """Test fallback when dotted path doesn't fully exist."""
+        payload = {
+            "data": {
+                "personId": "ABC",
+                "roomId": "ROOM123",
+                "text": "fallback"
+            }
+        }
+        # Path is "data.nonexistent" but only "data" exists
+        result = WebEXConnector._unwrap_payload(payload, "data.nonexistent")
+        # Should stop at "data" and return what's there
+        assert result["personId"] == "ABC"
+        assert result["text"] == "fallback"
+
+    def test_non_dict_payload_returns_as_is(self):
+        """Test that non-dict payloads are returned unchanged."""
+        payload = "not a dict"
+        result = WebEXConnector._unwrap_payload(payload, "data")
+        assert result == payload
+
+    def test_key_not_in_payload(self):
+        """Test payload when specified key doesn't exist."""
+        payload = {
+            "event": "messages",
+            "personId": "ABC",
+            "text": "hello"
+        }
+        result = WebEXConnector._unwrap_payload(payload, "data")
+        # Should return payload as-is since key not found
+        assert result == payload
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_issue_268_nested_payload_unwrap.py
+++ b/tests/test_issue_268_nested_payload_unwrap.py
@@ -115,5 +115,22 @@ class TestNestedPayloadUnwrap:
         assert result == payload
 
 
+
+    def test_issue_268_no_auto_unwrap_when_primary_key_absent(self):
+        """Test MAJOR bug fix: no auto-unwrap when payload_key configured but absent.
+        
+        When payload_key="data" configured but key not found, and payload has
+        top-level message_data, auto-unwrap (Step 2) must NOT fire.
+        """
+        payload = {
+            "personId": "ABC",
+            "text": "real message",
+            "message_data": {"meta": "x"},
+        }
+        result = WebEXConnector._unwrap_payload(payload, payload_key="data")
+        assert result == payload
+        assert result["personId"] == "ABC"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_issue_268_nested_payload_unwrap.py
+++ b/tests/test_issue_268_nested_payload_unwrap.py
@@ -114,11 +114,9 @@ class TestNestedPayloadUnwrap:
         # Should return payload as-is since key not found
         assert result == payload
 
-
-
     def test_issue_268_no_auto_unwrap_when_primary_key_absent(self):
         """Test MAJOR bug fix: no auto-unwrap when payload_key configured but absent.
-        
+
         When payload_key="data" configured but key not found, and payload has
         top-level message_data, auto-unwrap (Step 2) must NOT fire.
         """

--- a/webex_connector.py
+++ b/webex_connector.py
@@ -16,7 +16,7 @@ import threading
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import unquote
 
 import pika
@@ -1057,9 +1057,10 @@ class WebEXConnector(BaseConnector):
             )
             self.send_file(room_id, file_path, caption)
 
-
     @staticmethod
-    def _unwrap_payload(payload: Dict, payload_key: Optional[str] = None, max_depth: int = 4) -> Dict:
+    def _unwrap_payload(
+        payload: Dict, payload_key: Optional[str] = None, max_depth: int = 4
+    ) -> Any:
         """
         Unwrap nested payload structures from RabbitMQ messages.
 
@@ -1075,6 +1076,10 @@ class WebEXConnector(BaseConnector):
 
         Returns:
             The unwrapped payload dict
+
+        Note:
+            max_depth limits only the Step 2 auto-unwrap loop; dotted-path
+            traversal in Step 1 is not depth-limited.
         """
         if not isinstance(payload, dict):
             return payload
@@ -1087,23 +1092,27 @@ class WebEXConnector(BaseConnector):
             # Support dotted paths: "data.message_data" -> ["data", "message_data"]
             keys = payload_key.split(".")
             for key in keys:
-                if isinstance(current, dict) and key in current and isinstance(current[key], dict):
+                if (
+                    isinstance(current, dict)
+                    and key in current
+                    and isinstance(current[key], dict)
+                ):
                     current = current[key]
                     depth += 1
                 else:
                     # Key not found or not a dict, stop unwrapping
                     break
 
-        # Step 2: Auto-unwrap nested message_data if present
-        # This handles cases where after primary unwrap, there's still a nested message_data
-        while (
-            isinstance(current, dict)
-            and "message_data" in current
-            and isinstance(current["message_data"], dict)
-            and depth < max_depth
-        ):
-            current = current["message_data"]
-            depth += 1
+        # Step 2: Auto-unwrap nested message_data if present after primary unwrap.
+        if payload_key:
+            while (
+                isinstance(current, dict)
+                and "message_data" in current
+                and isinstance(current["message_data"], dict)
+                and depth < max_depth
+            ):
+                current = current["message_data"]
+                depth += 1
 
         return current
 
@@ -1395,8 +1404,9 @@ class WebEXConnector(BaseConnector):
                     # Support configurable payload unwrapping for gateway wrappers
                     # Supports dotted paths (e.g., "data.message_data") and auto-unwraps nested message_data
                     payload_key = self.config.config.get("rabbitmq_payload_key")
+                    original_payload = message_data
                     message_data = self._unwrap_payload(message_data, payload_key)
-                    if payload_key:
+                    if payload_key and message_data is not original_payload:
                         print(
                             f"[DEBUG] Unwrapped payload using key '{payload_key}'",
                             file=sys.stderr,

--- a/webex_connector.py
+++ b/webex_connector.py
@@ -1057,6 +1057,56 @@ class WebEXConnector(BaseConnector):
             )
             self.send_file(room_id, file_path, caption)
 
+
+    @staticmethod
+    def _unwrap_payload(payload: Dict, payload_key: Optional[str] = None, max_depth: int = 4) -> Dict:
+        """
+        Unwrap nested payload structures from RabbitMQ messages.
+
+        Supports:
+        1. Single-level unwrap: payload_key="data"
+        2. Dotted path unwrap: payload_key="data.message_data"
+        3. Auto-unwrap: looks for nested message_data dict and unwraps if present
+
+        Args:
+            payload: The raw message dict from RabbitMQ
+            payload_key: Optional key path to unwrap (supports dot notation)
+            max_depth: Maximum nesting depth to unwrap (safety limit)
+
+        Returns:
+            The unwrapped payload dict
+        """
+        if not isinstance(payload, dict):
+            return payload
+
+        current = payload
+        depth = 0
+
+        # Step 1: Unwrap via payload_key if provided
+        if payload_key:
+            # Support dotted paths: "data.message_data" -> ["data", "message_data"]
+            keys = payload_key.split(".")
+            for key in keys:
+                if isinstance(current, dict) and key in current and isinstance(current[key], dict):
+                    current = current[key]
+                    depth += 1
+                else:
+                    # Key not found or not a dict, stop unwrapping
+                    break
+
+        # Step 2: Auto-unwrap nested message_data if present
+        # This handles cases where after primary unwrap, there's still a nested message_data
+        while (
+            isinstance(current, dict)
+            and "message_data" in current
+            and isinstance(current["message_data"], dict)
+            and depth < max_depth
+        ):
+            current = current["message_data"]
+            depth += 1
+
+        return current
+
     def handle_message(self, message_data: Dict) -> bool:
         """Process incoming WebEX message from RabbitMQ."""
         if not self._begin_active_request():
@@ -1343,15 +1393,12 @@ class WebEXConnector(BaseConnector):
                     )
 
                     # Support configurable payload unwrapping for gateway wrappers
+                    # Supports dotted paths (e.g., "data.message_data") and auto-unwraps nested message_data
                     payload_key = self.config.config.get("rabbitmq_payload_key")
-                    if (
-                        payload_key
-                        and payload_key in message_data
-                        and isinstance(message_data[payload_key], dict)
-                    ):
-                        message_data = message_data[payload_key]
+                    message_data = self._unwrap_payload(message_data, payload_key)
+                    if payload_key:
                         print(
-                            f"[DEBUG] Unwrapped payload from key '{payload_key}'",
+                            f"[DEBUG] Unwrapped payload using key '{payload_key}'",
                             file=sys.stderr,
                         )
 

--- a/webex_connector.py
+++ b/webex_connector.py
@@ -1067,7 +1067,7 @@ class WebEXConnector(BaseConnector):
         Supports:
         1. Single-level unwrap: payload_key="data"
         2. Dotted path unwrap: payload_key="data.message_data"
-        3. Auto-unwrap: looks for nested message_data dict and unwraps if present
+        3. Auto-unwrap: after payload_key match, unwraps nested message_data if present
 
         Args:
             payload: The raw message dict from RabbitMQ
@@ -1104,7 +1104,7 @@ class WebEXConnector(BaseConnector):
                     break
 
         # Step 2: Auto-unwrap nested message_data if present after primary unwrap.
-        if payload_key:
+        if payload_key and current is not payload:
             while (
                 isinstance(current, dict)
                 and "message_data" in current


### PR DESCRIPTION
Implements support for double-wrapped payload envelopes in the WebEX connector.

## Problem
Some WebEX gateways (e.g., Cisco CX-HOSTED-BOTS-PROD) publish messages with nested message_data envelopes where text is nested under message_data inside data envelope.

The previous single-level unwrap logic only removed the outer data envelope, leaving text nested under message_data, causing the connector to treat messages as incomplete and discard them.

## Solution
Implemented Option A from the issue: support for dotted path notation in rabbitmq_payload_key:
- rabbitmq_payload_key="data" → unwrap single level (backward-compatible)
- rabbitmq_payload_key="data.message_data" → unwrap multiple levels using dotted notation
- Auto-unwrap: After primary unwrap, automatically drill down into any nested message_data dicts (up to max_depth=4)

## Changes
- Add _unwrap_payload() static method to WebEXConnector supporting dotted path notation for multi-level unwrapping, auto-detection of nested message_data, and safety limits
- Update payload processing to use the new helper
- Add 9 comprehensive regression tests

## Testing
All tests pass - 9 regression tests included

Closes #268
