### PR TITLE
fix: Issue #283 — Strip internal Codex error logs from responses

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -4925,6 +4925,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             # 6. "thinking" marker + reasoning
             # 7. "codex" marker + actual response(s)
             # 8. "tokens used" metadata
+            # 9. Internal error logs (to be stripped)
 
             found_codex_marker = False
             response_lines = []
@@ -4940,6 +4941,10 @@ You can mention an agent in your prompt and it will auto-delegate:
                 # Stop at tokens metadata
                 if "tokens" in line_lower and "used" in line_lower:
                     break
+
+                # Strip internal error logs (e.g., "2026-04-29T01:38:52.799391Z ERROR codex_core::...")
+                if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*ERROR", line):
+                    continue
 
                 # Before codex marker, skip everything
                 if not found_codex_marker:

--- a/tests/test_issue_283_codex_error_stripping.py
+++ b/tests/test_issue_283_codex_error_stripping.py
@@ -1,0 +1,117 @@
+"""
+Test Issue #283: Bug - Codex responses append internal session rollout error
+
+This test verifies that internal error logs from the Codex runtime are properly
+stripped from user-facing responses.
+"""
+
+import sys
+import os
+from pathlib import Path
+
+# Add parent directory to path to import agent_manager
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_manager import SessionManager
+
+
+def test_issue_283_codex_error_stripping():
+    """
+    Verify that Codex responses with internal error logs are properly cleaned.
+
+    The bug was that responses ended with:
+    2026-04-29T01:38:52.799391Z ERROR codex_core::sessionn: failed to record rollout items: thread 019dd6e3-7e78-7c73-92ca-ad208c03ef53 not found
+
+    This test ensures such error lines are stripped from the final output.
+    """
+    manager = SessionManager()
+
+    # Sample Codex output with the problematic error at the end
+    codex_output_with_error = """[Session] Starting new CODEX session with model gpt-5.3-codex in normal mode
+
+codex
+The answer is 4.
+
+2 + 2 = 4
+
+tokens used: 42
+2026-04-29T01:38:52.799391Z ERROR codex_core::sessionn: failed to record rollout items: thread 019dd6e3-7e78-7c73-92ca-ad208c03ef53 not found"""
+
+    # Apply strip_metadata for codex runtime
+    result = manager.strip_metadata(codex_output_with_error, "codex")
+
+    # Expected: The response should contain the actual answer but NOT the error line
+    assert "The answer is 4." in result, "Response should contain the actual answer"
+    assert "2 + 2 = 4" in result, "Response should contain the calculation"
+    assert "ERROR" not in result, "Response should not contain ERROR lines"
+    assert "failed to record rollout items" not in result, (
+        "Response should not contain internal error messages"
+    )
+    assert "tokens used" not in result, "Response should not contain tokens metadata"
+
+    # Verify the response is clean
+    lines = result.split("\n")
+    for line in lines:
+        assert not line.startswith("2026-"), (
+            f"Response should not contain timestamp-prefixed lines: {line}"
+        )
+
+
+def test_issue_283_codex_multiple_errors():
+    """
+    Test that Codex output with multiple error lines is properly handled.
+    """
+    manager = SessionManager()
+
+    codex_output_multi_error = """[Session] Starting new CODEX session
+
+codex
+Here is your solution.
+
+It works great.
+
+tokens used: 100
+2026-04-29T01:38:52.799391Z ERROR codex_core::sessionn: failed to record rollout items: thread 019dd6e3-7e78-7c73-92ca-ad208c03ef53 not found
+2026-04-29T01:38:53.123456Z ERROR codex_core::sessions: cleanup failed"""
+
+    result = manager.strip_metadata(codex_output_multi_error, "codex")
+
+    assert "Here is your solution." in result
+    assert "It works great." in result
+    assert "ERROR" not in result
+    assert "failed to record" not in result
+    assert "cleanup failed" not in result
+
+
+def test_issue_283_codex_clean_output():
+    """
+    Ensure that Codex output without errors remains unchanged.
+    """
+    manager = SessionManager()
+
+    clean_codex_output = """[Session] Starting new CODEX session
+
+codex
+Clean response without errors.
+
+tokens used: 50"""
+
+    result = manager.strip_metadata(clean_codex_output, "codex")
+
+    assert "Clean response without errors." in result
+    assert "tokens used" not in result  # metadata stripped
+    assert "ERROR" not in result
+    assert len(result.strip()) > 0
+
+
+if __name__ == "__main__":
+    test_issue_283_codex_error_stripping()
+    print("✓ test_issue_283_codex_error_stripping passed")
+
+    test_issue_283_codex_multiple_errors()
+    print("✓ test_issue_283_codex_multiple_errors passed")
+
+    test_issue_283_codex_clean_output()
+    print("✓ test_issue_283_codex_clean_output passed")
+
+    print("\nAll tests passed!")


### PR DESCRIPTION
## Issue
Codex responses were ending with internal session rollout error logs that should not be surfaced to users.

Example error line:
```
2026-04-29T01:38:52.799391Z ERROR codex_core::sessionn: failed to record rollout items: thread 019dd6e3-7e78-7c73-92ca-ad208c03ef53 not found
```

## Fix
Added filtering in the `strip_metadata()` method for the Codex runtime to remove lines matching the internal error pattern:
- Pattern: `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*ERROR`
- These lines are now skipped during metadata stripping

## Testing
Added comprehensive regression tests:
- `test_issue_283_codex_error_stripping` — Single error line removal
- `test_issue_283_codex_multiple_errors` — Multiple error lines removal
- `test_issue_283_codex_clean_output` — Clean output preservation

All tests pass successfully.

Closes #283