### PR TITLE
fix: increase BackgroundTaskRequest prompt limit to 200,000 chars

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -12410,8 +12410,8 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         @field_validator("prompt")
         @classmethod
         def validate_prompt(cls, v):
-            if len(v) > 10000:
-                raise ValueError("Prompt must be 10,000 characters or less")
+            if len(v) > 200000:
+                raise ValueError("Prompt must be 200,000 characters or less")
             return v
 
     def _emit_bg_notification(

--- a/tests/test_issue_308_background_task_prompt_limit.py
+++ b/tests/test_issue_308_background_task_prompt_limit.py
@@ -1,0 +1,110 @@
+"""
+Regression test for Issue #308:
+Bug: BackgroundTaskRequest.validate_prompt 10,000-char limit blocks dispatcher
+
+The dispatcher builds prompts that include GitHub issue bodies + comments,
+often exceeding 10,000 characters. This test ensures:
+1. Interactive endpoints (QueryRequest) enforce 10,000-char limit
+2. Background tasks (BackgroundTaskRequest) allow up to 200,000 chars
+3. Prompts exceeding 200,000 chars are rejected
+"""
+
+import pytest
+import subprocess
+import json
+import sys
+
+
+class TestPromptLimits:
+    """Test prompt character limits for different request types."""
+
+    def test_query_endpoint_rejects_10001_chars(self):
+        """Interactive /api/v1/query endpoint should reject >10,000 chars."""
+        prompt = "x" * 10001
+        payload = {
+            "prompt": prompt,
+            "agent": "fosterbot"
+        }
+        
+        # This should return 422 - Unprocessable Entity
+        result = subprocess.run(
+            ['curl', '-s', '-w', '\n%{http_code}', '-X', 'POST', 
+             '-H', 'Content-Type: application/json',
+             '-H', 'Authorization: Bearer shared_R6R6wReORUV6bouLntScMTowbsh30Rzqa3hzjs3bWgU',
+             '-d', json.dumps(payload),
+             'https://127.0.0.1:8001/api/v1/query'],
+            capture_output=True, text=True, cwd='/opt/n8n-copilot-shim-dev'
+        )
+        
+        lines = result.stdout.strip().split('\n')
+        status_code = lines[-1]
+        assert status_code == '422', f"Expected 422, got {status_code}: {result.stdout}"
+
+    def test_background_task_accepts_15000_chars(self):
+        """Background task endpoint should accept >10,000 chars."""
+        prompt = "x" * 15000
+        payload = {
+            "prompt": prompt,
+            "agent": "fosterbot"
+        }
+        
+        # This should return 202 - Accepted (or at least not 422)
+        result = subprocess.run(
+            ['curl', '-s', '-w', '\n%{http_code}', '-X', 'POST',
+             '-H', 'Content-Type: application/json',
+             '-H', 'Authorization: Bearer shared_R6R6wReORUV6bouLntScMTowbsh30Rzqa3hzjs3bWgU',
+             '-d', json.dumps(payload),
+             'https://127.0.0.1:8001/api/v1/background-tasks'],
+            capture_output=True, text=True, cwd='/opt/n8n-copilot-shim-dev'
+        )
+        
+        lines = result.stdout.strip().split('\n')
+        status_code = lines[-1]
+        # Should be 202 Accepted or 200 OK, not 422
+        assert status_code in ['200', '202'], f"Expected 200/202, got {status_code}: {result.stdout}"
+
+    def test_background_task_accepts_200000_chars(self):
+        """Background task endpoint should accept up to 200,000 chars."""
+        prompt = "x" * 200000
+        payload = {
+            "prompt": prompt,
+            "agent": "fosterbot"
+        }
+        
+        result = subprocess.run(
+            ['curl', '-s', '-w', '\n%{http_code}', '-X', 'POST',
+             '-H', 'Content-Type: application/json',
+             '-H', 'Authorization: Bearer shared_R6R6wReORUV6bouLntScMTowbsh30Rzqa3hzjs3bWgU',
+             '-d', json.dumps(payload),
+             'https://127.0.0.1:8001/api/v1/background-tasks'],
+            capture_output=True, text=True, cwd='/opt/n8n-copilot-shim-dev'
+        )
+        
+        lines = result.stdout.strip().split('\n')
+        status_code = lines[-1]
+        assert status_code in ['200', '202'], f"Expected 200/202, got {status_code}: {result.stdout}"
+
+    def test_background_task_rejects_200001_chars(self):
+        """Background task endpoint should reject >200,000 chars."""
+        prompt = "x" * 200001
+        payload = {
+            "prompt": prompt,
+            "agent": "fosterbot"
+        }
+        
+        result = subprocess.run(
+            ['curl', '-s', '-w', '\n%{http_code}', '-X', 'POST',
+             '-H', 'Content-Type: application/json',
+             '-H', 'Authorization: Bearer shared_R6R6wReORUV6bouLntScMTowbsh30Rzqa3hzjs3bWgU',
+             '-d', json.dumps(payload),
+             'https://127.0.0.1:8001/api/v1/background-tasks'],
+            capture_output=True, text=True, cwd='/opt/n8n-copilot-shim-dev'
+        )
+        
+        lines = result.stdout.strip().split('\n')
+        status_code = lines[-1]
+        assert status_code == '422', f"Expected 422, got {status_code}: {result.stdout}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
Fixes #308 where the dispatcher fails when GitHub issues have long bodies + comments exceeding the 10,000 character limit.

## Changes
- Increased BackgroundTaskRequest.validate_prompt limit from 10,000 to 200,000 chars
- QueryRequest (interactive endpoints) keeps 10,000 char limit for safety
- Added regression test test_issue_308_background_task_prompt_limit.py

## Testing
All tests passing:
- ✓ Query endpoint correctly rejects >10,000 chars (422)
- ✓ Background task accepts 15,000 chars (200 OK)
- ✓ Background task accepts 200,000 chars (200 OK)
- ✓ Background task rejects >200,000 chars (422)

The dispatcher frequently builds prompts with issue bodies + all comments, which can exceed 22,000+ characters for complex issues. The 200,000 char limit provides ample headroom while maintaining safety on interactive endpoints.