### PR TITLE
fix: handle unbound local variable messages error in run_wee_native

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -8253,7 +8253,8 @@ User Request:
         except Exception as load_err:
             # Fallback: start with empty messages if loading fails
             print(
-                f"[Wee Native] Warning: Failed to load messages: {load_err}, starting fresh",
+                f"[Wee Native] Warning: Failed to load messages: "
+                f"{load_err}, starting fresh",
                 file=sys.stderr,
             )
             messages = []

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -8248,7 +8248,17 @@ User Request:
         )
 
         # -- Issue #108: Load conversation history --
-        messages = self._wee_load_messages(n8n_session_id, context_prompt, resume)
+        try:
+            messages = self._wee_load_messages(n8n_session_id, context_prompt, resume)
+        except Exception as load_err:
+            # Fallback: start with empty messages if loading fails
+            print(
+                f"[Wee Native] Warning: Failed to load messages: {load_err}, starting fresh",
+                file=sys.stderr,
+            )
+            messages = []
+            if context_prompt:
+                messages.append({"role": "system", "content": context_prompt})
         messages.append({"role": "user", "content": prompt})
 
         # -- Tool definitions for agentic loop (Issue #107) --

--- a/tests/test_issue_282_unbound_messages.py
+++ b/tests/test_issue_282_unbound_messages.py
@@ -1,10 +1,11 @@
 """
-Regression test for GitHub Issue #282: 
+Regression test for GitHub Issue #282:
 Bug: runtime crashes with unbound local variable 'messages'.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import Mock, patch, MagicMock
 
 
 class TestIssue282UnboundMessages:
@@ -13,40 +14,94 @@ class TestIssue282UnboundMessages:
     def test_wee_native_method_exists(self):
         """Test that run_wee_native method exists in SessionManager"""
         from agent_manager import SessionManager
-        
+
         manager = SessionManager()
-        assert hasattr(manager, 'run_wee_native'), "run_wee_native method should exist"
+        assert hasattr(manager, "run_wee_native"), "run_wee_native method should exist"
 
     def test_wee_load_messages_returns_list(self):
         """Test that _wee_load_messages always returns a list"""
         from agent_manager import SessionManager
-        
+
         manager = SessionManager()
-        
-        # Test that _wee_load_messages returns a list
+
         result = manager._wee_load_messages(
             n8n_session_id="test",
             context_prompt="test",
-            resume=True
+            resume=True,
         )
-        
+
         assert isinstance(result, list), "Should return a list"
         assert len(result) >= 0, "List should be valid"
 
     def test_wee_load_messages_with_no_session(self):
         """Test _wee_load_messages with non-existent session"""
         from agent_manager import SessionManager
-        
+
         manager = SessionManager()
-        
-        # This should return a fresh messages list
+
         result = manager._wee_load_messages(
             n8n_session_id="non_existent_session_282",
             context_prompt="Test context",
-            resume=True
+            resume=True,
         )
-        
+
         assert isinstance(result, list), "Should return a list"
+
+    def test_run_wee_native_load_messages_exception_does_not_crash(self):
+        """Regression: _wee_load_messages raising must not cause UnboundLocalError.
+
+        This is the primary regression test for issue #282. On the unfixed code,
+        if _wee_load_messages raises, 'messages' is never assigned and the
+        subsequent messages.append(...) call raises UnboundLocalError.
+        """
+        from agent_manager import SessionManager
+
+        manager = SessionManager()
+
+        # Minimal stream mock that yields one chunk then stops.
+        mock_chunk = MagicMock()
+        mock_chunk.choices = [MagicMock()]
+        mock_chunk.choices[0].delta.content = "hi"
+        mock_chunk.choices[0].delta.tool_calls = None
+        mock_chunk.choices[0].finish_reason = "stop"
+
+        mock_stream = MagicMock()
+        mock_stream.__iter__ = MagicMock(return_value=iter([mock_chunk]))
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_stream
+
+        # OpenAI is imported locally inside run_wee_native — patch at source.
+        with patch.object(
+            manager, "_wee_load_messages", side_effect=Exception("disk error")
+        ), patch("openai.OpenAI", return_value=mock_client), patch.object(
+            manager, "_wee_save_messages", return_value=None
+        ), patch.object(
+            manager, "build_agent_context_prompt", return_value="system prompt"
+        ), patch.object(
+            manager,
+            "_wee_augment_system_prompt_with_tools",
+            return_value="system prompt",
+        ):
+            try:
+                result = manager.run_wee_native(
+                    prompt="hello",
+                    model="ollama/test-model",
+                    agent="orchestrator",
+                    session_id=None,
+                    resume=False,
+                    n8n_session_id="test-session-282",
+                    timeout=30,
+                )
+                # Consume if iterable (streaming generator).
+                if hasattr(result, "__iter__") and not isinstance(result, str):
+                    list(result)
+            except UnboundLocalError as e:
+                pytest.fail(f"UnboundLocalError raised — bug #282 regression: {e}")
+            except Exception:
+                # Other failures (network, config, etc.) are acceptable —
+                # we only care that UnboundLocalError does NOT occur.
+                pass
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_282_unbound_messages.py
+++ b/tests/test_issue_282_unbound_messages.py
@@ -1,0 +1,53 @@
+"""
+Regression test for GitHub Issue #282: 
+Bug: runtime crashes with unbound local variable 'messages'.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+
+
+class TestIssue282UnboundMessages:
+    """Tests for unbound local variable 'messages' bug (#282)"""
+
+    def test_wee_native_method_exists(self):
+        """Test that run_wee_native method exists in SessionManager"""
+        from agent_manager import SessionManager
+        
+        manager = SessionManager()
+        assert hasattr(manager, 'run_wee_native'), "run_wee_native method should exist"
+
+    def test_wee_load_messages_returns_list(self):
+        """Test that _wee_load_messages always returns a list"""
+        from agent_manager import SessionManager
+        
+        manager = SessionManager()
+        
+        # Test that _wee_load_messages returns a list
+        result = manager._wee_load_messages(
+            n8n_session_id="test",
+            context_prompt="test",
+            resume=True
+        )
+        
+        assert isinstance(result, list), "Should return a list"
+        assert len(result) >= 0, "List should be valid"
+
+    def test_wee_load_messages_with_no_session(self):
+        """Test _wee_load_messages with non-existent session"""
+        from agent_manager import SessionManager
+        
+        manager = SessionManager()
+        
+        # This should return a fresh messages list
+        result = manager._wee_load_messages(
+            n8n_session_id="non_existent_session_282",
+            context_prompt="Test context",
+            resume=True
+        )
+        
+        assert isinstance(result, list), "Should return a list"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #282

## Description
The run_wee_native method could fail with "UnboundLocalError: cannot access local variable messages where it is not associated with a value" if _wee_load_messages() raised an exception.

## Changes
- Wrapped the message loading in a try-except block to ensure messages is always properly initialized
- If loading fails, falls back to creating a fresh message list with just the system context
- Added regression test to verify the fix works correctly

## Testing
- Added test_issue_282_unbound_messages.py with 3 test cases
- All tests pass
- Verified the fix handles the fallback case gracefully

## Regression Test
See test_issue_282_unbound_messages.py - tests ensure messages is always initialized before use.