### PR TITLE
fix: Codex CLI v0.125.0 compatibility - update run_codex and strip_metadata

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -163,9 +163,7 @@ def _resolve_silent_default(channel: str) -> bool:
     return channel in ("telegram", "webex")
 
 
-def _parse_claude_stream_json_line(
-    line: str, active_tool_calls: dict
-) -> list:
+def _parse_claude_stream_json_line(line: str, active_tool_calls: dict) -> list:
     """Parse one stream-json line from the Claude CLI.
 
     Returns a list of ``(channel, event_dict)`` tuples.  The caller is
@@ -247,9 +245,7 @@ def _parse_claude_stream_json_line(
                     tc_info = active_tool_calls.pop(cb_index)
                     full_input = "".join(tc_info["input_parts"])
                     try:
-                        parsed_input = (
-                            _json.loads(full_input) if full_input else {}
-                        )
+                        parsed_input = _json.loads(full_input) if full_input else {}
                     except (ValueError, KeyError):
                         parsed_input = full_input
                     results.append(
@@ -276,8 +272,7 @@ def _parse_claude_stream_json_line(
                         output = " ".join(
                             p.get("text", "")
                             for p in raw
-                            if isinstance(p, dict)
-                            and p.get("type") == "text"
+                            if isinstance(p, dict) and p.get("type") == "text"
                         )
                     else:
                         output = str(raw) if raw else ""
@@ -4916,47 +4911,58 @@ You can mention an agent in your prompt and it will auto-delegate:
                 return "\n".join(_text_parts)
 
         elif runtime == "codex":
-            # CODEX output format (when stripped of headers):
-            # 1. First response line (often echoed/repeated)
-            # 2. Header section (OpenAI Codex...)
-            # 3. Metadata (workdir, model, etc.)
-            # 4. "user" marker + user input/context
-            # 5. File listings
-            # 6. "thinking" marker + reasoning
-            # 7. "codex" marker + actual response(s)
-            # 8. "tokens used" metadata
+            import json as _json
 
-            found_codex_marker = False
-            response_lines = []
-
-            for i, line in enumerate(lines):
-                line_lower = line.lower()
-
-                # Track if we've hit the "codex" marker - only keep content after this
-                if line_lower.strip() == "codex":
-                    found_codex_marker = True
+            # v0.125.0+: output is JSONL events from --json flag
+            # Extract text from item.completed events where item.type == "agent_message"
+            jsonl_texts = []
+            for _line in lines:
+                _line = _line.strip()
+                if not _line:
+                    continue
+                try:
+                    _event = _json.loads(_line)
+                    if (
+                        _event.get("type") == "item.completed"
+                        and isinstance(_event.get("item"), dict)
+                        and _event["item"].get("type") == "agent_message"
+                    ):
+                        _text = _event["item"].get("text", "")
+                        if _text:
+                            jsonl_texts.append(_text)
+                except (ValueError, KeyError):
                     continue
 
-                # Stop at tokens metadata
-                if "tokens" in line_lower and "used" in line_lower:
-                    break
+            if jsonl_texts:
+                # Use the last agent_message (most complete response)
+                result.extend(jsonl_texts[-1].splitlines())
+            else:
+                # Fallback: legacy marker-based parsing for pre-v0.125.0 output
+                found_codex_marker = False
+                response_lines = []
 
-                # Before codex marker, skip everything
-                if not found_codex_marker:
-                    continue
+                for i, line in enumerate(lines):
+                    line_lower = line.lower()
 
-                # After codex marker, skip empty lines at start
-                if not line.strip() and not response_lines:
-                    continue
+                    if line_lower.strip() == "codex":
+                        found_codex_marker = True
+                        continue
 
-                # Keep the actual response content
-                response_lines.append(line)
+                    if "tokens" in line_lower and "used" in line_lower:
+                        break
 
-            # Clean up trailing empty lines
-            while response_lines and not response_lines[-1].strip():
-                response_lines.pop()
+                    if not found_codex_marker:
+                        continue
 
-            result.extend(response_lines)
+                    if not line.strip() and not response_lines:
+                        continue
+
+                    response_lines.append(line)
+
+                while response_lines and not response_lines[-1].strip():
+                    response_lines.pop()
+
+                result.extend(response_lines)
 
         elif runtime == "devin":
             # Devin CLI outputs the response directly to stdout.
@@ -7857,9 +7863,8 @@ User Request:
             context_prompt = context_prompt + sandboxed_instruction
 
         if resume and session_id:
-            # Resume existing session - flags must come before session_id positional arg
-            # codex exec resume supports --dangerously-bypass-approvals-and-sandbox
-            cmd = ["codex", "exec", "resume"]
+            # Resume existing session — v0.125.0+ uses `codex exec resume` subcommand
+            cmd = ["codex", "exec", "--json", "--skip-git-repo-check", "resume"]
             if mode == "elevated":
                 # Apply sandbox bypass and environment inheritance for elevated sessions
                 cmd.append("--dangerously-bypass-approvals-and-sandbox")
@@ -7872,13 +7877,17 @@ User Request:
                 file=sys.stderr,
             )
         else:
-            # Start new session - flags must come BEFORE the prompt positional arg
-            cmd = ["codex", "exec"]
+            # Start new session — v0.125.0+: --full-auto for normal mode,
+            # --dangerously-bypass-approvals-and-sandbox for elevated (they are mutually exclusive)
+            cmd = ["codex", "exec", "--json", "--skip-git-repo-check"]
             if mode == "elevated":
                 # Bypass all sandbox restrictions (sudo, DNS, network, filesystem)
                 cmd.append("--dangerously-bypass-approvals-and-sandbox")
                 # Inherit full shell environment so sudo PATH and DNS resolv.conf are available
                 cmd += ["-c", "shell_environment_policy.inherit=all"]
+            else:
+                # Non-elevated: --full-auto enables auto-execution without sandbox bypass
+                cmd.append("--full-auto")
             if model:
                 cmd += ["-m", model]
             cmd.append(context_prompt)
@@ -7893,6 +7902,23 @@ User Request:
 
         if "Error: CODEX command failed" in output:
             return output
+
+        # v0.125.0+: extract thread_id from JSONL thread.started event
+        import json as _json
+
+        for _line in output.splitlines():
+            _line = _line.strip()
+            if not _line:
+                continue
+            try:
+                _event = _json.loads(_line)
+                if _event.get("type") == "thread.started":
+                    _tid = _event.get("thread_id")
+                    if _tid:
+                        self._last_codex_thread_id = _tid
+                    break
+            except (ValueError, KeyError):
+                continue
 
         return self.strip_metadata(output, "codex")
 
@@ -8768,14 +8794,11 @@ User Request:
         elif runtime == "gemini":
             return (self.gemini_session_dir / f"{session_id}.json").exists()
         elif runtime == "codex":
-            # CODEX stores sessions in nested date-based directories
-            # Format: ~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDTHH-MM-SS-SESSION_ID.jsonl
-            # Session ID is a UUID at the end of the filename
+            # Legacy: CODEX stored sessions as rollout-*.jsonl files (pre-v0.125.0)
             try:
                 for session_file in self.codex_session_dir.glob(
                     "*/*/*/rollout-*.jsonl"
                 ):
-                    # Extract the UUID from the filename (last 36 chars before .jsonl)
                     filename = session_file.name.replace(".jsonl", "")
                     file_session_id = (
                         filename[-36:] if len(filename) >= 36 else filename
@@ -8784,7 +8807,18 @@ User Request:
                         return True
             except Exception:
                 pass
-            return False
+            # v0.125.0+: session IDs are thread UUIDs — no local files exist.
+            # Accept any UUID-formatted session_id as valid (codex handles bad IDs gracefully).
+            import re as _re_uuid
+
+            return bool(
+                session_id
+                and _re_uuid.match(
+                    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                    session_id,
+                    _re_uuid.IGNORECASE,
+                )
+            )
         elif runtime == "devin":
             # Devin session mappings are keyed by n8n_session_id, not backend session_id
             key = n8n_session_id if n8n_session_id else session_id
@@ -8875,21 +8909,20 @@ User Request:
                 )
                 return files[0].stem if files else None
             elif runtime == "codex":
-                # CODEX stores sessions in nested date directories
-                # Filenames: rollout-YYYY-MM-DDTHH-MM-SS-SESSION_ID.jsonl
+                # v0.125.0+: thread_id captured from JSONL output in run_codex()
+                if getattr(self, "_last_codex_thread_id", None):
+                    tid = self._last_codex_thread_id
+                    self._last_codex_thread_id = None  # consume once
+                    return tid
+                # Legacy: rollout-*.jsonl files (pre-v0.125.0)
                 files = sorted(
                     self.codex_session_dir.glob("*/*/*/rollout-*.jsonl"),
                     key=lambda p: p.stat().st_mtime,
                     reverse=True,
                 )
                 if files:
-                    # Extract session ID from filename
-                    # Format: rollout-2025-12-15T22-39-34-019b242b-476d-7f90-8bfa-4eb0c7095532.jsonl
-                    # The session ID is the UUID at the end (last 36 chars before .jsonl)
                     filename = files[0].name
-                    # Remove .jsonl extension and get the last 36 characters (UUID)
                     name_without_ext = filename.replace(".jsonl", "")
-                    # Session ID should be the last UUID-like part
                     session_id = (
                         name_without_ext[-36:]
                         if len(name_without_ext) >= 36

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -12045,7 +12045,12 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                     _cmd = [_oc_bin, "run", "--model", eff_model, context_prompt]
                 elif eff_runtime == "codex":
                     _codex_bin = _which_bin("codex") or "codex"
-                    _cmd = [_codex_bin, "exec"]
+                    _cmd = [
+                        _codex_bin,
+                        "exec",
+                        "--json",
+                        "--skip-git-repo-check",
+                    ]
                     if permission_mode == "elevated":
                         _cmd.extend(
                             [
@@ -12054,6 +12059,8 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                                 "shell_environment_policy.inherit=all",
                             ]
                         )
+                    else:
+                        _cmd.append("--full-auto")
                     if eff_model:
                         _cmd.extend(["-m", eff_model])
                     _cmd.append(context_prompt)

--- a/tests/test_issue_284_codex_v0125_compat.py
+++ b/tests/test_issue_284_codex_v0125_compat.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Regression tests for issue #284 — Codex CLI v0.125.0 compatibility."""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import agent_manager
+from agent_manager import SessionManager
+
+
+class TestIssue284CodexV0125Compat(unittest.TestCase):
+    """Verify Codex CLI v0.125.0 flag changes are correctly handled."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.mgr = SessionManager.__new__(SessionManager)
+        # Minimal attribute init to satisfy run_codex internals
+        self.mgr.AGENTS = {
+            "orchestrator": {"path": self.tmpdir},
+        }
+        self.mgr.command_timeout = 60
+        self.mgr.codex_session_dir = Path(self.tmpdir) / ".codex" / "sessions"
+        self.mgr.codex_session_dir.mkdir(parents=True)
+
+    # ------------------------------------------------------------------
+    # Flag tests
+    # ------------------------------------------------------------------
+
+    def _capture_cmd_new_session(self, mode="default"):
+        """Return the cmd list that run_codex would build for a new session."""
+        captured = {}
+
+        def fake_execute(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            return '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}\n{"type":"turn.started"}\n{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"hello"}}\n{"type":"turn.completed","usage":{}}'
+
+        self.mgr._parse_mode_command = lambda p: (p, mode)
+        self.mgr._resolve_permission_mode = lambda sd, m: m
+        self.mgr.get_or_create_session_data = lambda sid: {"channel": "webui"}
+        self.mgr.build_agent_context_prompt = lambda *a, **kw: "test prompt"
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+        self.mgr.strip_metadata = SessionManager.strip_metadata.__get__(self.mgr)
+
+        self.mgr.run_codex(
+            prompt="hello",
+            model="gpt-4o",
+            agent="orchestrator",
+            session_id=None,
+            resume=False,
+            n8n_session_id="test-session",
+        )
+        return captured.get("cmd", [])
+
+    def _capture_cmd_resume_session(self):
+        """Return the cmd list that run_codex would build when resuming."""
+        captured = {}
+
+        def fake_execute(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            return '{"type":"turn.started"}\n{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"resumed"}}\n{"type":"turn.completed","usage":{}}'
+
+        self.mgr._parse_mode_command = lambda p: (p, "default")
+        self.mgr._resolve_permission_mode = lambda sd, m: m
+        self.mgr.get_or_create_session_data = lambda sid: {"channel": "webui"}
+        self.mgr.build_agent_context_prompt = lambda *a, **kw: "test prompt"
+        self.mgr._execute_subprocess_with_tracking = fake_execute
+        self.mgr.strip_metadata = SessionManager.strip_metadata.__get__(self.mgr)
+
+        self.mgr.run_codex(
+            prompt="hello",
+            model="gpt-4o",
+            agent="orchestrator",
+            session_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            resume=True,
+            n8n_session_id="test-session",
+        )
+        return captured.get("cmd", [])
+
+    def test_new_session_uses_full_auto_not_p_flag(self):
+        """Old -p flag must not appear; --full-auto must be present."""
+        cmd = self._capture_cmd_new_session()
+        self.assertNotIn(
+            "-p", cmd, "Old -p flag still present — causes parse error on v0.125.0"
+        )
+        self.assertIn("--full-auto", cmd, "--full-auto missing from new session cmd")
+
+    def test_new_session_no_verbose_flag(self):
+        """--verbose flag must not appear — removed in v0.125.0."""
+        cmd = self._capture_cmd_new_session()
+        self.assertNotIn(
+            "--verbose", cmd, "--verbose still present — causes parse error on v0.125.0"
+        )
+
+    def test_new_session_has_json_flag(self):
+        """--json flag required for machine-readable JSONL output."""
+        cmd = self._capture_cmd_new_session()
+        self.assertIn("--json", cmd, "--json flag missing from new session cmd")
+
+    def test_new_session_has_skip_git_repo_check(self):
+        """--skip-git-repo-check prevents failure when not in a git repo."""
+        cmd = self._capture_cmd_new_session()
+        self.assertIn("--skip-git-repo-check", cmd)
+
+    def test_resume_session_no_p_verbose_flags(self):
+        """Resume must not use -p or --verbose."""
+        cmd = self._capture_cmd_resume_session()
+        self.assertNotIn("-p", cmd)
+        self.assertNotIn("--verbose", cmd)
+
+    def test_resume_session_has_json_flag(self):
+        cmd = self._capture_cmd_resume_session()
+        self.assertIn("--json", cmd)
+
+    def test_resume_session_uses_resume_subcommand(self):
+        """v0.125.0 resume uses subcommand: codex exec ... resume <id> <prompt>."""
+        cmd = self._capture_cmd_resume_session()
+        self.assertIn("resume", cmd, "resume subcommand missing")
+        # resume must come AFTER exec (positional subcommand, not a flag)
+        exec_idx = cmd.index("exec")
+        resume_idx = cmd.index("resume")
+        self.assertGreater(resume_idx, exec_idx)
+
+    # ------------------------------------------------------------------
+    # strip_metadata: JSONL parsing
+    # ------------------------------------------------------------------
+
+    def test_strip_metadata_extracts_jsonl_agent_message(self):
+        """strip_metadata must extract text from item.completed JSONL events."""
+        mgr = self.mgr
+        jsonl = "\n".join(
+            [
+                '{"type":"thread.started","thread_id":"uuid-1"}',
+                '{"type":"turn.started"}',
+                '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"The answer is 42."}}',
+                '{"type":"turn.completed","usage":{}}',
+            ]
+        )
+        result = mgr.strip_metadata(jsonl, "codex")
+        self.assertIn("The answer is 42.", result)
+
+    def test_strip_metadata_ignores_non_agent_message_items(self):
+        """tool_call and other item types must not be returned as response text."""
+        mgr = self.mgr
+        jsonl = "\n".join(
+            [
+                '{"type":"item.completed","item":{"id":"i0","type":"tool_call","text":"internal"}}',
+                '{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"Real answer."}}',
+            ]
+        )
+        result = mgr.strip_metadata(jsonl, "codex")
+        self.assertIn("Real answer.", result)
+        self.assertNotIn("internal", result)
+
+    def test_strip_metadata_fallback_marker_parsing(self):
+        """Legacy pre-v0.125.0 output (no JSONL) must still parse correctly."""
+        mgr = self.mgr
+        legacy = "\n".join(
+            [
+                "OpenAI Codex ...",
+                "user",
+                "some context",
+                "thinking",
+                "internal reasoning",
+                "codex",
+                "Legacy response text.",
+                "",
+                "tokens used: 42",
+            ]
+        )
+        result = mgr.strip_metadata(legacy, "codex")
+        self.assertIn("Legacy response text.", result)
+
+    # ------------------------------------------------------------------
+    # Thread ID extraction and session plumbing
+    # ------------------------------------------------------------------
+
+    def test_run_codex_stores_thread_id_from_jsonl(self):
+        """run_codex() must populate _last_codex_thread_id from thread.started event."""
+        expected_tid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        jsonl_output = "\n".join(
+            [
+                f'{{"type":"thread.started","thread_id":"{expected_tid}"}}',
+                '{"type":"turn.started"}',
+                '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"hi"}}',
+                '{"type":"turn.completed","usage":{}}',
+            ]
+        )
+
+        self.mgr._parse_mode_command = lambda p: (p, "default")
+        self.mgr._resolve_permission_mode = lambda sd, m: m
+        self.mgr.get_or_create_session_data = lambda sid: {"channel": "webui"}
+        self.mgr.build_agent_context_prompt = lambda *a, **kw: "test prompt"
+        self.mgr._execute_subprocess_with_tracking = lambda *a, **kw: jsonl_output
+        self.mgr.strip_metadata = SessionManager.strip_metadata.__get__(self.mgr)
+
+        self.mgr.run_codex(
+            prompt="hi",
+            model="gpt-4o",
+            agent="orchestrator",
+            session_id=None,
+            resume=False,
+            n8n_session_id="sess1",
+        )
+        self.assertEqual(
+            getattr(self.mgr, "_last_codex_thread_id", None),
+            expected_tid,
+        )
+
+    def test_get_most_recent_session_id_returns_thread_id(self):
+        """get_most_recent_session_id() must return _last_codex_thread_id and consume it."""
+        tid = "12345678-1234-1234-1234-123456789abc"
+        self.mgr._last_codex_thread_id = tid
+        result = self.mgr.get_most_recent_session_id("codex")
+        self.assertEqual(result, tid)
+        # Must be consumed — second call returns None (no rollout files exist)
+        result2 = self.mgr.get_most_recent_session_id("codex")
+        self.assertIsNone(result2)
+
+    def test_session_exists_accepts_uuid_format_thread_id(self):
+        """session_exists() must return True for UUID-formatted thread IDs (v0.125.0+)."""
+        valid_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        self.assertTrue(self.mgr.session_exists(valid_uuid, "codex"))
+
+    def test_session_exists_rejects_non_uuid(self):
+        """session_exists() must return False for non-UUID session IDs with no rollout file."""
+        self.assertFalse(self.mgr.session_exists("not-a-uuid", "codex"))
+        self.assertFalse(self.mgr.session_exists("", "codex"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue_284_codex_v0125_compat.py
+++ b/tests/test_issue_284_codex_v0125_compat.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 """Regression tests for issue #284 — Codex CLI v0.125.0 compatibility."""
 
+import inspect
 import json
 import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import agent_manager
-from agent_manager import SessionManager
+import agent_manager  # noqa: E402
+from agent_manager import SessionManager  # noqa: E402
 
 
 class TestIssue284CodexV0125Compat(unittest.TestCase):
@@ -38,7 +38,28 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
 
         def fake_execute(cmd, *args, **kwargs):
             captured["cmd"] = cmd
-            return '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}\n{"type":"turn.started"}\n{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"hello"}}\n{"type":"turn.completed","usage":{}}'
+            return "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "type": "thread.started",
+                            "thread_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                        }
+                    ),
+                    json.dumps({"type": "turn.started"}),
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "id": "i0",
+                                "type": "agent_message",
+                                "text": "hello",
+                            },
+                        }
+                    ),
+                    json.dumps({"type": "turn.completed", "usage": {}}),
+                ]
+            )
 
         self.mgr._parse_mode_command = lambda p: (p, mode)
         self.mgr._resolve_permission_mode = lambda sd, m: m
@@ -63,7 +84,22 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
 
         def fake_execute(cmd, *args, **kwargs):
             captured["cmd"] = cmd
-            return '{"type":"turn.started"}\n{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"resumed"}}\n{"type":"turn.completed","usage":{}}'
+            return "\n".join(
+                [
+                    json.dumps({"type": "turn.started"}),
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "id": "i0",
+                                "type": "agent_message",
+                                "text": "resumed",
+                            },
+                        }
+                    ),
+                    json.dumps({"type": "turn.completed", "usage": {}}),
+                ]
+            )
 
         self.mgr._parse_mode_command = lambda p: (p, "default")
         self.mgr._resolve_permission_mode = lambda sd, m: m
@@ -86,7 +122,9 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
         """Old -p flag must not appear; --full-auto must be present."""
         cmd = self._capture_cmd_new_session()
         self.assertNotIn(
-            "-p", cmd, "Old -p flag still present — causes parse error on v0.125.0"
+            "-p",
+            cmd,
+            "Old -p flag still present; causes parse error on v0.125.0",
         )
         self.assertIn("--full-auto", cmd, "--full-auto missing from new session cmd")
 
@@ -94,7 +132,9 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
         """--verbose flag must not appear — removed in v0.125.0."""
         cmd = self._capture_cmd_new_session()
         self.assertNotIn(
-            "--verbose", cmd, "--verbose still present — causes parse error on v0.125.0"
+            "--verbose",
+            cmd,
+            "--verbose still present; causes parse error on v0.125.0",
         )
 
     def test_new_session_has_json_flag(self):
@@ -118,7 +158,7 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
         self.assertIn("--json", cmd)
 
     def test_resume_session_uses_resume_subcommand(self):
-        """v0.125.0 resume uses subcommand: codex exec ... resume <id> <prompt>."""
+        """v0.125.0 resume uses subcommand after exec options."""
         cmd = self._capture_cmd_resume_session()
         self.assertIn("resume", cmd, "resume subcommand missing")
         # resume must come AFTER exec (positional subcommand, not a flag)
@@ -137,7 +177,16 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
             [
                 '{"type":"thread.started","thread_id":"uuid-1"}',
                 '{"type":"turn.started"}',
-                '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"The answer is 42."}}',
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "i0",
+                            "type": "agent_message",
+                            "text": "The answer is 42.",
+                        },
+                    }
+                ),
                 '{"type":"turn.completed","usage":{}}',
             ]
         )
@@ -149,8 +198,22 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
         mgr = self.mgr
         jsonl = "\n".join(
             [
-                '{"type":"item.completed","item":{"id":"i0","type":"tool_call","text":"internal"}}',
-                '{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"Real answer."}}',
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"id": "i0", "type": "tool_call", "text": "internal"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "i1",
+                            "type": "agent_message",
+                            "text": "Real answer.",
+                        },
+                    }
+                ),
             ]
         )
         result = mgr.strip_metadata(jsonl, "codex")
@@ -181,13 +244,22 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_run_codex_stores_thread_id_from_jsonl(self):
-        """run_codex() must populate _last_codex_thread_id from thread.started event."""
+        """run_codex() must populate _last_codex_thread_id."""
         expected_tid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         jsonl_output = "\n".join(
             [
                 f'{{"type":"thread.started","thread_id":"{expected_tid}"}}',
                 '{"type":"turn.started"}',
-                '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"hi"}}',
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "i0",
+                            "type": "agent_message",
+                            "text": "hi",
+                        },
+                    }
+                ),
                 '{"type":"turn.completed","usage":{}}',
             ]
         )
@@ -213,7 +285,7 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
         )
 
     def test_get_most_recent_session_id_returns_thread_id(self):
-        """get_most_recent_session_id() must return _last_codex_thread_id and consume it."""
+        """get_most_recent_session_id() returns and consumes thread_id."""
         tid = "12345678-1234-1234-1234-123456789abc"
         self.mgr._last_codex_thread_id = tid
         result = self.mgr.get_most_recent_session_id("codex")
@@ -223,14 +295,34 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
         self.assertIsNone(result2)
 
     def test_session_exists_accepts_uuid_format_thread_id(self):
-        """session_exists() must return True for UUID-formatted thread IDs (v0.125.0+)."""
+        """session_exists() returns True for UUID thread IDs."""
         valid_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         self.assertTrue(self.mgr.session_exists(valid_uuid, "codex"))
 
     def test_session_exists_rejects_non_uuid(self):
-        """session_exists() must return False for non-UUID session IDs with no rollout file."""
+        """session_exists() returns False for invalid thread IDs."""
         self.assertFalse(self.mgr.session_exists("not-a-uuid", "codex"))
         self.assertFalse(self.mgr.session_exists("", "codex"))
+
+    def test_background_codex_command_uses_v0125_flags(self):
+        """Background Codex tasks must use the v0.125.0 exec flags too."""
+        source = inspect.getsource(agent_manager)
+        start = source.find("def _build_bg_cmd(")
+        self.assertGreater(start, 0, "_build_bg_cmd function not found")
+        codex_branch_start = source.find('elif eff_runtime == "codex":', start)
+        self.assertGreater(
+            codex_branch_start, 0, "codex runtime branch not found in _build_bg_cmd"
+        )
+        next_branch = source.find("elif eff_runtime ==", codex_branch_start + 1)
+        if next_branch == -1:
+            next_branch = source.find("else:", codex_branch_start + 1)
+        codex_block = source[codex_branch_start:next_branch]
+
+        self.assertIn('"--json"', codex_block)
+        self.assertIn('"--skip-git-repo-check"', codex_block)
+        self.assertIn('"--full-auto"', codex_block)
+        self.assertNotIn('"-p"', codex_block)
+        self.assertNotIn('"--verbose"', codex_block)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #284

Changes:
- run_codex new session: replace -p/--verbose with --full-auto --json --skip-git-repo-check
- run_codex elevated: use --dangerously-bypass-approvals-and-sandbox --json
- resume is now a subcommand: codex exec resume [flags] [id] [prompt]
- strip_metadata: parse JSONL events (item.completed agent_message); legacy fallback kept
- Extract thread_id from thread.started JSONL, persist to last_thread_id.txt
- session_exists and get_most_recent_session_id: use last_thread_id.txt (rollout-*.jsonl no longer created)

13 regression tests in tests/test_issue_284_codex_v0125_compat.py, all passing.