### PR TITLE
Extend session token TTL for longer-lived client sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,10 @@ AUTH_TOKEN_SECRET=CHANGE_ME_generate_with_openssl_rand_base64_32
 # --- Pairing & Sessions ---
 PAIRING_CODE_LENGTH=6
 PAIRING_CODE_TTL=300
-SESSION_TOKEN_TTL=3600
+# Sliding window in seconds, refreshed on every authenticated request.
+SESSION_TOKEN_TTL=2592000
+# Hard cap in seconds from token creation, regardless of activity.
+SESSION_TOKEN_ABSOLUTE_TTL=15552000
 MAX_SESSIONS=25
 
 # --- Rate Limiting ---

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -585,8 +585,16 @@ class AuthManager:
         shared_key: str,
         pairing_code_length: int = 6,
         pairing_code_ttl: int = 300,
-        session_token_ttl: int = 3600,
-        session_token_absolute_ttl: int = 86400,
+        # Sliding window, refreshed on every authenticated request — as long
+        # as a client (iOS app, WebUI, etc.) is used at least this often it
+        # never has to re-pair. Personal single-tenant deployment, and the
+        # iOS client now gates re-entry locally with Face ID, so a long
+        # sliding window doesn't weaken on-device security.
+        session_token_ttl: int = 2592000,  # 30 days
+        # Hard cap from creation regardless of activity — bounds how long a
+        # token stays valid if a device is lost, without forcing re-pairing
+        # during normal day-to-day use.
+        session_token_absolute_ttl: int = 15552000,  # 180 days
         sessions_file: Optional[str] = None,
     ):
         self.shared_key = shared_key
@@ -11247,9 +11255,9 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         )
     PAIRING_CODE_LENGTH = int(os.environ.get("PAIRING_CODE_LENGTH", "6"))
     PAIRING_CODE_TTL = int(os.environ.get("PAIRING_CODE_TTL", "300"))
-    SESSION_TOKEN_TTL = int(os.environ.get("SESSION_TOKEN_TTL", "3600"))
+    SESSION_TOKEN_TTL = int(os.environ.get("SESSION_TOKEN_TTL", "2592000"))  # 30 days
     SESSION_TOKEN_ABSOLUTE_TTL = int(
-        os.environ.get("SESSION_TOKEN_ABSOLUTE_TTL", "86400")
+        os.environ.get("SESSION_TOKEN_ABSOLUTE_TTL", "15552000")  # 180 days
     )
     CONFIG_FILE = os.environ.get("AGENT_CONFIG_FILE")
     SCHEDULER_JOBS_FILE = os.environ.get(


### PR DESCRIPTION
## Summary
- Sliding `session_token_ttl` (refreshed on activity): 1 hour → 30 days
- Hard-cap `session_token_absolute_ttl`: 24 hours → 180 days
- Documented `SESSION_TOKEN_ABSOLUTE_TTL` in `.env.example` (previously undocumented)

## Why
The iOS client (and WebUI) were getting forced back to Telegram re-pairing far too often — the 1-hour sliding window meant any gap in usage logged you out, and the 24-hour absolute cap forced re-pairing daily even with continuous use.

This is a single-tenant personal deployment. The iOS client now has a local Face ID re-lock (gates re-entry into the app itself after inactivity), so a longer-lived backend session token doesn't reduce on-device security — physical access to an unlocked device is what actually matters there, not the token's server-side TTL.

Both values stay configurable via `SESSION_TOKEN_TTL` / `SESSION_TOKEN_ABSOLUTE_TTL` env vars for anyone who wants different behavior.

## Test plan
- [x] `tests/test_api_auth.py` (26 tests) — all pass, unaffected since the test suite constructs `AuthManager` with explicit TTL values rather than relying on defaults
- [x] `tests/test_issue_28_timing_safe_key.py` — pre-existing unrelated failure (`hmac.compare_digest` assertion) confirmed present on `main` before this change too; not touched by this PR
- [x] Verified `.env.example` change reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)