### PR TITLE
fix: bg task permission_mode inherits from agent config (all formats)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -3100,6 +3100,9 @@ You can mention an agent in your prompt and it will auto-delegate:
                         "primary_model": agent.get("primary_model"),
                         "fallback_runtime": agent.get("fallback_runtime"),
                         "fallback_model": agent.get("fallback_model"),
+                        "permission_mode": agent.get("permission_mode"),
+                        "yolo": agent.get("yolo", False),
+                        "permissions": agent.get("permissions"),
                     }
                 return agents
         except json.JSONDecodeError as e:
@@ -11526,6 +11529,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         permission_mode: Optional[str] = (
             None  # elevated, restricted (default), sandboxed
         )
+        yolo: Optional[bool] = None  # True => elevated; False => restricted (overrides agent config)
         description: Optional[str] = (
             None  # human-readable task name shown in Agents panel
         )
@@ -12568,15 +12572,28 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 "agent": agent,
                 "runtime": runtime,
                 "model": model,
-                "permission_mode": body.permission_mode or (agent_config.get("permissions") or {}).get("mode", "restricted"),
+                "permission_mode": body.permission_mode or (agent_config.get("permissions") or {}).get("mode") or agent_config.get("permission_mode") or ("elevated" if agent_config.get("yolo") else "restricted"),
                 "status": "queued",
                 "queue_position": queue_pos,
                 "timeout": bg_timeout,
             }
 
         # Resolve permission mode: request body > agent config default > restricted
-        _agent_perm_mode = (agent_config.get("permissions") or {}).get("mode", "restricted")
-        perm_mode = body.permission_mode or _agent_perm_mode
+        # Support all config formats:
+        #   1. nested {"permissions": {"mode": "elevated"}}  (wee-qa actual)
+        #   2. top-level {"permission_mode": "elevated"}  (simplified)
+        #   3. top-level {"yolo": true}  => elevated  (legacy)
+        _nested_perm = (agent_config.get("permissions") or {}).get("mode")
+        _top_perm = agent_config.get("permission_mode")
+        _yolo = agent_config.get("yolo")
+        _agent_perm_mode = _nested_perm or _top_perm or ("elevated" if _yolo else "restricted")
+        # Priority: body.permission_mode > body.yolo > agent config > restricted
+        if body.permission_mode:
+            perm_mode = body.permission_mode
+        elif body.yolo is not None:
+            perm_mode = "elevated" if body.yolo else "restricted"
+        else:
+            perm_mode = _agent_perm_mode
         if perm_mode not in ("elevated", "restricted", "sandboxed"):
             perm_mode = "restricted"
 

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -12568,14 +12568,15 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 "agent": agent,
                 "runtime": runtime,
                 "model": model,
-                "permission_mode": body.permission_mode or "restricted",
+                "permission_mode": body.permission_mode or (agent_config.get("permissions") or {}).get("mode", "restricted"),
                 "status": "queued",
                 "queue_position": queue_pos,
                 "timeout": bg_timeout,
             }
 
-        # Resolve permission mode (default: restricted)
-        perm_mode = body.permission_mode or "restricted"
+        # Resolve permission mode: request body > agent config default > restricted
+        _agent_perm_mode = (agent_config.get("permissions") or {}).get("mode", "restricted")
+        perm_mode = body.permission_mode or _agent_perm_mode
         if perm_mode not in ("elevated", "restricted", "sandboxed"):
             perm_mode = "restricted"
 

--- a/tests/test_issue287_agent_nested_permissions_mode.py
+++ b/tests/test_issue287_agent_nested_permissions_mode.py
@@ -1,0 +1,140 @@
+"""Regression tests for Issue #287.
+
+Bug: background tasks ignore agent permissions.mode (nested format)
+     from agents.json. Only top-level permission_mode/yolo were read
+     after issue #245's fix. The nested {"permissions": {"mode": ...}}
+     format used by wee-qa was silently dropped, causing codex to run
+     in sandboxed mode and blocking external DNS (api.telegram.org).
+
+Root cause: _load_agents_config() only copied top-level fields into the
+AGENTS dict; "permissions" (nested) was omitted. Additionally,
+create_background_task() only read body.permission_mode without checking
+any agent config format — not nested, not top-level.
+
+Fix:
+  1. _load_agents_config() now copies "permission_mode", "yolo", and
+     "permissions" into the AGENTS dict.
+  2. create_background_task() resolves perm_mode using all three formats:
+     nested permissions.mode > top-level permission_mode > yolo flag.
+     Priority: body.permission_mode > body.yolo > agent config > "restricted".
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+sys.path.insert(0, "/opt/n8n-copilot-shim-dev")
+os.environ["API_SHARED_KEY"] = "test_key_123"
+os.environ.setdefault("APP_ENV", "DEV")
+
+
+def _make_client(agents):
+    """Build an isolated TestClient with the given agents config."""
+    from fastapi.testclient import TestClient
+
+    tmp = tempfile.mkdtemp()
+    cfg_path = os.path.join(tmp, "agents.json")
+    with open(cfg_path, "w") as f:
+        json.dump({"agents": agents}, f)
+    os.environ["AGENT_CONFIG_FILE"] = cfg_path
+
+    import agent_manager as am
+    app = am.create_api_app()
+    app.state.bg_task_mgr._path = os.path.join(tmp, "bg.json")
+    app.state.bg_task_mgr._tasks_cache = None
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, SimpleNamespace(cleanup=lambda: shutil.rmtree(tmp, ignore_errors=True))
+
+
+HEADERS = {"Authorization": "Bearer shared_test_key_123"}
+
+
+class TestNestedPermissionsModeFormat(unittest.TestCase):
+    """Nested permissions.mode must propagate to background tasks (the wee-qa format)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.client, cls.store = _make_client([
+            {
+                "name": "wee-qa",
+                "path": "/opt/wee-qa",
+                "description": "QA agent",
+                "primary_runtime": "codex",
+                "primary_model": "gpt-5.4-mini",
+                "permissions": {
+                    "mode": "elevated",
+                    "network": {"allow_urls": ["*"]},
+                },
+            },
+            {
+                "name": "sandboxed-agent",
+                "path": "/opt/sandboxed",
+                "description": "Sandboxed agent",
+                "primary_runtime": "copilot",
+                "primary_model": "claude-haiku-4.5",
+                "permissions": {
+                    "mode": "sandboxed",
+                },
+            },
+            {
+                "name": "plain-agent",
+                "path": "/opt/plain",
+                "description": "Agent with no permissions config",
+                "primary_runtime": "copilot",
+                "primary_model": "claude-haiku-4.5",
+            },
+        ])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.store.cleanup()
+
+    def _post(self, payload):
+        resp = self.client.post(
+            "/api/v1/background-tasks", json=payload, headers=HEADERS
+        )
+        self.assertIn(resp.status_code, (200, 201), resp.text[:300])
+        return resp.json()
+
+    def test_nested_permissions_mode_elevated_propagates(self):
+        """wee-qa's nested permissions.mode=elevated must yield elevated."""
+        data = self._post({"prompt": "test", "agent": "wee-qa"})
+        self.assertEqual(
+            data.get("permission_mode"),
+            "elevated",
+            f"Expected elevated from nested permissions.mode, got: {data.get('permission_mode')}. "
+            f"Full: {data}",
+        )
+
+    def test_nested_permissions_mode_sandboxed_propagates(self):
+        """Nested permissions.mode=sandboxed must yield sandboxed."""
+        data = self._post({"prompt": "test", "agent": "sandboxed-agent"})
+        self.assertEqual(data.get("permission_mode"), "sandboxed")
+
+    def test_no_permissions_defaults_to_restricted(self):
+        """Agent without any permissions config defaults to restricted."""
+        data = self._post({"prompt": "test", "agent": "plain-agent"})
+        self.assertEqual(data.get("permission_mode"), "restricted")
+
+    def test_body_permission_mode_overrides_nested(self):
+        """body.permission_mode wins over agent's nested permissions.mode."""
+        data = self._post(
+            {"prompt": "test", "agent": "wee-qa", "permission_mode": "restricted"}
+        )
+        self.assertEqual(data.get("permission_mode"), "restricted")
+
+    def test_body_permission_mode_elevates_sandboxed_agent(self):
+        """body.permission_mode=elevated wins over agent's sandboxed setting."""
+        data = self._post(
+            {"prompt": "test", "agent": "sandboxed-agent", "permission_mode": "elevated"}
+        )
+        self.assertEqual(data.get("permission_mode"), "elevated")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #287

## Root Cause

`bg_91dd76e5` (wee-qa, codex runtime) failed to send a Telegram notification because codex ran in sandboxed mode, blocking `api.telegram.org` DNS resolution.

**Why**: wee-qa in agents.json uses `"permissions": {"mode": "elevated"}` (nested format). But:
1. `_load_agents_config()` only copied a fixed whitelist of fields — `permissions`, `permission_mode`, and `yolo` were all missing
2. `create_background_task()` defaulted to `"restricted"` when `body.permission_mode` was not explicitly set

Result: codex ran without `--dangerously-bypass-approvals-and-sandbox`, which blocks external network access.

## Changes

- **`_load_agents_config()`**: Add `permission_mode`, `yolo`, `permissions` to the AGENTS dict
- **`create_background_task()`**: Resolve `perm_mode` with priority: `body.permission_mode` > `body.yolo` > agent config (all 3 formats) > `"restricted"`
- **`BackgroundTaskRequest`**: Add optional `yolo: Optional[bool]` field (`True`→elevated, `False`→restricted)
- **Also fixes**: pre-existing issue #245 tests that were failing (same root cause — different format)

## Tests

- 5 new regression tests in `test_issue287_agent_nested_permissions_mode.py`
- All 5 pre-existing issue #245 tests now pass (were previously failing)