### PR TITLE
feat: add thinking visibility toggle to wee-cli (#293)

### DIFF
--- a/tests/test_issue_293_thinking_visibility.py
+++ b/tests/test_issue_293_thinking_visibility.py
@@ -29,10 +29,10 @@ from wee_cli import (
     run_single_shot,
 )
 
-
 # ---------------------------------------------------------------------------
 # ThinkingBuffer unit tests
 # ---------------------------------------------------------------------------
+
 
 class TestThinkingBuffer(unittest.TestCase):
     """Unit tests for the ThinkingBuffer streaming state machine."""
@@ -140,6 +140,7 @@ class TestThinkingBuffer(unittest.TestCase):
 # _strip_thinking utility
 # ---------------------------------------------------------------------------
 
+
 class TestStripThinking(unittest.TestCase):
     """Tests for _strip_thinking post-processing helper."""
 
@@ -174,6 +175,7 @@ class TestStripThinking(unittest.TestCase):
 # build_parser: --show-thinking flag
 # ---------------------------------------------------------------------------
 
+
 class TestBuildParserShowThinking(unittest.TestCase):
     """Test that --show-thinking flag exists and defaults correctly."""
 
@@ -196,6 +198,7 @@ class TestBuildParserShowThinking(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # chat_stream: show_thinking integration
 # ---------------------------------------------------------------------------
+
 
 def _make_mock_stream(tokens):
     """Build a mock OpenAI streaming response from a list of token strings."""
@@ -296,11 +299,13 @@ class TestChatStreamThinking(unittest.TestCase):
 # agent_manager.strip_thinking_tags: existing behavior unchanged
 # ---------------------------------------------------------------------------
 
+
 class TestAgentManagerStripThinkingTags(unittest.TestCase):
     """Verify that agent_manager's strip_thinking_tags still works as before."""
 
     def setUp(self):
         import agent_manager
+
         self.mgr = agent_manager.SessionManager.__new__(agent_manager.SessionManager)
 
     def test_strips_complete_block(self):
@@ -320,9 +325,7 @@ class TestAgentManagerStripThinkingTags(unittest.TestCase):
         self.assertEqual(result, text)
 
     def test_strips_multiline(self):
-        result = self.mgr.strip_thinking_tags(
-            "Start<think>\nline1\nline2\n</think>End"
-        )
+        result = self.mgr.strip_thinking_tags("Start<think>\nline1\nline2\n</think>End")
         self.assertEqual(result, "Start" + "End".strip())
 
 

--- a/tests/test_issue_293_thinking_visibility.py
+++ b/tests/test_issue_293_thinking_visibility.py
@@ -1,0 +1,330 @@
+"""Tests for Issue #293: Toggle model thinking visibility in wee-cli and WebUI.
+
+Covers:
+- ThinkingBuffer: strips thinking by default, passes through when show=True
+- ThinkingBuffer: handles partial tags spanning chunk boundaries
+- ThinkingBuffer: handles unclosed <think> blocks
+- _strip_thinking: post-processing helper
+- chat_stream: show_thinking=False (default) strips thinking from stdout
+- chat_stream: show_thinking=True passes thinking to stdout
+- build_parser: --show-thinking flag exists and defaults to False
+- run_single_shot: show_thinking threads through to chat_stream
+- agent_manager.strip_thinking_tags: existing behavior unchanged
+"""
+
+import json
+import sys
+import os
+import unittest
+from io import StringIO
+from unittest.mock import MagicMock, patch, call
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from wee_cli import (
+    ThinkingBuffer,
+    _strip_thinking,
+    build_parser,
+    chat_stream,
+    run_single_shot,
+)
+
+
+# ---------------------------------------------------------------------------
+# ThinkingBuffer unit tests
+# ---------------------------------------------------------------------------
+
+class TestThinkingBuffer(unittest.TestCase):
+    """Unit tests for the ThinkingBuffer streaming state machine."""
+
+    def test_no_thinking_passthrough(self):
+        """Non-thinking content passes through unchanged."""
+        buf = ThinkingBuffer(show=False)
+        result = buf.feed("Hello, world!")
+        result += buf.flush()
+        self.assertEqual(result, "Hello, world!")
+        self.assertEqual(buf.thinking_blocks, [])
+
+    def test_thinking_stripped_by_default(self):
+        """<think>...</think> blocks are stripped from output when show=False."""
+        buf = ThinkingBuffer(show=False)
+        text = "Before<think>reasoning here</think>After"
+        result = buf.feed(text)
+        result += buf.flush()
+        self.assertEqual(result, "BeforeAfter")
+        self.assertEqual(buf.thinking_blocks, ["reasoning here"])
+
+    def test_thinking_shown_when_enabled(self):
+        """<think>...</think> blocks are included in output when show=True."""
+        buf = ThinkingBuffer(show=True)
+        text = "Before<think>reasoning here</think>After"
+        result = buf.feed(text)
+        result += buf.flush()
+        self.assertEqual(result, "Before<think>reasoning here</think>After")
+        self.assertEqual(buf.thinking_blocks, ["reasoning here"])
+
+    def test_thinking_stripped_across_chunks(self):
+        """Thinking stripping works when tags span multiple tokens."""
+        buf = ThinkingBuffer(show=False)
+        tokens = ["Pre", "<", "thi", "nk>", "some reason", "ing</", "think", ">Post"]
+        result = "".join(buf.feed(t) for t in tokens)
+        result += buf.flush()
+        self.assertEqual(result, "PrePost")
+        self.assertIn("some reasoning", buf.thinking_blocks[0])
+
+    def test_thinking_shown_across_chunks(self):
+        """Thinking passthrough works when tags span multiple tokens."""
+        buf = ThinkingBuffer(show=True)
+        tokens = ["Pre<thi", "nk>reas", "on</think>Post"]
+        result = "".join(buf.feed(t) for t in tokens)
+        result += buf.flush()
+        self.assertIn("Pre", result)
+        self.assertIn("Post", result)
+        self.assertIn("reason", result)
+
+    def test_unclosed_think_block_suppressed(self):
+        """Unclosed <think> block at end of stream is suppressed when show=False."""
+        buf = ThinkingBuffer(show=False)
+        result = buf.feed("Before<think>dangling thought")
+        result += buf.flush()
+        self.assertEqual(result, "Before")
+        self.assertEqual(len(buf.thinking_blocks), 1)
+        self.assertIn("dangling thought", buf.thinking_blocks[0])
+
+    def test_unclosed_think_block_shown(self):
+        """Unclosed <think> block at end of stream is included when show=True."""
+        buf = ThinkingBuffer(show=True)
+        result = buf.feed("Before<think>dangling thought")
+        result += buf.flush()
+        self.assertIn("Before", result)
+        self.assertIn("dangling thought", result)
+
+    def test_multiple_thinking_blocks(self):
+        """Multiple thinking blocks are all captured."""
+        buf = ThinkingBuffer(show=False)
+        text = "A<think>t1</think>B<think>t2</think>C"
+        result = buf.feed(text)
+        result += buf.flush()
+        self.assertEqual(result, "ABC")
+        self.assertEqual(len(buf.thinking_blocks), 2)
+        self.assertEqual(buf.thinking_blocks[0], "t1")
+        self.assertEqual(buf.thinking_blocks[1], "t2")
+
+    def test_empty_think_block(self):
+        """Empty <think></think> is stripped without error."""
+        buf = ThinkingBuffer(show=False)
+        result = buf.feed("Hello<think></think>World")
+        result += buf.flush()
+        self.assertEqual(result, "HelloWorld")
+
+    def test_no_thinking_in_response(self):
+        """Plain response without any thinking tags is unchanged."""
+        buf = ThinkingBuffer(show=False)
+        text = "This is a plain response with no thinking."
+        result = buf.feed(text)
+        result += buf.flush()
+        self.assertEqual(result, text)
+        self.assertEqual(buf.thinking_blocks, [])
+
+    def test_single_token_per_char(self):
+        """Works correctly even when fed one character at a time."""
+        buf = ThinkingBuffer(show=False)
+        text = "A<think>t</think>B"
+        result = "".join(buf.feed(c) for c in text)
+        result += buf.flush()
+        self.assertEqual(result, "AB")
+        self.assertEqual(buf.thinking_blocks, ["t"])
+
+
+# ---------------------------------------------------------------------------
+# _strip_thinking utility
+# ---------------------------------------------------------------------------
+
+class TestStripThinking(unittest.TestCase):
+    """Tests for _strip_thinking post-processing helper."""
+
+    def test_strips_complete_block(self):
+        result = _strip_thinking("Hello<think>reasoning</think>World")
+        self.assertNotIn("<think>", result)
+        self.assertNotIn("reasoning", result)
+        self.assertIn("Hello", result)
+        self.assertIn("World", result)
+
+    def test_strips_unclosed_block(self):
+        result = _strip_thinking("Before<think>trailing")
+        self.assertNotIn("<think>", result)
+        self.assertNotIn("trailing", result)
+        self.assertEqual(result, "Before")
+
+    def test_strips_multiline_block(self):
+        result = _strip_thinking("A<think>\nline1\nline2\n</think>B")
+        self.assertEqual(result, "AB")
+
+    def test_no_op_without_thinking(self):
+        text = "Just a normal response."
+        result = _strip_thinking(text)
+        self.assertEqual(result, text)
+
+    def test_strips_multiple_blocks(self):
+        result = _strip_thinking("A<think>t1</think>B<think>t2</think>C")
+        self.assertEqual(result, "ABC")
+
+
+# ---------------------------------------------------------------------------
+# build_parser: --show-thinking flag
+# ---------------------------------------------------------------------------
+
+class TestBuildParserShowThinking(unittest.TestCase):
+    """Test that --show-thinking flag exists and defaults correctly."""
+
+    def test_default_is_false(self):
+        parser = build_parser()
+        args = parser.parse_args(["Hello"])
+        self.assertFalse(args.show_thinking)
+
+    def test_flag_sets_true(self):
+        parser = build_parser()
+        args = parser.parse_args(["--show-thinking", "Hello"])
+        self.assertTrue(args.show_thinking)
+
+    def test_flag_in_help(self):
+        parser = build_parser()
+        help_text = parser.format_help()
+        self.assertIn("show-thinking", help_text)
+
+
+# ---------------------------------------------------------------------------
+# chat_stream: show_thinking integration
+# ---------------------------------------------------------------------------
+
+def _make_mock_stream(tokens):
+    """Build a mock OpenAI streaming response from a list of token strings."""
+    chunks = []
+    for token in tokens:
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = token
+        chunk.choices[0].delta.tool_calls = None
+        chunk.usage = None
+        chunks.append(chunk)
+    # Final chunk with no content
+    final = MagicMock()
+    final.choices = [MagicMock()]
+    final.choices[0].delta.content = None
+    final.choices[0].delta.tool_calls = None
+    final.usage = None
+    chunks.append(final)
+    return iter(chunks)
+
+
+class TestChatStreamThinking(unittest.TestCase):
+    """Integration tests for chat_stream with thinking visibility."""
+
+    def _make_client(self, tokens):
+        client = MagicMock()
+        client.chat.completions.create.return_value = _make_mock_stream(tokens)
+        return client
+
+    def test_thinking_hidden_by_default(self):
+        """By default, thinking content is not written to stdout."""
+        tokens = ["Before", "<think>", "secret reasoning", "</think>", "After"]
+        client = self._make_client(tokens)
+        stdout_capture = StringIO()
+        with patch("sys.stdout", stdout_capture):
+            response = chat_stream(
+                client=client,
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                show_thinking=False,
+            )
+        output = stdout_capture.getvalue()
+        self.assertNotIn("secret reasoning", output)
+        self.assertIn("Before", output)
+        self.assertIn("After", output)
+        # Full response with thinking is preserved in return value for history
+        self.assertIn("secret reasoning", response)
+
+    def test_thinking_shown_when_enabled(self):
+        """With show_thinking=True, thinking content is written to stdout."""
+        tokens = ["Before", "<think>", "reasoning", "</think>", "After"]
+        client = self._make_client(tokens)
+        stdout_capture = StringIO()
+        with patch("sys.stdout", stdout_capture):
+            response = chat_stream(
+                client=client,
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                show_thinking=True,
+            )
+        output = stdout_capture.getvalue()
+        self.assertIn("reasoning", output)
+        self.assertIn("Before", output)
+        self.assertIn("After", output)
+
+    def test_no_thinking_unaffected(self):
+        """Responses without thinking tags are unaffected by show_thinking."""
+        tokens = ["Hello", " ", "World"]
+        client = self._make_client(tokens)
+        stdout_capture = StringIO()
+        with patch("sys.stdout", stdout_capture):
+            response = chat_stream(
+                client=client,
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                show_thinking=False,
+            )
+        output = stdout_capture.getvalue()
+        self.assertIn("Hello World", output)
+        self.assertEqual(response, "Hello World")
+
+    def test_thinking_preserved_in_return_value(self):
+        """Full response including thinking is always returned (for session history)."""
+        tokens = ["A<think>thinking</think>B"]
+        client = self._make_client(tokens)
+        stdout_capture = StringIO()
+        with patch("sys.stdout", stdout_capture):
+            response = chat_stream(
+                client=client,
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                show_thinking=False,
+            )
+        self.assertIn("<think>thinking</think>", response)
+
+
+# ---------------------------------------------------------------------------
+# agent_manager.strip_thinking_tags: existing behavior unchanged
+# ---------------------------------------------------------------------------
+
+class TestAgentManagerStripThinkingTags(unittest.TestCase):
+    """Verify that agent_manager's strip_thinking_tags still works as before."""
+
+    def setUp(self):
+        import agent_manager
+        self.mgr = agent_manager.SessionManager.__new__(agent_manager.SessionManager)
+
+    def test_strips_complete_block(self):
+        result = self.mgr.strip_thinking_tags("Hello<think>reasoning</think>World")
+        self.assertNotIn("<think>", result)
+        self.assertNotIn("reasoning", result)
+        self.assertIn("Hello", result)
+        self.assertIn("World", result)
+
+    def test_strips_unclosed_block(self):
+        result = self.mgr.strip_thinking_tags("Before<think>trailing")
+        self.assertEqual(result, "Before")
+
+    def test_no_op_without_tags(self):
+        text = "Normal response text."
+        result = self.mgr.strip_thinking_tags(text)
+        self.assertEqual(result, text)
+
+    def test_strips_multiline(self):
+        result = self.mgr.strip_thinking_tags(
+            "Start<think>\nline1\nline2\n</think>End"
+        )
+        self.assertEqual(result, "Start" + "End".strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wee_cli.py
+++ b/wee_cli.py
@@ -478,7 +478,10 @@ class ThinkingBuffer:
         return "".join(output_parts)
 
     def flush(self) -> str:
-        """Flush remaining buffer at stream end. Returns any pending non-thinking text."""
+        """Flush remaining buffer at stream end.
+
+        Returns any pending non-thinking text.
+        """
         remaining = self._buf
         self._buf = ""
         if self.in_thinking:

--- a/wee_cli.py
+++ b/wee_cli.py
@@ -141,7 +141,9 @@ def _clone_messages(messages: list) -> list:
     return json.loads(json.dumps(messages))
 
 
-def _prepare_session_messages(system_prompt: str, existing_messages: list = None) -> tuple:
+def _prepare_session_messages(
+    system_prompt: str, existing_messages: list = None
+) -> tuple:
     """Build or resume a message list and return (messages, effective_system)."""
     effective_system = _build_effective_system_prompt(system_prompt).lstrip()
     if existing_messages:
@@ -454,12 +456,10 @@ class ThinkingBuffer:
                     self._current_thinking.append(thinking_text)
                     if self.show:
                         output_parts.append(thinking_text + self._CLOSE)
-                    self.thinking_blocks.append(
-                        "".join(self._current_thinking).strip()
-                    )
+                    self.thinking_blocks.append("".join(self._current_thinking).strip())
                     self._current_thinking = []
                     self.in_thinking = False
-                    self._buf = self._buf[pos + len(self._CLOSE):]
+                    self._buf = self._buf[pos + len(self._CLOSE) :]
             else:
                 pos = self._buf.find(self._OPEN)
                 if pos == -1:
@@ -473,7 +473,7 @@ class ThinkingBuffer:
                     if self.show:
                         output_parts.append(self._OPEN)
                     self.in_thinking = True
-                    self._buf = self._buf[pos + len(self._OPEN):]
+                    self._buf = self._buf[pos + len(self._OPEN) :]
 
         return "".join(output_parts)
 
@@ -489,7 +489,7 @@ class ThinkingBuffer:
             self.thinking_blocks.append("".join(self._current_thinking).strip())
             self._current_thinking = []
             self.in_thinking = False
-            return self._OPEN + remaining if self.show else ""
+            return remaining if self.show else ""
         return remaining
 
 
@@ -934,7 +934,9 @@ def run_interactive(
                     _print_error("Compact target must be between 10 and 90.")
                     continue
 
-                current_window = token_tracker.context_window or get_context_window(model)
+                current_window = token_tracker.context_window or get_context_window(
+                    model
+                )
                 token_tracker.context_window = current_window
                 before_tokens = count_message_tokens(messages, model)
                 target_tokens = max(1, int(current_window * (target_pct / 100.0)))
@@ -1220,8 +1222,8 @@ def run_interactive(
                         timeout,
                         output_format,
                         permission,
-                        ),
-                    )
+                    ),
+                )
             if (
                 token_tracker.context_window
                 and token_tracker.percent_used() >= COMPACT_TRIGGER_FRACTION * 100
@@ -1514,7 +1516,9 @@ def main(argv=None):
         session_name = "default"
 
     session_data = {}
-    should_resume_session = bool(args.resume or (session_name == "default" and default_interactive))
+    should_resume_session = bool(
+        args.resume or (session_name == "default" and default_interactive)
+    )
     if session_name and should_resume_session:
         session_data = load_session_data(session_name)
 

--- a/wee_cli.py
+++ b/wee_cli.py
@@ -397,6 +397,99 @@ def _print_info(msg: str):
         print(msg, file=sys.stderr)
 
 
+def _strip_thinking(text: str) -> str:
+    """Remove <think>...</think> blocks from text."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<think>.*", "", text, flags=re.DOTALL)
+    return text.strip()
+
+
+class ThinkingBuffer:
+    """State machine that filters <think>...</think> blocks during streaming.
+
+    When show=False (default): thinking content is buffered and discarded;
+    only non-thinking content is returned from feed().
+
+    When show=True: all content is returned unchanged; thinking blocks are
+    additionally recorded in thinking_blocks for inspection.
+    """
+
+    _OPEN = "<think>"
+    _CLOSE = "</think>"
+
+    def __init__(self, show: bool = False):
+        self.show = show
+        self.in_thinking = False
+        self._buf = ""
+        self._current_thinking: list = []
+        self.thinking_blocks: list = []
+
+    @staticmethod
+    def _longest_prefix_suffix(s: str, tag: str) -> int:
+        """Return len of longest suffix of s that is a prefix of tag (< len(tag))."""
+        max_len = min(len(tag) - 1, len(s))
+        for length in range(max_len, 0, -1):
+            if s[-length:] == tag[:length]:
+                return length
+        return 0
+
+    def feed(self, token: str) -> str:
+        """Process a streaming token. Returns text that should be written to stdout."""
+        self._buf += token
+        output_parts: list = []
+
+        while self._buf:
+            if self.in_thinking:
+                pos = self._buf.find(self._CLOSE)
+                if pos == -1:
+                    tail = self._longest_prefix_suffix(self._buf, self._CLOSE)
+                    safe = self._buf[:-tail] if tail else self._buf
+                    self._current_thinking.append(safe)
+                    if self.show:
+                        output_parts.append(safe)
+                    self._buf = self._buf[-tail:] if tail else ""
+                    break
+                else:
+                    thinking_text = self._buf[:pos]
+                    self._current_thinking.append(thinking_text)
+                    if self.show:
+                        output_parts.append(thinking_text + self._CLOSE)
+                    self.thinking_blocks.append(
+                        "".join(self._current_thinking).strip()
+                    )
+                    self._current_thinking = []
+                    self.in_thinking = False
+                    self._buf = self._buf[pos + len(self._CLOSE):]
+            else:
+                pos = self._buf.find(self._OPEN)
+                if pos == -1:
+                    tail = self._longest_prefix_suffix(self._buf, self._OPEN)
+                    safe = self._buf[:-tail] if tail else self._buf
+                    output_parts.append(safe)
+                    self._buf = self._buf[-tail:] if tail else ""
+                    break
+                else:
+                    output_parts.append(self._buf[:pos])
+                    if self.show:
+                        output_parts.append(self._OPEN)
+                    self.in_thinking = True
+                    self._buf = self._buf[pos + len(self._OPEN):]
+
+        return "".join(output_parts)
+
+    def flush(self) -> str:
+        """Flush remaining buffer at stream end. Returns any pending non-thinking text."""
+        remaining = self._buf
+        self._buf = ""
+        if self.in_thinking:
+            self._current_thinking.append(remaining)
+            self.thinking_blocks.append("".join(self._current_thinking).strip())
+            self._current_thinking = []
+            self.in_thinking = False
+            return self._OPEN + remaining if self.show else ""
+        return remaining
+
+
 # ---------------------------------------------------------------------------
 # Token usage tracking
 # ---------------------------------------------------------------------------
@@ -468,6 +561,7 @@ def chat_stream(
     permission: str = "auto",
     stream_output: bool = True,
     tool_results_buffer: dict = None,
+    show_thinking: bool = False,
 ) -> str:
     """Send a chat completion request and stream the response.
 
@@ -479,12 +573,16 @@ def chat_stream(
             treated the same as "auto" (no additional privilege escalation in CLI).
         tool_results_buffer: Optional dict to collect tool results. Will be populated
             with {tool_name: result} entries during tool execution.
-    Returns the full response text. Handles tool-calling loops.
+        show_thinking: When True, stream <think>...</think> blocks to stdout.
+            When False (default), thinking blocks are suppressed from stdout but
+            the full response (including thinking) is still returned for history.
+    Returns the full response text including thinking. Handles tool-calling loops.
     """
     tool_call_counter = 0
     collected_output = []
     if tool_results_buffer is None:
         tool_results_buffer = {}
+    thinking_filter = ThinkingBuffer(show=show_thinking)
 
     for round_num in range(MAX_TOOL_ROUNDS + 1):
         create_kwargs = {
@@ -519,8 +617,10 @@ def chat_stream(
                 token = delta.content
                 round_content.append(token)
                 if stream_output:
-                    sys.stdout.write(token)
-                    sys.stdout.flush()
+                    filtered = thinking_filter.feed(token)
+                    if filtered:
+                        sys.stdout.write(filtered)
+                        sys.stdout.flush()
 
             if getattr(delta, "tool_calls", None):
                 for tc_delta in delta.tool_calls:
@@ -546,6 +646,12 @@ def chat_stream(
             # Track usage from the final chunk
             if hasattr(chunk, "usage") and chunk.usage and token_tracker:
                 token_tracker.update(chunk.usage)
+
+        if stream_output:
+            remaining = thinking_filter.flush()
+            if remaining:
+                sys.stdout.write(remaining)
+                sys.stdout.flush()
 
         content_text = "".join(round_content)
 
@@ -675,6 +781,8 @@ Wee CLI Interactive Mode — Commands:
   /tools              Show tool status
   /tools on|off       Enable/disable tool calling
   /tools-output       Show last tool call outputs
+  /thinking           Show thinking visibility status
+  /thinking on|off    Show or hide model thinking output (default: off)
   /permission MODE    Set permission level (restricted, auto, elevated)
   /agents             List agents. Use call_agent tool to dispatch work
   /skills             List available skills (alias: /discover-skills)
@@ -700,6 +808,7 @@ def run_interactive(
     model_str: str = None,
     session_name: str = None,
     existing_messages: list = None,
+    show_thinking: bool = False,
 ) -> str:
     """Run the interactive REPL.
 
@@ -913,6 +1022,20 @@ def run_interactive(
                     _print_error(f"Invalid argument: {arg}. Use 'on' or 'off'.")
                 continue
 
+            elif cmd == "/thinking":
+                if not arg:
+                    status = "on" if show_thinking else "off"
+                    _print_info(f"Model thinking visibility is {status}.")
+                elif arg.lower() in ("on", "show", "yes", "true"):
+                    show_thinking = True
+                    _print_info("Thinking visibility enabled.")
+                elif arg.lower() in ("off", "hide", "no", "false"):
+                    show_thinking = False
+                    _print_info("Thinking visibility disabled.")
+                else:
+                    _print_error(f"Invalid argument: {arg}. Use 'on' or 'off'.")
+                continue
+
             elif cmd == "/tools-output":
                 if not tool_results_buffer:
                     _print_info("No tool results from recent calls.")
@@ -1079,6 +1202,7 @@ def run_interactive(
                 token_tracker=token_tracker,
                 permission=permission,
                 tool_results_buffer=tool_results_buffer,
+                show_thinking=show_thinking,
             )
             messages.append({"role": "assistant", "content": response})
             if session_name:
@@ -1159,6 +1283,7 @@ def run_single_shot(
     output_format: str,
     permission: str = "auto",
     existing_messages: list = None,
+    show_thinking: bool = False,
 ):
     """Run a single prompt and exit."""
     client = _make_client(api_base, api_key, timeout)
@@ -1180,9 +1305,13 @@ def run_single_shot(
             token_tracker=token_tracker,
             permission=permission,
             stream_output=stream_output,
+            show_thinking=show_thinking,
         )
         messages.append({"role": "assistant", "content": response})
-        _print_markdown(response, output_format)
+        # For non-streaming formats (json/markdown), strip thinking here since
+        # ThinkingBuffer only applies during streaming (text format).
+        display_response = response if show_thinking else _strip_thinking(response)
+        _print_markdown(display_response, output_format)
         return messages
     except KeyboardInterrupt:
         sys.exit(130)
@@ -1308,6 +1437,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="List available models (optional: ollama, openrouter, lmstudio)",
     )
     parser.add_argument(
+        "--show-thinking",
+        action="store_true",
+        default=False,
+        help=(
+            "Show model thinking/reasoning output (<think>...</think> blocks) "
+            "when the runtime emits it. By default, thinking is hidden."
+        ),
+    )
+    parser.add_argument(
         "prompt",
         nargs="*",
         help="Prompt text (omit for interactive mode or pipe from stdin)",
@@ -1426,6 +1564,7 @@ def main(argv=None):
             model_str=model_str,
             session_name=session_name,
             existing_messages=existing_messages,
+            show_thinking=args.show_thinking,
         )
         # Persist model choice for next session
         cfg["model"] = updated_model
@@ -1463,6 +1602,7 @@ def main(argv=None):
             model_str=model_str,
             session_name=session_name,
             existing_messages=existing_messages,
+            show_thinking=args.show_thinking,
         )
         # Persist model choice for next session
         cfg["model"] = updated_model
@@ -1481,6 +1621,7 @@ def main(argv=None):
             output_format=output_format,
             permission=permission,
             existing_messages=existing_messages,
+            show_thinking=args.show_thinking,
         )
         if session_name:
             save_session_data(


### PR DESCRIPTION
## Summary

Implements Issue #293: toggle model thinking/reasoning output visibility in wee-cli.

- **`ThinkingBuffer` streaming state machine** — filters `<think>…</think>` blocks in real time as tokens arrive, correctly handles tags split across chunk boundaries and unclosed blocks
- **`_strip_thinking()` helper** — post-processing for non-streaming output formats (json/markdown)
- **`--show-thinking` CLI flag** — hidden by default; pass to show thinking during output
- **/thinking on|off REPL command** — toggle thinking visibility in interactive mode
- **Session history preserved** — full response including thinking is always returned from `chat_stream()` for conversation history; only display is filtered
- **WebUI unchanged** — already strips thinking via `SessionManager.strip_thinking_tags()` in `strip_metadata()`, no changes needed

## Changes

- `wee_cli.py`: `ThinkingBuffer` class, `_strip_thinking()`, `--show-thinking` flag, `/thinking` REPL command, threaded through `chat_stream()`, `run_single_shot()`, `run_interactive()`
- `tests/test_issue_293_thinking_visibility.py`: 27 new tests covering buffer state machine, edge cases, parser flag, chat_stream integration, and agent_manager regression

## Test Results

```
27 passed in tests/test_issue_293_thinking_visibility.py
216 passed / 1 pre-existing failure (test_stdin_pipe) in full suite
```

Closes #293