### PR TITLE
fix: validate model on background task submission (#292)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -12519,7 +12519,17 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
         agent = body.agent or defaults.get("agent", get_default_agent())
         runtime = body.runtime or defaults.get("runtime", get_default_runtime())
-        model = body.model or defaults.get("model", get_default_model())
+        raw_model = body.model or defaults.get("model", get_default_model())
+        resolved_model = session_mgr.get_model_from_name(raw_model, runtime)
+        if body.model and not resolved_model:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Invalid model '{body.model}' for runtime '{runtime}'. "
+                    f"Use GET /api/v1/models?runtime={runtime} to list available models."
+                ),
+            )
+        model = resolved_model or raw_model
 
         task_id = f"bg_{str(uuid4())[:8]}"
         session_id = str(uuid4())  # Must be valid UUID format for Copilot CLI

--- a/tests/test_issue_292_bg_task_model_validation.py
+++ b/tests/test_issue_292_bg_task_model_validation.py
@@ -1,0 +1,248 @@
+"""
+Regression test for Issue #292:
+POST /api/v1/background-tasks accepts any model string without validation — invalid
+model names are silently queued and fail at execution time.
+
+Expected behavior after fix:
+- Explicitly provided invalid model → HTTP 422
+- Explicitly provided valid model → accepted, resolved to canonical ID
+- No model provided → accepted (API uses runtime default)
+- "auto" as model name → HTTP 422 (not a valid model ID for any runtime)
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_292")
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "8099")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+
+def _start_app():
+    """Import and start the FastAPI app with minimal mocking."""
+    from unittest.mock import patch as _p
+
+    import agent_manager
+
+    patches = []
+
+    p1 = _p.object(
+        agent_manager,
+        "_resolve_telegram_identity",
+        side_effect=lambda identity: identity,
+    )
+    p1.start()
+    patches.append(p1)
+
+    p2 = _p.object(
+        agent_manager,
+        "_send_pairing_code",
+        return_value=True,
+    )
+    p2.start()
+    patches.append(p2)
+
+    app = agent_manager.create_api_app()
+    return app, patches
+
+
+class TestIssue292BgTaskModelValidation(unittest.TestCase):
+    """Background task model validation — reject invalid models at submission."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi.testclient import TestClient
+
+        cls.app, cls._patches = _start_app()
+        cls.client = TestClient(cls.app)
+        cls.auth = {
+            "Authorization": "Bearer shared_test_key_292",
+            "X-User-Identity": "test_user_292",
+            "X-Auth-Channel": "api",
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in cls._patches:
+            p.stop()
+
+    def _post_bg_task(self, payload):
+        return self.client.post(
+            "/api/v1/background-tasks",
+            json=payload,
+            headers=self.auth,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Core regression: invalid explicit model must return 422 (not 200/queued)
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def test_invalid_model_returns_422(self):
+        """Invalid model name must return 422, not silently queue the task."""
+        resp = self._post_bg_task(
+            {
+                "prompt": "Say hello",
+                "agent": "fosterbot",
+                "runtime": "copilot",
+                "model": "definitely-not-a-real-model-zzz999",
+            }
+        )
+        self.assertEqual(
+            resp.status_code,
+            422,
+            f"Expected 422 for invalid model, got {resp.status_code}",
+        )
+        detail = str(resp.json().get("detail", ""))
+        self.assertIn(
+            "definitely-not-a-real-model-zzz999",
+            detail,
+            "Error detail should include the invalid model name",
+        )
+
+    def test_auto_model_returns_422_for_explicit_model(self):
+        """'auto' is not a real model ID — must be rejected when explicit."""
+        resp = self._post_bg_task(
+            {
+                "prompt": "Say hello",
+                "agent": "fosterbot",
+                "runtime": "copilot",
+                "model": "auto",
+            }
+        )
+        self.assertEqual(
+            resp.status_code,
+            422,
+            f"'auto' should be rejected, got {resp.status_code}",
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Happy path: no model provided — should not reject
+    # ──────────────────────────────────────────────────────────────────────────
+
+    @patch("agent_manager.BackgroundTaskManager.create_task")
+    @patch("agent_manager.BackgroundTaskManager.count_running", return_value=0)
+    @patch("agent_manager.BackgroundTaskManager.count_queued", return_value=0)
+    def test_no_model_uses_default_and_succeeds(
+        self, mock_queued, mock_running, mock_create
+    ):
+        """Omitting 'model' should succeed — API resolves using default model."""
+        mock_task = {
+            "task_id": "bg_test292",
+            "session_id": "sess-292",
+            "agent": "fosterbot",
+            "runtime": "copilot",
+            "model": "claude-sonnet-4.6",
+            "status": "running",
+            "timeout": 900,
+            "permission_mode": "restricted",
+        }
+        mock_create.return_value = mock_task
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value = MagicMock()
+            resp = self._post_bg_task(
+                {
+                    "prompt": "Say hello",
+                    "agent": "fosterbot",
+                    "runtime": "copilot",
+                    # no "model" field
+                }
+            )
+
+        self.assertNotEqual(
+            resp.status_code,
+            422,
+            f"Omitting model should not return 422, got {resp.status_code}",
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Model resolved to canonical ID when valid alias/name is provided
+    # ──────────────────────────────────────────────────────────────────────────
+
+    @patch("agent_manager.BackgroundTaskManager.create_task")
+    @patch("agent_manager.BackgroundTaskManager.count_running", return_value=0)
+    @patch("agent_manager.BackgroundTaskManager.count_queued", return_value=0)
+    @patch(
+        "agent_manager.SessionManager.get_model_from_name",
+        return_value="claude-sonnet-4-6-20251001",
+    )
+    def test_valid_model_alias_is_resolved(
+        self, mock_get_model, mock_queued, mock_running, mock_create
+    ):
+        """A valid model alias should be resolved to canonical ID before creation."""
+        mock_task = {
+            "task_id": "bg_test292b",
+            "session_id": "sess-292b",
+            "agent": "fosterbot",
+            "runtime": "claude",
+            "model": "claude-sonnet-4-6-20251001",
+            "status": "running",
+            "timeout": 900,
+            "permission_mode": "restricted",
+        }
+        mock_create.return_value = mock_task
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value = MagicMock()
+            resp = self._post_bg_task(
+                {
+                    "prompt": "Say hello",
+                    "agent": "fosterbot",
+                    "runtime": "claude",
+                    "model": "claude-sonnet-4.6",
+                }
+            )
+
+        self.assertNotEqual(
+            resp.status_code,
+            422,
+            f"Valid model should not return 422, got {resp.status_code}",
+        )
+        mock_get_model.assert_called_with("claude-sonnet-4.6", "claude")
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Error message quality: must include the model name and runtime
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def test_422_error_includes_runtime_in_detail(self):
+        """422 error detail must mention the runtime for the caller to diagnose."""
+        resp = self._post_bg_task(
+            {
+                "prompt": "Say hello",
+                "runtime": "copilot",
+                "model": "not-a-model-xyz",
+            }
+        )
+        self.assertEqual(resp.status_code, 422)
+        detail = str(resp.json().get("detail", ""))
+        self.assertIn(
+            "copilot",
+            detail,
+            "Error detail should mention the runtime",
+        )
+
+    def test_422_error_includes_models_endpoint_hint(self):
+        """422 error detail should hint at the models endpoint for discovery."""
+        resp = self._post_bg_task(
+            {
+                "prompt": "Say hello",
+                "runtime": "claude",
+                "model": "gpt-4-turbo-invalid",
+            }
+        )
+        self.assertEqual(resp.status_code, 422)
+        detail = str(resp.json().get("detail", ""))
+        self.assertIn(
+            "/api/v1/models",
+            detail,
+            "Error detail should point to /api/v1/models endpoint",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Fixes #292 — background task endpoint now validates the `model` field on submission
instead of silently queuing invalid model names.

### Changes

**`agent_manager.py`** — `create_background_task` endpoint:
- Resolves model via `session_mgr.get_model_from_name(model, runtime)` before queuing
- Returns HTTP **422** with actionable error when caller provides an unresolvable model
- Falls back gracefully when model comes from inherited defaults (no error)

**`tests/test_issue_292_bg_task_model_validation.py`** — 6 regression tests:
- Invalid model name → 422
- `"auto"` model name → 422 (not a valid model ID)
- No model provided → accepted (uses runtime default)
- Valid model alias → resolved to canonical ID before task creation
- 422 error detail includes the model name and runtime
- 422 error hints at `/api/v1/models` for discovery

### Note on dispatcher fix

The dispatcher fix (`dispatch_wee_dev_work_queue.py`, `dispatch_wee_qa_work_queue.py`)
is dispatcher-scope per AGENTS.md and applied directly to prod — separate from this PR.

## Test plan
- [x] `python3 -m pytest tests/test_issue_292_bg_task_model_validation.py -v` — 6/6 pass
- [x] `python3 -m flake8 tests/test_issue_292_bg_task_model_validation.py` — clean

Closes #292
