### PR TITLE
feat: add Devin ACP runtime

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -10319,6 +10319,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             "gemini",
             "codex",
             "devin",
+            "devin-acp",
             "cursor",
             "wee",
         }

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -968,6 +968,7 @@ def check_runtime_available(runtime: str) -> bool:
         "gemini": "gemini",
         "codex": "codex",
         "devin": "devin",
+        "devin-acp": "devin",
         "cursor": "agent",  # Cursor uses 'agent' binary
         "opencode": "opencode",
         "wee": "openai",  # OpenAI-compatible API (no binary needed),
@@ -1025,6 +1026,7 @@ def get_available_runtimes() -> List[Dict[str, str]]:
         {"id": "gemini", "label": "gemini"},
         {"id": "codex", "label": "codex"},
         {"id": "devin", "label": "devin"},
+        {"id": "devin-acp", "label": "devin-acp", "icon": "🤖"},
         {"id": "cursor", "label": "cursor", "icon": "🖱️"},
         {"id": "wee", "label": "wee", "icon": "🍀"},
     ]
@@ -2256,13 +2258,14 @@ You can mention an agent in your prompt and it will auto-delegate:
                 "gemini",
                 "codex",
                 "devin",
+                "devin-acp",
                 "cursor",
                 "wee",
             ]:
                 return (
                     f"Unknown runtime: '{new_runtime}'. Use "
                     "copilot, copilot-sdk, opencode, claude, claude-sdk, "
-                    "gemini, codex, devin, cursor, or wee."
+                    "gemini, codex, devin, devin-acp, cursor, or wee."
                 )
 
             # Capture previous session state before any updates
@@ -2337,7 +2340,7 @@ You can mention an agent in your prompt and it will auto-delegate:
                 default_model = "gemini-1.5-flash"
             elif new_runtime == "codex":
                 default_model = "gpt-5.4"
-            elif new_runtime == "devin":
+            elif new_runtime in ("devin", "devin-acp"):
                 default_model = os.getenv("DEVIN_DEFAULT_MODEL", "claude-sonnet-4")
             elif new_runtime == "cursor":
                 default_model = os.getenv("CURSOR_DEFAULT_MODEL", "auto")
@@ -3759,6 +3762,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "gemini": self._env_gemini_models,
             "codex": self._env_codex_models,
             "devin": self._env_devin_models,
+            "devin-acp": self._env_devin_models,
             "cursor": self._env_cursor_models,
             "wee": self._env_wee_models,
         }
@@ -3777,6 +3781,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "codex": self.CODEX_MODELS,
             "opencode": self.OPENCODE_MODELS,
             "devin": self.DEVIN_MODELS,
+            "devin-acp": self.DEVIN_MODELS,
             "cursor": self.CURSOR_MODELS,
             "wee": self.WEE_MODELS,
         }
@@ -4061,6 +4066,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "gemini": self.fetch_gemini_models,
             "codex": self.fetch_codex_models,
             "devin": self.fetch_devin_models,
+            "devin-acp": self.fetch_devin_models,
             "cursor": self.fetch_cursor_models,
             "wee": self.fetch_wee_models,
         }
@@ -4138,7 +4144,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             default_model = "gemini-1.5-flash"
         elif default_runtime == "codex":
             default_model = "gpt-5.4"
-        elif default_runtime == "devin":
+        elif default_runtime in ("devin", "devin-acp"):
             default_model = os.getenv("DEVIN_DEFAULT_MODEL", "claude-sonnet-4")
         elif default_runtime == "cursor":
             default_model = os.getenv("CURSOR_DEFAULT_MODEL", "auto")
@@ -4217,7 +4223,7 @@ You can mention an agent in your prompt and it will auto-delegate:
                     current_model, "codex"
                 ):
                     merged["model"] = "gpt-5.4"
-            elif runtime == "devin":
+            elif runtime in ("devin", "devin-acp"):
                 current_model = merged.get("model", "")
                 if not current_model or not self.get_model_from_name(
                     current_model, "devin"
@@ -4247,6 +4253,7 @@ You can mention an agent in your prompt and it will auto-delegate:
                 "copilot",
                 "copilot-sdk",
                 "devin",
+                "devin-acp",
                 "cursor",
                 "wee",
             ]:
@@ -4598,7 +4605,7 @@ You can mention an agent in your prompt and it will auto-delegate:
         name_lower = name.lower().strip("\"'")
 
         # Ensure env models are loaded/cached by triggering fetch for this runtime
-        if runtime in ("claude", "gemini", "codex", "devin", "cursor"):
+        if runtime in ("claude", "gemini", "codex", "devin", "devin-acp", "cursor"):
             self.get_models_for_runtime(runtime)
 
         # Step 1: check env-loaded or static alias tables for all runtimes that have them.
@@ -4607,6 +4614,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "gemini": self._env_gemini_models,
             "codex": self._env_codex_models,
             "devin": self._env_devin_models,
+            "devin-acp": self._env_devin_models,
             "cursor": self._env_cursor_models,
             "wee": self._env_wee_models,
         }
@@ -4616,6 +4624,7 @@ You can mention an agent in your prompt and it will auto-delegate:
             "codex": self.CODEX_MODELS,
             "opencode": self.OPENCODE_MODELS,
             "devin": self.DEVIN_MODELS,
+            "devin-acp": self.DEVIN_MODELS,
             "cursor": self.CURSOR_MODELS,
             "wee": self.WEE_MODELS,
         }
@@ -8042,6 +8051,87 @@ User Request:
 
         return self.strip_metadata(output, "devin")
 
+    def run_devin_acp(
+        self,
+        prompt: str,
+        model: str,
+        agent: str,
+        session_id: Optional[str],
+        resume: bool,
+        n8n_session_id: str,
+        timeout: Optional[int] = None,
+        render_type: str = "text",
+        mode: str = "restricted",
+    ) -> str:
+        """Execute Devin via ACP JSON-RPC stdio and stream structured updates."""
+        prompt, parsed_mode = self._parse_mode_command(prompt)
+        session_data = self.get_or_create_session_data(n8n_session_id)
+        if mode != "restricted":
+            pass
+        elif parsed_mode != "restricted":
+            mode = parsed_mode
+        else:
+            mode = self._resolve_permission_mode(session_data, parsed_mode)
+
+        agent_dir = self.AGENTS.get(agent, self.AGENTS["orchestrator"])["path"]
+        effective_timeout = timeout if timeout is not None else self.command_timeout
+        channel = session_data.get("channel", "webui")
+        devin_bin = self.devin_bin or "devin"
+
+        context_prompt = self.build_agent_context_prompt(
+            agent,
+            prompt,
+            n8n_session_id,
+            render_type,
+            effective_timeout,
+            "devin-acp",
+            model,
+            channel,
+        )
+        if mode == "elevated":
+            context_prompt += (
+                "\n\n[ELEVATED MODE ENABLED]\n"
+                "Full permissions granted. Execute required work without asking for confirmation."
+            )
+        elif mode == "sandboxed":
+            context_prompt += (
+                "\n\n[SANDBOXED MODE ENABLED]\n"
+                "Read-only access only. Do NOT modify files or run destructive commands."
+            )
+
+        stream_buffer = getattr(self, "_stream_buffers", {}).get(n8n_session_id)
+        tracked_pid = {"pid": None}
+
+        def _push(kind, data):
+            if stream_buffer:
+                stream_buffer.push(kind, data)
+
+        def _on_pid(pid: int):
+            tracked_pid["pid"] = pid
+            self.track_running_query(n8n_session_id, pid, "devin-acp", agent, prompt)
+
+        try:
+            from devin_acp_runtime import DevinACPAdapter
+
+            adapter = DevinACPAdapter(
+                devin_bin=devin_bin,
+                cwd=agent_dir,
+                model=model,
+                mode=mode,
+                timeout=effective_timeout,
+                stream_push=_push,
+                on_pid=_on_pid,
+            )
+            output = adapter.run(context_prompt)
+        except Exception as exc:
+            output = f"Error (Devin ACP): {type(exc).__name__}: {exc}"
+        finally:
+            self.clear_running_query(n8n_session_id)
+
+        if stream_buffer:
+            stream_buffer.push("done", output)
+        return self.strip_metadata(output, "devin")
+
     def run_cursor(
         self,
         prompt: str,
@@ -9123,6 +9213,19 @@ User Request:
                 n8n_session_id,
                 effective_timeout,
                 render_type,
+                mode,
+            )
+        elif runtime == "devin-acp":
+            result = self.run_devin_acp(
+                prompt,
+                model,
+                agent,
+                session_id if can_resume else None,
+                can_resume,
+                n8n_session_id,
+                effective_timeout,
+                render_type,
+                mode,
             )
         elif runtime == "cursor":
             result = self.run_cursor(
@@ -9232,7 +9335,7 @@ User Request:
         # For Gemini, we always try to resume the latest session for context retention
         if current_runtime == "gemini":
             can_resume = True  # Always attempt to resume latest Gemini session
-        elif current_runtime == "devin":
+        elif current_runtime in ("devin", "devin-acp"):
             # Devin handles its own session resumption internally via
             # _get_devin_session_id(); pass n8n_session_id for correct lookup
             can_resume = (

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -8113,6 +8113,7 @@ User Request:
         try:
             from devin_acp_runtime import DevinACPAdapter
 
+            existing_devin_session_id = self._get_devin_session_id(n8n_session_id)
             adapter = DevinACPAdapter(
                 devin_bin=devin_bin,
                 cwd=agent_dir,
@@ -8121,8 +8122,19 @@ User Request:
                 timeout=effective_timeout,
                 stream_push=_push,
                 on_pid=_on_pid,
+                existing_session_id=existing_devin_session_id,
+                resume=bool(resume and existing_devin_session_id),
             )
             output = adapter.run(context_prompt)
+            if adapter.session_id:
+                self.devin_session_dir.mkdir(exist_ok=True)
+                mapping_file = self.devin_session_dir / f"{n8n_session_id}.json"
+                with open(mapping_file, "w") as f:
+                    json.dump({"devin_session_id": adapter.session_id}, f)
+                print(
+                    f"[Session] Stored devin-acp session mapping: {n8n_session_id[:8]}... → {adapter.session_id[:8]}...",
+                    file=sys.stderr,
+                )
         except Exception as exc:
             output = f"Error (Devin ACP): {type(exc).__name__}: {exc}"
         finally:
@@ -8909,8 +8921,10 @@ User Request:
                     _re_uuid.IGNORECASE,
                 )
             )
-        elif runtime == "devin":
-            # Devin session mappings are keyed by n8n_session_id, not backend session_id
+        elif runtime in ("devin", "devin-acp"):
+            # Devin session mappings are keyed by n8n_session_id, not backend session_id.
+            # devin-acp stores the ACP sessionId in the same mapping file so follow-up
+            # turns can call session/load and retain conversation context.
             key = n8n_session_id if n8n_session_id else session_id
             return (self.devin_session_dir / f"{key}.json").exists()
         elif runtime == "cursor":

--- a/devin_acp_runtime.py
+++ b/devin_acp_runtime.py
@@ -35,6 +35,7 @@ class DevinACPAdapter:
     client_name: str = "wee-orchestrator-devin-acp"
     existing_session_id: Optional[str] = None
     resume: bool = False
+    ignore_replay_on_load: bool = True
 
     proc: Optional[asyncio.subprocess.Process] = None
     next_id: int = 1
@@ -45,6 +46,8 @@ class DevinACPAdapter:
     _turn_done: Optional[asyncio.Event] = None
     _prompt_result: Any = None
     _prompt_error: Optional[BaseException] = None
+    _loading_existing_session: bool = False
+    _accepting_current_turn: bool = False
 
     def run(self, prompt: str) -> str:
         """Run one ACP turn and return the final assistant text."""
@@ -84,7 +87,11 @@ class DevinACPAdapter:
             if self.resume and self.existing_session_id:
                 session_params["sessionId"] = self.existing_session_id
                 try:
-                    session = await self._rpc("session/load", session_params)
+                    self._loading_existing_session = bool(self.ignore_replay_on_load)
+                    try:
+                        session = await self._rpc("session/load", session_params)
+                    finally:
+                        self._loading_existing_session = False
                     self.session_id = self.existing_session_id
                     self._push("tool_call", {
                         "event": "status",
@@ -129,6 +136,7 @@ class DevinACPAdapter:
                     "timestamp": self._ts(),
                 })
 
+            self._accepting_current_turn = True
             prompt_task = asyncio.create_task(
                 self._rpc(
                     "session/prompt",
@@ -262,6 +270,12 @@ class DevinACPAdapter:
     def _handle_session_update(self, params: dict[str, Any]) -> None:
         update = params.get("update") or params
         kind = update.get("sessionUpdate") or update.get("type")
+        if self._loading_existing_session and not self._accepting_current_turn:
+            # ACP session/load is allowed to replay the entire prior transcript.
+            # That history is useful to Devin internally, but it must not be
+            # collected or streamed as the current response; otherwise a new
+            # follow-up can appear to answer with content from a previous turn.
+            return
         if kind == "agent_message_chunk":
             text = self._extract_text(update.get("content"))
             if text:

--- a/devin_acp_runtime.py
+++ b/devin_acp_runtime.py
@@ -1,0 +1,327 @@
+"""Devin ACP runtime adapter for Wee-Orchestrator.
+
+This module talks to ``devin acp`` over JSON-RPC stdio and translates ACP
+``session/update`` notifications into Wee's existing stream-buffer events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+
+StreamPush = Callable[[str, Any], None]
+PidCallback = Callable[[int], None]
+
+
+@dataclass
+class DevinACPAdapter:
+    """Synchronous wrapper around the async Devin ACP JSON-RPC protocol."""
+
+    devin_bin: str = "devin"
+    cwd: str = "."
+    model: Optional[str] = None
+    mode: str = "restricted"
+    timeout: int = 900
+    stream_push: Optional[StreamPush] = None
+    on_pid: Optional[PidCallback] = None
+    client_name: str = "wee-orchestrator-devin-acp"
+
+    proc: Optional[asyncio.subprocess.Process] = None
+    next_id: int = 1
+    pending: dict[int, asyncio.Future] = field(default_factory=dict)
+    session_id: Optional[str] = None
+    collected_text: list[str] = field(default_factory=list)
+    stderr_lines: list[str] = field(default_factory=list)
+    _turn_done: Optional[asyncio.Event] = None
+    _prompt_result: Any = None
+    _prompt_error: Optional[BaseException] = None
+
+    def run(self, prompt: str) -> str:
+        """Run one ACP turn and return the final assistant text."""
+        return asyncio.run(self._run(prompt))
+
+    async def _run(self, prompt: str) -> str:
+        await self._start()
+        assert self.proc is not None
+        self._turn_done = asyncio.Event()
+        try:
+            init_result = await self._rpc(
+                "initialize",
+                {
+                    "protocolVersion": 1,
+                    "clientInfo": {"name": self.client_name, "version": "0.1"},
+                    "clientCapabilities": {
+                        "terminal": False,
+                        "fs": {"readTextFile": False, "writeTextFile": False},
+                    },
+                },
+            )
+            self._push("tool_call", {
+                "event": "status",
+                "id": "devin-acp-initialize",
+                "name": "devin-acp",
+                "output": f"Initialized Devin ACP: {self._agent_name(init_result)}",
+                "runtime": "devin-acp",
+                "timestamp": self._ts(),
+            })
+
+            new_params: dict[str, Any] = {"cwd": self.cwd, "mcpServers": []}
+            if self.model:
+                # Some ACP servers ignore model here and require a mode/config API;
+                # passing it is harmless when unsupported by Devin's current schema.
+                new_params["model"] = self.model
+            session = await self._rpc("session/new", new_params)
+            self.session_id = session.get("sessionId") or session.get("id")
+            if not self.session_id:
+                raise RuntimeError(f"Devin ACP session/new returned no sessionId: {session!r}")
+
+            mode_id = self._mode_to_acp(self.mode)
+            try:
+                await self._rpc(
+                    "session/set_mode",
+                    {"sessionId": self.session_id, "modeId": mode_id},
+                )
+            except Exception as exc:  # non-fatal; older builds may not support this
+                self._push("tool_call", {
+                    "event": "status",
+                    "id": "devin-acp-mode",
+                    "name": "session/set_mode",
+                    "output": f"Could not set ACP mode {mode_id}: {exc}",
+                    "runtime": "devin-acp",
+                    "timestamp": self._ts(),
+                })
+
+            prompt_task = asyncio.create_task(
+                self._rpc(
+                    "session/prompt",
+                    {
+                        "sessionId": self.session_id,
+                        "prompt": [{"type": "text", "text": prompt}],
+                    },
+                )
+            )
+
+            done_task = asyncio.create_task(self._turn_done.wait())
+            wait_timeout = max(1, int(self.timeout))
+            done, pending = await asyncio.wait(
+                {prompt_task, done_task},
+                timeout=wait_timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                raise TimeoutError(f"Devin ACP timed out after {wait_timeout}s")
+
+            if prompt_task in done:
+                self._prompt_result = prompt_task.result()
+                if not done_task.done():
+                    # Give final session/update notifications a brief chance to arrive.
+                    try:
+                        await asyncio.wait_for(done_task, timeout=2.0)
+                    except asyncio.TimeoutError:
+                        pass
+            elif done_task in done:
+                if not prompt_task.done():
+                    # The stopped notification is authoritative; do not hang on RPC.
+                    prompt_task.cancel()
+                else:
+                    self._prompt_result = prompt_task.result()
+
+            result = "".join(self.collected_text).strip()
+            if not result and self._prompt_result is not None:
+                result = self._extract_text(self._prompt_result).strip()
+            if not result and self.stderr_lines:
+                result = "\n".join(self.stderr_lines[-20:]).strip()
+            return result or ""
+        finally:
+            await self._stop()
+
+    async def _start(self) -> None:
+        self.proc = await asyncio.create_subprocess_exec(
+            self.devin_bin,
+            "acp",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.cwd,
+        )
+        if self.on_pid and self.proc.pid:
+            self.on_pid(self.proc.pid)
+        asyncio.create_task(self._read_stdout())
+        asyncio.create_task(self._read_stderr())
+
+    async def _stop(self) -> None:
+        if not self.proc:
+            return
+        if self.proc.returncode is None:
+            self.proc.terminate()
+            try:
+                await asyncio.wait_for(self.proc.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                self.proc.kill()
+                await self.proc.wait()
+
+    async def _rpc(self, method: str, params: dict[str, Any]) -> Any:
+        assert self.proc and self.proc.stdin
+        rid = self.next_id
+        self.next_id += 1
+        fut = asyncio.get_running_loop().create_future()
+        self.pending[rid] = fut
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": rid, "method": method, "params": params},
+            separators=(",", ":"),
+        ) + "\n"
+        self.proc.stdin.write(body.encode())
+        await self.proc.stdin.drain()
+        return await fut
+
+    async def _read_stdout(self) -> None:
+        assert self.proc and self.proc.stdout
+        async for raw in self.proc.stdout:
+            line = raw.decode(errors="replace").strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except Exception:
+                self._push("tool_call", {
+                    "event": "status",
+                    "id": f"devin-acp-stdout-{time.time_ns()}",
+                    "name": "stdout",
+                    "output": line[:2000],
+                    "runtime": "devin-acp",
+                    "timestamp": self._ts(),
+                })
+                continue
+            if "id" in msg and msg["id"] in self.pending:
+                fut = self.pending.pop(msg["id"])
+                if "error" in msg:
+                    fut.set_exception(RuntimeError(json.dumps(msg["error"])))
+                else:
+                    fut.set_result(msg.get("result"))
+                continue
+            if msg.get("method") == "session/update":
+                self._handle_session_update(msg.get("params") or {})
+
+    async def _read_stderr(self) -> None:
+        assert self.proc and self.proc.stderr
+        async for raw in self.proc.stderr:
+            line = raw.decode(errors="replace").rstrip()
+            if not line:
+                continue
+            self.stderr_lines.append(line)
+            # Surface auth/MCP warnings without spamming every debug line.
+            lower = line.lower()
+            if any(k in lower for k in ("mcp", "auth", "error", "warn", "failed")):
+                self._push("tool_call", {
+                    "event": "status",
+                    "id": f"devin-acp-stderr-{time.time_ns()}",
+                    "name": "devin-stderr",
+                    "output": line[:2000],
+                    "runtime": "devin-acp",
+                    "timestamp": self._ts(),
+                })
+
+    def _handle_session_update(self, params: dict[str, Any]) -> None:
+        update = params.get("update") or params
+        kind = update.get("sessionUpdate") or update.get("type")
+        if kind == "agent_message_chunk":
+            text = self._extract_text(update.get("content"))
+            if text:
+                self.collected_text.append(text)
+                self._push("chunk", {"text": text})
+        elif kind == "agent_thought_chunk":
+            text = self._extract_text(update.get("content"))
+            if text:
+                self._push("tool_call", {
+                    "event": "status",
+                    "id": f"devin-thought-{time.time_ns()}",
+                    "name": "thought",
+                    "output": text[:2000],
+                    "runtime": "devin-acp",
+                    "timestamp": self._ts(),
+                })
+        elif kind == "tool_call":
+            tool_id = update.get("toolCallId") or update.get("id") or f"tc_devin_acp_{time.time_ns()}"
+            self._push("tool_call", {
+                "event": "start",
+                "id": tool_id,
+                "name": update.get("title") or update.get("name") or "tool",
+                "input": update.get("content") or update,
+                "runtime": "devin-acp",
+                "timestamp": self._ts(),
+            })
+        elif kind == "tool_call_update":
+            tool_id = update.get("toolCallId") or update.get("id") or f"tc_devin_acp_{time.time_ns()}"
+            status = update.get("status") or update.get("state") or "completed"
+            self._push("tool_call", {
+                "event": "completed" if status in ("completed", "complete", "done") else "result",
+                "id": tool_id,
+                "name": update.get("title") or update.get("name") or "tool",
+                "output": json.dumps(update, default=str)[:2000],
+                "status": status,
+                "is_error": status in ("error", "failed"),
+                "runtime": "devin-acp",
+                "timestamp": self._ts(),
+            })
+        elif kind == "usage_update":
+            # The SessionManager done event handles token metadata for Wee-native.
+            # For now, expose usage as a status event so it is visible/debuggable.
+            self._push("tool_call", {
+                "event": "status",
+                "id": f"devin-usage-{time.time_ns()}",
+                "name": "usage_update",
+                "output": json.dumps(update, default=str)[:1000],
+                "runtime": "devin-acp",
+                "timestamp": self._ts(),
+            })
+        elif kind in ("_cognition.ai/agent_stopped", "agent_stopped"):
+            if self._turn_done:
+                self._turn_done.set()
+
+    def _push(self, kind: str, data: Any) -> None:
+        if self.stream_push:
+            self.stream_push(kind, data)
+
+    @staticmethod
+    def _mode_to_acp(mode: str) -> str:
+        if mode == "elevated":
+            return "bypass"
+        if mode == "sandboxed":
+            return "plan"
+        return "ask"
+
+    @staticmethod
+    def _extract_text(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            if isinstance(value.get("text"), str):
+                return value["text"]
+            if isinstance(value.get("content"), str):
+                return value["content"]
+        if isinstance(value, list):
+            return "".join(DevinACPAdapter._extract_text(v) for v in value)
+        return ""
+
+    @staticmethod
+    def _agent_name(init_result: Any) -> str:
+        if isinstance(init_result, dict):
+            agent = init_result.get("agent") or init_result.get("agentInfo") or {}
+            if isinstance(agent, dict):
+                return str(agent.get("name") or init_result.get("name") or "unknown")
+            return str(agent)
+        return "unknown"
+
+    @staticmethod
+    def _ts() -> str:
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/devin_acp_runtime.py
+++ b/devin_acp_runtime.py
@@ -33,6 +33,8 @@ class DevinACPAdapter:
     stream_push: Optional[StreamPush] = None
     on_pid: Optional[PidCallback] = None
     client_name: str = "wee-orchestrator-devin-acp"
+    existing_session_id: Optional[str] = None
+    resume: bool = False
 
     proc: Optional[asyncio.subprocess.Process] = None
     next_id: int = 1
@@ -73,15 +75,43 @@ class DevinACPAdapter:
                 "timestamp": self._ts(),
             })
 
-            new_params: dict[str, Any] = {"cwd": self.cwd, "mcpServers": []}
+            session_params: dict[str, Any] = {"cwd": self.cwd, "mcpServers": []}
             if self.model:
                 # Some ACP servers ignore model here and require a mode/config API;
                 # passing it is harmless when unsupported by Devin's current schema.
-                new_params["model"] = self.model
-            session = await self._rpc("session/new", new_params)
-            self.session_id = session.get("sessionId") or session.get("id")
+                session_params["model"] = self.model
+
+            if self.resume and self.existing_session_id:
+                session_params["sessionId"] = self.existing_session_id
+                try:
+                    session = await self._rpc("session/load", session_params)
+                    self.session_id = self.existing_session_id
+                    self._push("tool_call", {
+                        "event": "status",
+                        "id": "devin-acp-session-load",
+                        "name": "session/load",
+                        "output": f"Loaded Devin ACP session {self.session_id}",
+                        "runtime": "devin-acp",
+                        "timestamp": self._ts(),
+                    })
+                except Exception as exc:
+                    self._push("tool_call", {
+                        "event": "status",
+                        "id": "devin-acp-session-load-fallback",
+                        "name": "session/load",
+                        "output": f"Could not load Devin ACP session {self.existing_session_id}: {exc}; starting a new session",
+                        "runtime": "devin-acp",
+                        "timestamp": self._ts(),
+                    })
+                    session_params.pop("sessionId", None)
+                    session = await self._rpc("session/new", session_params)
+                    self.session_id = session.get("sessionId") or session.get("id")
+            else:
+                session = await self._rpc("session/new", session_params)
+                self.session_id = session.get("sessionId") or session.get("id")
+
             if not self.session_id:
-                raise RuntimeError(f"Devin ACP session/new returned no sessionId: {session!r}")
+                raise RuntimeError(f"Devin ACP session setup returned no sessionId: {session!r}")
 
             mode_id = self._mode_to_acp(self.mode)
             try:

--- a/tests/test_devin_acp_runtime.py
+++ b/tests/test_devin_acp_runtime.py
@@ -77,6 +77,24 @@ class TestDevinACPAdapterMapping(unittest.TestCase):
         self.assertEqual(adapter.existing_session_id, "devin-session-1")
         self.assertTrue(adapter.resume)
 
+    def test_session_load_replay_is_not_streamed_or_collected(self):
+        self.adapter._loading_existing_session = True
+        self.adapter._accepting_current_turn = False
+        self.adapter._handle_session_update(
+            {"update": {"sessionUpdate": "agent_message_chunk", "content": {"text": "old answer"}}}
+        )
+        self.assertEqual(self.adapter.collected_text, [])
+        self.assertEqual(self.events, [])
+
+    def test_current_turn_after_load_is_streamed_and_collected(self):
+        self.adapter._loading_existing_session = False
+        self.adapter._accepting_current_turn = True
+        self.adapter._handle_session_update(
+            {"update": {"sessionUpdate": "agent_message_chunk", "content": {"text": "new answer"}}}
+        )
+        self.assertEqual(self.adapter.collected_text, ["new answer"])
+        self.assertEqual(self.events, [("chunk", {"text": "new answer"})])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_devin_acp_runtime.py
+++ b/tests/test_devin_acp_runtime.py
@@ -72,6 +72,11 @@ class TestDevinACPAdapterMapping(unittest.TestCase):
         self.assertEqual(DevinACPAdapter._mode_to_acp("sandboxed"), "plan")
         self.assertEqual(DevinACPAdapter._mode_to_acp("elevated"), "bypass")
 
+    def test_resume_fields_are_recorded(self):
+        adapter = DevinACPAdapter(existing_session_id="devin-session-1", resume=True)
+        self.assertEqual(adapter.existing_session_id, "devin-session-1")
+        self.assertTrue(adapter.resume)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_devin_acp_runtime.py
+++ b/tests/test_devin_acp_runtime.py
@@ -1,0 +1,77 @@
+"""Unit tests for the Devin ACP runtime adapter."""
+
+import unittest
+
+from devin_acp_runtime import DevinACPAdapter
+
+
+class TestDevinACPAdapterMapping(unittest.TestCase):
+    def setUp(self):
+        self.events = []
+        self.adapter = DevinACPAdapter(stream_push=lambda kind, data: self.events.append((kind, data)))
+
+    def test_agent_message_chunk_maps_to_chunk(self):
+        self.adapter._handle_session_update(
+            {"update": {"sessionUpdate": "agent_message_chunk", "content": {"text": "hello"}}}
+        )
+        self.assertEqual(self.adapter.collected_text, ["hello"])
+        self.assertEqual(self.events, [("chunk", {"text": "hello"})])
+
+    def test_tool_call_maps_to_wee_tool_start(self):
+        self.adapter._handle_session_update(
+            {
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "id": "tool-1",
+                    "name": "bash",
+                    "content": {"command": "pwd"},
+                }
+            }
+        )
+        kind, data = self.events[0]
+        self.assertEqual(kind, "tool_call")
+        self.assertEqual(data["event"], "start")
+        self.assertEqual(data["id"], "tool-1")
+        self.assertEqual(data["name"], "bash")
+        self.assertEqual(data["runtime"], "devin-acp")
+
+    def test_tool_call_update_maps_to_wee_tool_completed(self):
+        self.adapter._handle_session_update(
+            {
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "tool-1",
+                    "status": "completed",
+                    "output": "ok",
+                }
+            }
+        )
+        kind, data = self.events[0]
+        self.assertEqual(kind, "tool_call")
+        self.assertEqual(data["event"], "completed")
+        self.assertEqual(data["id"], "tool-1")
+        self.assertFalse(data["is_error"])
+
+    def test_agent_stopped_sets_turn_done_event_when_present(self):
+        class Done:
+            def __init__(self):
+                self.called = False
+
+            def set(self):
+                self.called = True
+
+        done = Done()
+        self.adapter._turn_done = done
+        self.adapter._handle_session_update(
+            {"update": {"sessionUpdate": "_cognition.ai/agent_stopped"}}
+        )
+        self.assertTrue(done.called)
+
+    def test_mode_mapping_is_conservative(self):
+        self.assertEqual(DevinACPAdapter._mode_to_acp("restricted"), "ask")
+        self.assertEqual(DevinACPAdapter._mode_to_acp("sandboxed"), "plan")
+        self.assertEqual(DevinACPAdapter._mode_to_acp("elevated"), "bypass")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a first-class `devin-acp` runtime that integrates Devin's ACP JSON-RPC stdio protocol into Wee-Orchestrator's existing runtime and WebUI streaming flow.

## What changed

- Add `devin_acp_runtime.py` adapter for `devin acp`
  - initializes ACP over stdio
  - creates or loads ACP sessions
  - sends prompts via `session/prompt`
  - maps `session/update` notifications into Wee stream events
- Register `devin-acp` as a selectable runtime
- Reuse Devin model discovery for the `devin-acp` model dropdown
- Add `/api/v1/models?runtime=devin-acp` support
- Persist ACP session IDs and resume follow-up turns with `session/load`
- Add focused unit tests for ACP event mapping and resume fields

## Validation

Ran locally:

```bash
.venv/bin/python -m py_compile agent_manager.py devin_acp_runtime.py tests/test_devin_acp_runtime.py
.venv/bin/python -m unittest -q tests.test_devin_acp_runtime
git diff --check upstream/main...HEAD
```

Result:

```text
Ran 6 tests in 0.000s
OK
```

Also smoke-tested follow-up context locally: the first turn stored a Devin ACP session ID and the second turn loaded that session and recalled a codeword from the previous turn.
