### PR TITLE
feat: context window management and compaction for wee-runtime and wee-cli (#273)

### DIFF
--- a/tests/test_issue_273.py
+++ b/tests/test_issue_273.py
@@ -8,6 +8,7 @@ sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
 
 from wee_cli import TokenTracker  # noqa: E402
 from wee_runtime import (  # noqa: E402
+    _COMPACT_WARN_PCT,
     COMPACT_TRIGGER_FRACTION,
     MODEL_CONTEXT_WINDOWS,
     compact_messages,
@@ -27,6 +28,25 @@ class TestModelContextWindows(unittest.TestCase):
 
     def test_openai_gpt4_base(self):
         assert get_context_window("gpt-4") == 8192
+
+    def test_openai_gpt41(self):
+        assert get_context_window("gpt-4.1") == 1_047_576
+
+    def test_openai_gpt41_mini(self):
+        assert get_context_window("gpt-4.1-mini") == 1_047_576
+
+    def test_openai_gpt41_nano(self):
+        assert get_context_window("gpt-4.1-nano") == 1_047_576
+
+    def test_openai_gpt5(self):
+        assert get_context_window("gpt-5") == 1_047_576
+
+    def test_openai_gpt4o_mini_explicit(self):
+        assert get_context_window("gpt-4o-mini") == 128_000
+
+    def test_gpt41_does_not_fall_through_to_gpt4(self):
+        # gpt-4.1 must NOT resolve to gpt-4's 8192 context window
+        assert get_context_window("gpt-4.1") != 8192
 
     def test_qwen3(self):
         assert get_context_window("qwen3:8b") == 32768
@@ -88,6 +108,48 @@ class TestCountMessageTokens(unittest.TestCase):
         result = count_message_tokens(msgs)
         assert result >= 4  # at least the per-message overhead
 
+    def test_tool_call_messages_counted(self):
+        # tool_calls in assistant message should be counted
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "bash",
+                            "arguments": '{"command": "echo hello world"}',
+                        }
+                    }
+                ],
+            }
+        ]
+        result = count_message_tokens(msgs)
+        # Should count function name + arguments, not just overhead
+        base = count_message_tokens([{"role": "assistant", "content": None}])
+        assert result > base
+
+    def test_tool_result_content_counted(self):
+        # Anthropic-style tool_result parts in content list
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "name": "bash",
+                        "content": "hello world output from the tool",
+                    }
+                ],
+            }
+        ]
+        result = count_message_tokens(msgs)
+        plain = count_message_tokens(
+            [{"role": "user", "content": "hello world output from the tool"}]
+        )
+        # Tool result should contribute roughly same tokens as plain content
+        assert result >= plain - 4  # within per-message overhead margin
+
 
 class TestTokenTracker(unittest.TestCase):
     def test_init_with_context_window(self):
@@ -101,19 +163,38 @@ class TestTokenTracker(unittest.TestCase):
         assert tracker.percent_used() == 0.0
 
     def test_percent_used_calculation(self):
+        # percent_used() uses last_prompt_tokens (actual current context size),
+        # NOT session_total (which grows quadratically across turns).
         tracker = TokenTracker(context_window=10000)
         usage = MagicMock()
         usage.prompt_tokens = 1000
         usage.completion_tokens = 500
         usage.total_tokens = 1500
         tracker.update(usage)
-        assert tracker.session_total == 1500
-        assert abs(tracker.percent_used() - 15.0) < 0.01
+        assert tracker.session_total == 1500  # cumulative still tracked
+        assert tracker.last_prompt_tokens == 1000
+        assert abs(tracker.percent_used() - 10.0) < 0.01  # 1000/10000 * 100
+
+    def test_percent_used_does_not_grow_quadratically(self):
+        # Simulate multiple turns: session_total grows, but percent_used stays
+        # bounded by the actual prompt_tokens of the most recent turn.
+        tracker = TokenTracker(context_window=10000)
+        for i in range(20):
+            usage = MagicMock()
+            usage.prompt_tokens = 500  # same context size each turn
+            usage.completion_tokens = 100
+            usage.total_tokens = 600
+            tracker.update(usage)
+        # session_total = 20 * 600 = 12000 → would give 120% under old logic
+        # but percent_used() should reflect last_prompt_tokens = 500 = 5%
+        assert tracker.session_total == 12000
+        assert tracker.last_prompt_tokens == 500
+        assert abs(tracker.percent_used() - 5.0) < 0.01
 
     def test_percent_used_capped_at_100(self):
         tracker = TokenTracker(context_window=100)
         usage = MagicMock()
-        usage.prompt_tokens = 0
+        usage.prompt_tokens = 9999  # prompt_tokens drives percent_used
         usage.completion_tokens = 0
         usage.total_tokens = 9999
         tracker.update(usage)
@@ -199,6 +280,25 @@ class TestCompactMessages(unittest.TestCase):
         assert compacted == messages
         assert summary == ""
 
+    def test_compact_warns_when_result_exceeds_target(self):
+        import warnings
+
+        # Build a history with 20 very large messages so even keep_recent=6
+        # will exceed a tiny target_tokens.
+        messages = [{"role": "system", "content": "You are helpful."}]
+        for i in range(20):
+            messages.append({"role": "user", "content": "x" * 500})
+            messages.append({"role": "assistant", "content": "x" * 500})
+
+        client = self._make_client("Summary " + "x" * 200)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            compact_messages(
+                messages, target_tokens=10, model="qwen3:8b", client=client
+            )
+        # Should have emitted at least one warning about exceeding target
+        assert any("exceeds" in str(warning.message) for warning in w)
+
     def test_system_prompt_preserved(self):
         sys_content = "You are a specialized assistant."
         messages = [{"role": "system", "content": sys_content}]
@@ -232,6 +332,9 @@ class TestCompactMessages(unittest.TestCase):
 
     def test_compact_trigger_fraction(self):
         assert COMPACT_TRIGGER_FRACTION == 0.75
+
+    def test_compact_warn_pct(self):
+        assert _COMPACT_WARN_PCT == 75.0
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_273.py
+++ b/tests/test_issue_273.py
@@ -150,6 +150,36 @@ class TestCountMessageTokens(unittest.TestCase):
         # Tool result should contribute roughly same tokens as plain content
         assert result >= plain - 4  # within per-message overhead margin
 
+    def test_openai_tool_role_message_counted(self):
+        # OpenAI-format tool-result message: role="tool" with string content
+        # and a tool_call_id field.
+        tool_output = "The command output was: hello world from the shell"
+        msgs = [
+            {
+                "role": "tool",
+                "content": tool_output,
+                "tool_call_id": "call_abc123",
+            }
+        ]
+        result = count_message_tokens(msgs)
+        # Must count at least the content text
+        plain = count_message_tokens([{"role": "user", "content": tool_output}])
+        # role="tool" should be counted (content + tool_call_id overhead)
+        assert result >= plain - 4  # within one per-message overhead margin
+        # Zero-content tool message still has overhead
+        empty_tool = count_message_tokens([{"role": "tool", "content": ""}])
+        assert empty_tool >= 4  # at least the per-message overhead
+
+    def test_openai_tool_role_distinct_from_user_role(self):
+        # Verifies role="tool" messages are not silently dropped (i.e. the
+        # token count for role="tool" is the same order of magnitude as for
+        # an equivalent role="user" message).
+        msg_tool = [{"role": "tool", "content": "result text", "tool_call_id": "c1"}]
+        msg_user = [{"role": "user", "content": "result text"}]
+        # Both should produce a non-zero token count
+        assert count_message_tokens(msg_tool) > 0
+        assert count_message_tokens(msg_user) > 0
+
 
 class TestTokenTracker(unittest.TestCase):
     def test_init_with_context_window(self):
@@ -176,20 +206,30 @@ class TestTokenTracker(unittest.TestCase):
         assert abs(tracker.percent_used() - 10.0) < 0.01  # 1000/10000 * 100
 
     def test_percent_used_does_not_grow_quadratically(self):
-        # Simulate multiple turns: session_total grows, but percent_used stays
-        # bounded by the actual prompt_tokens of the most recent turn.
+        # SEMANTIC test (not formula math): each turn re-sends the full message
+        # history to the API, so session_total grows as O(turns^2) while the
+        # actual context window occupancy stays constant.  percent_used() MUST
+        # use last_prompt_tokens (the prompt size of the most recent API call),
+        # NOT session_total (the cumulative sum across all turns).
         tracker = TokenTracker(context_window=10000)
         for i in range(20):
             usage = MagicMock()
-            usage.prompt_tokens = 500  # same context size each turn
+            # Each turn the prompt is still ~500 tokens (history fits in one turn).
+            usage.prompt_tokens = 500
             usage.completion_tokens = 100
             usage.total_tokens = 600
             tracker.update(usage)
-        # session_total = 20 * 600 = 12000 → would give 120% under old logic
-        # but percent_used() should reflect last_prompt_tokens = 500 = 5%
+        # session_total = 20 * 600 = 12000 — would give 120% under old logic
+        # (using session_total / context_window).
         assert tracker.session_total == 12000
+        # percent_used() must reflect the CURRENT context size (last turn only)
         assert tracker.last_prompt_tokens == 500
+        # 5% = 500 / 10000 * 100 — NOT 120% from cumulative session_total
         assert abs(tracker.percent_used() - 5.0) < 0.01
+        # The key invariant: percent_used() < 100% even though session_total
+        # is 120% of context_window.
+        assert tracker.percent_used() < 100.0
+        assert tracker.session_total > tracker.context_window
 
     def test_percent_used_capped_at_100(self):
         tracker = TokenTracker(context_window=100)

--- a/tests/test_issue_273.py
+++ b/tests/test_issue_273.py
@@ -1,0 +1,238 @@
+"""Regression tests for Issue #273: Context Window Management and Compaction."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
+
+from wee_cli import TokenTracker  # noqa: E402
+from wee_runtime import (  # noqa: E402
+    COMPACT_TRIGGER_FRACTION,
+    MODEL_CONTEXT_WINDOWS,
+    compact_messages,
+    count_message_tokens,
+    estimate_tokens,
+    execute_tool,
+    get_context_window,
+)
+
+
+class TestModelContextWindows(unittest.TestCase):
+    def test_openai_gpt4o(self):
+        assert get_context_window("gpt-4o") == 128000
+
+    def test_openai_gpt4_turbo(self):
+        assert get_context_window("gpt-4-turbo") == 128000
+
+    def test_openai_gpt4_base(self):
+        assert get_context_window("gpt-4") == 8192
+
+    def test_qwen3(self):
+        assert get_context_window("qwen3:8b") == 32768
+
+    def test_gemma4(self):
+        assert get_context_window("ollama/gemma4:e4b") == 131072
+
+    def test_gemma2(self):
+        assert get_context_window("gemma2:9b") == 8192
+
+    def test_llama3(self):
+        assert get_context_window("llama-3.1-8b") == 131072
+
+    def test_unknown_model_default(self):
+        assert get_context_window("unknown-model-xyz") == 4096
+
+    def test_longest_match_wins(self):
+        # gpt-4o (128000) should beat gpt-4 (8192) for "gpt-4o-mini"
+        result = get_context_window("gpt-4o-mini")
+        assert result == 128000, f"Expected 128000, got {result}"
+
+    def test_model_context_windows_dict_populated(self):
+        assert len(MODEL_CONTEXT_WINDOWS) >= 10
+
+
+class TestEstimateTokens(unittest.TestCase):
+    def test_empty_string(self):
+        assert estimate_tokens("") == 0
+
+    def test_nonempty_string(self):
+        result = estimate_tokens("hello world this is a test")
+        assert result > 0
+
+    def test_heuristic_roughly_chars_over_4(self):
+        text = "a" * 100
+        result = estimate_tokens(text)
+        assert result == 25  # 100 // 4
+
+    def test_minimum_one(self):
+        result = estimate_tokens("a")
+        assert result >= 1
+
+
+class TestCountMessageTokens(unittest.TestCase):
+    def test_basic_messages(self):
+        msgs = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        total = count_message_tokens(msgs)
+        assert total > 0
+
+    def test_empty_messages(self):
+        assert count_message_tokens([]) == 0
+
+    def test_none_content(self):
+        msgs = [{"role": "assistant", "content": None}]
+        result = count_message_tokens(msgs)
+        assert result >= 4  # at least the per-message overhead
+
+
+class TestTokenTracker(unittest.TestCase):
+    def test_init_with_context_window(self):
+        tracker = TokenTracker(context_window=128000)
+        assert tracker.context_window == 128000
+        assert tracker.session_total == 0
+
+    def test_init_without_context_window(self):
+        tracker = TokenTracker()
+        assert tracker.context_window == 0
+        assert tracker.percent_used() == 0.0
+
+    def test_percent_used_calculation(self):
+        tracker = TokenTracker(context_window=10000)
+        usage = MagicMock()
+        usage.prompt_tokens = 1000
+        usage.completion_tokens = 500
+        usage.total_tokens = 1500
+        tracker.update(usage)
+        assert tracker.session_total == 1500
+        assert abs(tracker.percent_used() - 15.0) < 0.01
+
+    def test_percent_used_capped_at_100(self):
+        tracker = TokenTracker(context_window=100)
+        usage = MagicMock()
+        usage.prompt_tokens = 0
+        usage.completion_tokens = 0
+        usage.total_tokens = 9999
+        tracker.update(usage)
+        assert tracker.percent_used() == 100.0
+
+    def test_summary_includes_context_window(self):
+        tracker = TokenTracker(context_window=50000)
+        usage = MagicMock()
+        usage.prompt_tokens = 100
+        usage.completion_tokens = 50
+        usage.total_tokens = 150
+        tracker.update(usage)
+        summary = tracker.summary()
+        assert "Context window" in summary
+        assert "50,000" in summary
+
+    def test_summary_without_context_window(self):
+        tracker = TokenTracker()
+        summary = tracker.summary()
+        assert "Context window" not in summary
+
+    def test_session_total_fallback_when_total_tokens_zero(self):
+        tracker = TokenTracker(context_window=10000)
+        usage = MagicMock()
+        usage.prompt_tokens = 100
+        usage.completion_tokens = 50
+        usage.total_tokens = 0
+        tracker.update(usage)
+        assert tracker.session_total == 150  # falls back to pt+ct
+
+
+class TestExecuteToolPermission(unittest.TestCase):
+    def test_restricted_blocks_bash(self):
+        result = execute_tool("bash", {"command": "echo hi"}, permission="restricted")
+        assert "restricted" in result.lower()
+
+    def test_restricted_blocks_python(self):
+        result = execute_tool("python", {"code": "print(1)"}, permission="restricted")
+        assert "restricted" in result.lower()
+
+    def test_auto_executes_bash(self):
+        result = execute_tool("bash", {"command": "echo hello273"}, permission="auto")
+        assert "hello273" in result
+
+    def test_default_permission_is_auto(self):
+        result = execute_tool("bash", {"command": "echo defaultperm"})
+        assert "defaultperm" in result
+
+
+class TestCompactMessages(unittest.TestCase):
+    def _make_client(self, summary_text="Summarized context."):
+        client = MagicMock()
+        response = MagicMock()
+        response.choices[0].message.content = summary_text
+        client.chat.completions.create.return_value = response
+        return client
+
+    def test_compaction_reduces_messages(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+        ]
+        for i in range(20):
+            messages.append({"role": "user", "content": f"Question {i}"})
+            messages.append({"role": "assistant", "content": f"Answer {i}"})
+
+        client = self._make_client("Prior conversation summary.")
+        compacted, summary = compact_messages(
+            messages, target_tokens=500, model="qwen3:8b", client=client
+        )
+        assert len(compacted) < len(messages)
+        assert summary == "Prior conversation summary."
+
+    def test_short_history_not_compacted(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        client = self._make_client()
+        compacted, summary = compact_messages(
+            messages, target_tokens=5000, model="qwen3:8b", client=client
+        )
+        assert compacted == messages
+        assert summary == ""
+
+    def test_system_prompt_preserved(self):
+        sys_content = "You are a specialized assistant."
+        messages = [{"role": "system", "content": sys_content}]
+        for i in range(20):
+            messages.append({"role": "user", "content": f"Q{i}"})
+            messages.append({"role": "assistant", "content": f"A{i}"})
+
+        client = self._make_client("Summary here.")
+        compacted, _ = compact_messages(
+            messages, target_tokens=200, model="qwen3:8b", client=client
+        )
+        assert any(
+            m.get("role") == "system" and m.get("content") == sys_content
+            for m in compacted
+        )
+
+    def test_compaction_error_returns_gracefully(self):
+        messages = [{"role": "system", "content": "sys"}]
+        for i in range(20):
+            messages.append({"role": "user", "content": f"Q{i}"})
+            messages.append({"role": "assistant", "content": f"A{i}"})
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = RuntimeError("API error")
+        compacted, summary = compact_messages(
+            messages, target_tokens=200, model="qwen3:8b", client=client
+        )
+        # Should still return something usable with error in summary
+        assert len(compacted) > 0
+        assert "error" in summary.lower() or "Compaction error" in summary
+
+    def test_compact_trigger_fraction(self):
+        assert COMPACT_TRIGGER_FRACTION == 0.75
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/wee_cli.py
+++ b/wee_cli.py
@@ -35,6 +35,7 @@ sys.path.insert(0, _HERE)
 from wee_runtime import _WEE_TOOLS  # noqa: E402
 from wee_runtime import (  # noqa: E402
     _ANTI_HALLUCINATION_PROMPT,
+    _COMPACT_WARN_PCT,
     COMPACT_TRIGGER_FRACTION,
     MAX_TOOL_ROUNDS,
     compact_messages,
@@ -171,6 +172,9 @@ class TokenTracker:
         self.total_tokens = 0
         self.turns = 0
         self.session_total = 0  # cumulative across all API turns
+        self.last_prompt_tokens = (
+            0  # prompt tokens from the most recent turn (actual current context)
+        )
         self.context_window = context_window  # 0 means unknown
 
     def update(self, usage):
@@ -183,13 +187,20 @@ class TokenTracker:
             self.completion_tokens += ct
             self.total_tokens += tt
             self.session_total += tt if tt else (pt + ct)
+            self.last_prompt_tokens = pt  # tracks actual current context size
         self.turns += 1
 
     def percent_used(self) -> float:
-        """Return percentage of context window consumed (0 if window unknown)."""
+        """Return percentage of context window consumed (0 if window unknown).
+
+        Uses last_prompt_tokens (the prompt token count from the most recent API
+        call) rather than session_total to avoid quadratic over-counting: each
+        turn re-sends the full message history, so session_total grows without
+        bound even when the actual context usage is stable.
+        """
         if not self.context_window:
             return 0.0
-        return min(100.0, self.session_total / self.context_window * 100)
+        return min(100.0, self.last_prompt_tokens / self.context_window * 100)
 
     def summary(self) -> str:
         lines = [
@@ -201,7 +212,7 @@ class TokenTracker:
         if self.context_window:
             pct = self.percent_used()
             lines.append(
-                f"Context window: {self.session_total:,}"
+                f"Context window: {self.last_prompt_tokens:,}"
                 f"/{self.context_window:,} tokens ({pct:.1f}% used)"
             )
         return "\n".join(lines)
@@ -501,6 +512,10 @@ def run_interactive(
                         continue
                 ctx_win = token_tracker.context_window or get_context_window(model)
                 target_toks = int(ctx_win * target_pct / 100)
+                non_sys_count = sum(1 for m in messages if m.get("role") != "system")
+                if non_sys_count <= 6:
+                    _print_info("Nothing to compact — history is already short.")
+                    continue
                 before_n = len(messages)
                 before_toks = count_message_tokens(messages, model)
                 _print_info(
@@ -508,9 +523,15 @@ def run_interactive(
                     f" → target {target_pct}% ({target_toks:,} tokens)..."
                 )
                 try:
-                    compacted, summary = compact_messages(
-                        messages, target_toks, model, client
-                    )
+                    import warnings
+
+                    with warnings.catch_warnings(record=True) as w:
+                        warnings.simplefilter("always")
+                        compacted, summary = compact_messages(
+                            messages, target_toks, model, client
+                        )
+                        for warning in w:
+                            _print_info(f"[Wee] Warning: {warning.message}")
                     after_n = len(compacted)
                     after_toks = count_message_tokens(compacted, model)
                     messages = compacted
@@ -575,7 +596,7 @@ def run_interactive(
             messages.append({"role": "assistant", "content": response})
             if token_tracker.context_window:
                 pct = token_tracker.percent_used()
-                if pct >= COMPACT_TRIGGER_FRACTION * 100:
+                if pct >= _COMPACT_WARN_PCT:
                     _print_info(
                         f"[Wee] Context window {pct:.0f}% full —"
                         " consider /compact to free space."

--- a/wee_cli.py
+++ b/wee_cli.py
@@ -35,8 +35,12 @@ sys.path.insert(0, _HERE)
 from wee_runtime import _WEE_TOOLS  # noqa: E402
 from wee_runtime import (  # noqa: E402
     _ANTI_HALLUCINATION_PROMPT,
+    COMPACT_TRIGGER_FRACTION,
     MAX_TOOL_ROUNDS,
+    compact_messages,
+    count_message_tokens,
     execute_tool,
+    get_context_window,
     resolve_model_and_endpoint,
 )
 
@@ -81,12 +85,13 @@ def _init_readline():
     # Tab completion for slash commands
     _COMMANDS = [
         "/clear",
+        "/compact",
+        "/config",
+        "/help",
         "/history",
         "/model",
-        "/tokens",
         "/system",
-        "/help",
-        "/config",
+        "/tokens",
         "/version",
     ]
 
@@ -160,27 +165,46 @@ def _print_info(msg: str):
 class TokenTracker:
     """Track token usage across turns."""
 
-    def __init__(self):
+    def __init__(self, context_window: int = 0):
         self.prompt_tokens = 0
         self.completion_tokens = 0
         self.total_tokens = 0
         self.turns = 0
+        self.session_total = 0  # cumulative across all API turns
+        self.context_window = context_window  # 0 means unknown
 
     def update(self, usage):
         """Update from an OpenAI usage object."""
         if usage:
-            self.prompt_tokens += getattr(usage, "prompt_tokens", 0) or 0
-            self.completion_tokens += getattr(usage, "completion_tokens", 0) or 0
-            self.total_tokens += getattr(usage, "total_tokens", 0) or 0
+            pt = getattr(usage, "prompt_tokens", 0) or 0
+            ct = getattr(usage, "completion_tokens", 0) or 0
+            tt = getattr(usage, "total_tokens", 0) or 0
+            self.prompt_tokens += pt
+            self.completion_tokens += ct
+            self.total_tokens += tt
+            self.session_total += tt if tt else (pt + ct)
         self.turns += 1
 
+    def percent_used(self) -> float:
+        """Return percentage of context window consumed (0 if window unknown)."""
+        if not self.context_window:
+            return 0.0
+        return min(100.0, self.session_total / self.context_window * 100)
+
     def summary(self) -> str:
-        return (
+        lines = [
             f"Tokens — prompt: {self.prompt_tokens}, "
             f"completion: {self.completion_tokens}, "
             f"total: {self.total_tokens}, "
             f"turns: {self.turns}"
-        )
+        ]
+        if self.context_window:
+            pct = self.percent_used()
+            lines.append(
+                f"Context window: {self.session_total:,}"
+                f"/{self.context_window:,} tokens ({pct:.1f}% used)"
+            )
+        return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -365,9 +389,10 @@ def _make_client(api_base: str, api_key: str, timeout: float):
 REPL_HELP = """\
 Wee CLI Interactive Mode — Commands:
   /clear          Clear conversation history
+  /compact [N]    Compact context to N% of window (default 50%)
   /history        Show conversation history
   /model MODEL    Switch model
-  /tokens         Show token usage
+  /tokens         Show token usage and context window percentage
   /system PROMPT  Set system prompt
   /config         Show current configuration
   /version        Show version
@@ -396,7 +421,8 @@ def run_interactive(
     _init_readline()
 
     client = _make_client(api_base, api_key, timeout)
-    token_tracker = TokenTracker()
+    ctx_window = get_context_window(model)
+    token_tracker = TokenTracker(context_window=ctx_window)
     messages = []
 
     if system_prompt:
@@ -451,11 +477,54 @@ def run_interactive(
                     old_model = model
                     model, api_base, api_key = resolve_model_and_endpoint(arg)
                     client = _make_client(api_base, api_key, timeout)
-                    _print_info(f"Model switched: {old_model} → {model}")
+                    token_tracker.context_window = get_context_window(model)
+                    _print_info(
+                        f"Model switched: {old_model} → {model} "
+                        f"(context: {token_tracker.context_window:,} tokens)"
+                    )
                 continue
 
             elif cmd == "/tokens":
                 _print_info(token_tracker.summary())
+                continue
+
+            elif cmd == "/compact":
+                target_pct = 50
+                if arg:
+                    try:
+                        target_pct = int(arg)
+                        if not 10 <= target_pct <= 90:
+                            _print_info("Target percentage must be 10-90.")
+                            continue
+                    except ValueError:
+                        _print_info("Usage: /compact [percentage]  (default: 50)")
+                        continue
+                ctx_win = token_tracker.context_window or get_context_window(model)
+                target_toks = int(ctx_win * target_pct / 100)
+                before_n = len(messages)
+                before_toks = count_message_tokens(messages, model)
+                _print_info(
+                    f"Compacting: {before_n} messages, ~{before_toks:,} tokens"
+                    f" → target {target_pct}% ({target_toks:,} tokens)..."
+                )
+                try:
+                    compacted, summary = compact_messages(
+                        messages, target_toks, model, client
+                    )
+                    after_n = len(compacted)
+                    after_toks = count_message_tokens(compacted, model)
+                    messages = compacted
+                    _print_info(
+                        f"Done: {before_n} → {after_n} messages,"
+                        f" ~{before_toks:,} → ~{after_toks:,} tokens"
+                    )
+                    if summary:
+                        _print_info(
+                            f"Summary: {summary[:200]}"
+                            f"{'...' if len(summary) > 200 else ''}"
+                        )
+                except Exception as exc:
+                    _print_info(f"Compaction failed: {exc}")
                 continue
 
             elif cmd == "/system":
@@ -504,6 +573,13 @@ def run_interactive(
                 permission=permission,
             )
             messages.append({"role": "assistant", "content": response})
+            if token_tracker.context_window:
+                pct = token_tracker.percent_used()
+                if pct >= COMPACT_TRIGGER_FRACTION * 100:
+                    _print_info(
+                        f"[Wee] Context window {pct:.0f}% full —"
+                        " consider /compact to free space."
+                    )
         except KeyboardInterrupt:
             print("\n[interrupted]")
             messages.append({"role": "assistant", "content": "[interrupted]"})

--- a/wee_cli.py
+++ b/wee_cli.py
@@ -36,7 +36,6 @@ from wee_runtime import _WEE_TOOLS  # noqa: E402
 from wee_runtime import (  # noqa: E402
     _ANTI_HALLUCINATION_PROMPT,
     _COMPACT_WARN_PCT,
-    COMPACT_TRIGGER_FRACTION,
     MAX_TOOL_ROUNDS,
     compact_messages,
     count_message_tokens,

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -33,12 +33,17 @@ PROVIDER_PRESETS = {
 # Keys are model name substrings; longest match wins.
 MODEL_CONTEXT_WINDOWS: dict = {
     # OpenAI
-    "gpt-4o": 128000,
-    "gpt-4-turbo": 128000,
-    "gpt-4-32k": 32768,
-    "gpt-4": 8192,
-    "gpt-3.5-turbo-16k": 16385,
-    "gpt-3.5-turbo": 16385,
+    "gpt-5": 1_047_576,
+    "gpt-4.1-mini": 1_047_576,
+    "gpt-4.1-nano": 1_047_576,
+    "gpt-4.1": 1_047_576,
+    "gpt-4o-mini": 128_000,
+    "gpt-4o": 128_000,
+    "gpt-4-turbo": 128_000,
+    "gpt-4-32k": 32_768,
+    "gpt-4": 8_192,
+    "gpt-3.5-turbo-16k": 16_385,
+    "gpt-3.5-turbo": 16_385,
     # Anthropic Claude (via OpenRouter or direct)
     "claude-3": 200000,
     "claude-2": 100000,
@@ -114,15 +119,30 @@ def count_message_tokens(messages: list, model: str = "") -> int:
         content = msg.get("content") or ""
         if isinstance(content, list):
             for part in content:
-                if isinstance(part, dict) and part.get("type") == "text":
-                    total += estimate_tokens(part["text"], model)
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        total += estimate_tokens(part["text"], model)
+                    elif part.get("type") in ("tool_use", "tool_result"):
+                        # Count tool name + input/output text
+                        total += estimate_tokens(part.get("name", ""), model)
+                        inner = part.get("input") or part.get("content") or ""
+                        if isinstance(inner, str):
+                            total += estimate_tokens(inner, model)
+                        elif isinstance(inner, dict):
+                            total += estimate_tokens(str(inner), model)
         else:
             total += estimate_tokens(str(content), model)
+        # Count tool_calls array for assistant messages (OpenAI format)
+        for tc in msg.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            total += estimate_tokens(fn.get("name", ""), model)
+            total += estimate_tokens(fn.get("arguments", ""), model)
         total += 4  # per-message overhead (role, delimiters)
     return total
 
 
 COMPACT_TRIGGER_FRACTION = 0.75
+_COMPACT_WARN_PCT = COMPACT_TRIGGER_FRACTION * 100
 
 
 def compact_messages(
@@ -199,6 +219,17 @@ def compact_messages(
         ]
         + to_keep
     )
+
+    actual_tokens = count_message_tokens(compacted, model)
+    if actual_tokens > target_tokens:
+        import warnings
+
+        warnings.warn(
+            f"compact_messages: result ({actual_tokens} tokens) exceeds "
+            f"target ({target_tokens} tokens) — recent messages alone are too large.",
+            stacklevel=2,
+        )
+
     return compacted, summary_text
 
 

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -29,6 +29,179 @@ PROVIDER_PRESETS = {
     "lmstudio": ("http://localhost:1234/v1", "lm-studio"),
 }
 
+# Model context window sizes (tokens) — Issue #273
+# Keys are model name substrings; longest match wins.
+MODEL_CONTEXT_WINDOWS: dict = {
+    # OpenAI
+    "gpt-4o": 128000,
+    "gpt-4-turbo": 128000,
+    "gpt-4-32k": 32768,
+    "gpt-4": 8192,
+    "gpt-3.5-turbo-16k": 16385,
+    "gpt-3.5-turbo": 16385,
+    # Anthropic Claude (via OpenRouter or direct)
+    "claude-3": 200000,
+    "claude-2": 100000,
+    # Meta Llama
+    "llama-3": 131072,
+    "llama-2": 4096,
+    # Google Gemma
+    "gemma4": 131072,
+    "gemma3": 131072,
+    "gemma2": 8192,
+    "gemma": 8192,
+    # Alibaba Qwen
+    "qwen3": 32768,
+    "qwen2": 32768,
+    "qwen": 32768,
+    # Mistral AI
+    "mixtral": 32768,
+    "mistral": 32768,
+    # Microsoft Phi
+    "phi-3": 128000,
+    "phi3": 128000,
+    # DeepSeek
+    "deepseek": 65536,
+    # Code models
+    "codellama": 16384,
+}
+
+_DEFAULT_CONTEXT_WINDOW = 4096
+
+
+def get_context_window(model: str) -> int:
+    """Return the context window size for a model.
+
+    Matches by longest substring key in MODEL_CONTEXT_WINDOWS.
+    Falls back to _DEFAULT_CONTEXT_WINDOW when no match is found.
+    """
+    model_lower = model.lower()
+    matches = [
+        (key, size) for key, size in MODEL_CONTEXT_WINDOWS.items() if key in model_lower
+    ]
+    if matches:
+        return max(matches, key=lambda x: len(x[0]))[1]
+    return _DEFAULT_CONTEXT_WINDOW
+
+
+def estimate_tokens(text: str, model: str = "") -> int:
+    """Estimate token count for a text string.
+
+    Uses tiktoken for OpenAI models when available, falls back to ~4 chars/token.
+    """
+    if not text:
+        return 0
+    _openai_prefixes = ("gpt-", "text-embedding", "davinci", "curie", "babbage")
+    if any(p in model.lower() for p in _openai_prefixes):
+        try:
+            import tiktoken
+
+            try:
+                enc = tiktoken.encoding_for_model(model)
+            except KeyError:
+                enc = tiktoken.get_encoding("cl100k_base")
+            return len(enc.encode(text))
+        except ImportError:
+            pass
+    # Heuristic: ~4 chars per token
+    return max(1, len(text) // 4)
+
+
+def count_message_tokens(messages: list, model: str = "") -> int:
+    """Estimate the total token count for a list of chat messages."""
+    total = 0
+    for msg in messages:
+        content = msg.get("content") or ""
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    total += estimate_tokens(part["text"], model)
+        else:
+            total += estimate_tokens(str(content), model)
+        total += 4  # per-message overhead (role, delimiters)
+    return total
+
+
+COMPACT_TRIGGER_FRACTION = 0.75
+
+
+def compact_messages(
+    messages: list,
+    target_tokens: int,
+    model: str,
+    client,
+    keep_recent: int = 6,
+) -> tuple:
+    """Compact message history to fit within target_tokens.
+
+    Preserves the system prompt and the most recent ``keep_recent`` messages.
+    Older messages are summarised into a single context-summary exchange using
+    the LLM, keeping the conversation coherent without blowing the context window.
+
+    Returns:
+        (compacted_messages, summary_text) tuple.
+    """
+    system_msgs = [m for m in messages if m.get("role") == "system"]
+    non_system = [m for m in messages if m.get("role") != "system"]
+
+    if len(non_system) <= keep_recent:
+        return messages, ""
+
+    to_summarize = non_system[:-keep_recent]
+    to_keep = non_system[-keep_recent:]
+
+    transcript_lines = []
+    for m in to_summarize:
+        role = m.get("role", "")
+        content = m.get("content") or ""
+        if isinstance(content, list):
+            content = " ".join(
+                p.get("text", "") for p in content if isinstance(p, dict)
+            )
+        if role in ("user", "assistant") and content:
+            prefix = "User" if role == "user" else "Assistant"
+            transcript_lines.append(f"{prefix}: {str(content)[:500]}")
+
+    if not transcript_lines:
+        return messages, ""
+
+    transcript = "\n".join(transcript_lines)
+    summary_prompt = (
+        "Summarize the following conversation history concisely. Preserve all key "
+        "facts, decisions, file paths, and context needed to continue the conversation "
+        "coherently. Keep the summary under 400 words.\n\n"
+        f"Conversation:\n{transcript}"
+    )
+
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": summary_prompt}],
+            stream=False,
+        )
+        summary_text = resp.choices[0].message.content or ""
+    except Exception as exc:
+        summary_text = f"[Compaction error: {exc}]"
+
+    compacted = (
+        system_msgs
+        + [
+            {
+                "role": "user",
+                "content": f"[Earlier conversation summary]\n{summary_text}",
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "Understood. I have the context from the earlier conversation."
+                ),
+            },
+        ]
+        + to_keep
+    )
+    return compacted, summary_text
+
+
 # Tool definitions (Issue #107)
 _WEE_TOOLS = [
     {
@@ -223,8 +396,18 @@ def _execute_search(func_args: dict) -> str:
     return summary[:SEARCH_MAX_CHARS]
 
 
-def execute_tool(func_name: str, func_args: dict) -> str:
-    """Execute a tool call and return its output (Issue #107)."""
+def execute_tool(func_name: str, func_args: dict, permission: str = "auto") -> str:
+    """Execute a tool call and return its output (Issue #107).
+
+    Args:
+        permission: "restricted" blocks all execution. "auto" and "elevated"
+            execute tools as requested.
+    """
+    if permission == "restricted":
+        return (
+            "Error: tool execution is disabled (permission=restricted). "
+            "Pass --permission auto to enable tools."
+        )
     try:
         if func_name == "bash":
             command = func_args.get("command", "")

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -113,9 +113,21 @@ def estimate_tokens(text: str, model: str = "") -> int:
 
 
 def count_message_tokens(messages: list, model: str = "") -> int:
-    """Estimate the total token count for a list of chat messages."""
+    """Estimate the total token count for a list of chat messages.
+
+    Handles the following message shapes:
+
+    * Standard ``role: user/assistant/system`` with string or list content.
+    * Anthropic content-list parts: ``type: text``, ``type: tool_use``,
+      ``type: tool_result``.
+    * OpenAI tool-result messages: ``role: tool`` with a string ``content``
+      and an optional ``tool_call_id`` field.
+    * OpenAI assistant tool-call messages: ``role: assistant`` with a
+      ``tool_calls`` array.
+    """
     total = 0
     for msg in messages:
+        role = msg.get("role", "")
         content = msg.get("content") or ""
         if isinstance(content, list):
             for part in content:
@@ -123,7 +135,7 @@ def count_message_tokens(messages: list, model: str = "") -> int:
                     if part.get("type") == "text":
                         total += estimate_tokens(part["text"], model)
                     elif part.get("type") in ("tool_use", "tool_result"):
-                        # Count tool name + input/output text
+                        # Anthropic: count tool name + input/output payload
                         total += estimate_tokens(part.get("name", ""), model)
                         inner = part.get("input") or part.get("content") or ""
                         if isinstance(inner, str):
@@ -131,7 +143,14 @@ def count_message_tokens(messages: list, model: str = "") -> int:
                         elif isinstance(inner, dict):
                             total += estimate_tokens(str(inner), model)
         else:
+            # String content -- covers standard messages and OpenAI role="tool"
+            # tool-result messages (content is always a plain string there).
             total += estimate_tokens(str(content), model)
+        if role in ("tool", "tool_result", "tool_call"):
+            # OpenAI tool-result messages carry a tool_call_id; count it.
+            tc_id = msg.get("tool_call_id", "")
+            if tc_id:
+                total += estimate_tokens(tc_id, model)
         # Count tool_calls array for assistant messages (OpenAI format)
         for tc in msg.get("tool_calls") or []:
             fn = tc.get("function") or {}
@@ -157,6 +176,11 @@ def compact_messages(
     Preserves the system prompt and the most recent ``keep_recent`` messages.
     Older messages are summarised into a single context-summary exchange using
     the LLM, keeping the conversation coherent without blowing the context window.
+
+    Note: Does not guarantee the result fits within *target_tokens*. If the
+    ``keep_recent`` messages alone exceed the target, a :mod:`warnings` warning
+    is emitted but the result is still returned — callers should check the
+    returned token count independently.
 
     Returns:
         (compacted_messages, summary_text) tuple.


### PR DESCRIPTION
## Summary

Implements intelligent context window management and compaction for `wee-runtime` and `wee-cli`.

### wee-runtime changes
- **Model context window registry**: `MODEL_CONTEXT_WINDOWS` dict with 20+ models (OpenAI, Llama, Gemma, Qwen, Mistral, Phi, DeepSeek, Claude)
- **`get_context_window(model)`**: longest-match substring lookup, falls back to 4096 tokens
- **`estimate_tokens(text, model)`**: tiktoken for OpenAI models, ~4 chars/token fallback
- **`count_message_tokens(messages, model)`**: full conversation token estimation
- **`compact_messages(...)`**: LLM-powered compaction — preserves system prompt + recent turns, summarises older history into a single context-summary exchange
- **`COMPACT_TRIGGER_FRACTION = 0.75`**: shared threshold constant
- **`execute_tool()` permission param**: accepts restricted/auto/elevated; restricted blocks all execution

### wee-cli changes
- **`TokenTracker` enhanced**: adds `context_window`, `session_total`, `percent_used()`; `summary()` now shows context window usage percentage
- **`/compact [N]` command**: compacts conversation to N% of context window (default 50%), shows before/after message count and token estimates
- **`/model` command**: refreshes context window size when switching models
- **Context window warning**: printed after each REPL turn when usage ≥ 75%
- **Tab completion and help**: updated to include `/compact`

### Tests
- 33 regression tests in `tests/test_issue_273.py` covering all new functions and edge cases

Closes #273