### PR TITLE
Add GPT-5.6 (Luna/Terral/Sol) and Claude Sonnet 5/Fable 5 to model catalog

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1890,6 +1890,16 @@ class SessionManager:
                 "Claude Opus (Latest)",
                 ["claude-opus", "claude-opus-4-6", "claude-opus-4.6", "opus-4.6"],
             ),
+            (
+                "claude-sonnet-5",
+                "Claude Sonnet 5",
+                ["sonnet-5", "claude-sonnet5"],
+            ),
+            (
+                "claude-fable-5",
+                "Claude Fable 5",
+                ["fable-5", "claude-fable5"],
+            ),
         ],
         "US Frontier Models (Comparison)": [
             (
@@ -1973,6 +1983,10 @@ class SessionManager:
     # CODEX models configuration (from copilot CLI --model choices)
     CODEX_MODELS = {
         "OpenAI Models": [
+            ("gpt-5.6", "GPT-5.6", ["gpt-5.6"]),
+            ("gpt-5.6-luna", "GPT-5.6 Luna", ["luna"]),
+            ("gpt-5.6-terral", "GPT-5.6 Terral", ["terral"]),
+            ("gpt-5.6-sol", "GPT-5.6 Sol", ["sol"]),
             ("gpt-5.5", "GPT-5.5", ["gpt-5.5"]),
             ("gpt-5.4", "GPT-5.4", ["gpt-5.4", "gpt-5.4-pro"]),
             ("gpt-5.4-mini", "GPT-5.4 Mini", ["gpt-5.4-mini"]),

--- a/model-manifest.json
+++ b/model-manifest.json
@@ -1,9 +1,13 @@
 {
-  "source": "manually verified from Codex CLI model picker 2026-04-26; claude/devin/cursor/gemini/wee migrated from agent_manager.py static dicts for issue #359",
-  "last_updated": "2026-06-10T00:00:00.000000Z",
+  "source": "manually verified from Codex CLI model picker 2026-04-26; claude/devin/cursor/gemini/wee migrated from agent_manager.py static dicts for issue #359; gpt-5.6 (luna/terral/sol) and claude sonnet-5/fable-5 added 2026-07-11",
+  "last_updated": "2026-07-11T00:00:00.000000Z",
   "runtimes": {
     "copilot": [
       "auto",
+      "gpt-5.6",
+      "gpt-5.6-luna",
+      "gpt-5.6-terral",
+      "gpt-5.6-sol",
       "gpt-5.4",
       "gpt-5.5",
       "gpt-5.3-codex",
@@ -12,6 +16,8 @@
       "gpt-5.4-mini",
       "gpt-5-mini",
       "gpt-4.1",
+      "claude-sonnet-5",
+      "claude-fable-5",
       "claude-sonnet-4.6",
       "claude-sonnet-4.5",
       "claude-haiku-4.5",
@@ -20,6 +26,10 @@
     ],
     "copilot-sdk": [
       "auto",
+      "gpt-5.6",
+      "gpt-5.6-luna",
+      "gpt-5.6-terral",
+      "gpt-5.6-sol",
       "gpt-5.4",
       "gpt-5.5",
       "gpt-5.3-codex",
@@ -28,6 +38,8 @@
       "gpt-5.4-mini",
       "gpt-5-mini",
       "gpt-4.1",
+      "claude-sonnet-5",
+      "claude-fable-5",
       "claude-sonnet-4.6",
       "claude-sonnet-4.5",
       "claude-haiku-4.5",
@@ -35,6 +47,10 @@
       "claude-sonnet-4"
     ],
     "codex": [
+      "gpt-5.6",
+      "gpt-5.6-luna",
+      "gpt-5.6-terral",
+      "gpt-5.6-sol",
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",
@@ -45,11 +61,15 @@
       "sonnet",
       "haiku",
       "opus",
+      "claude-sonnet-5",
+      "claude-fable-5",
       "claude-3-5-sonnet-latest",
       "claude-3-5-haiku-latest",
       "claude-3-opus-latest"
     ],
     "claude-sdk": [
+      "claude-sonnet-5",
+      "claude-fable-5",
       "claude-sonnet-4.6",
       "claude-sonnet-4.5",
       "claude-haiku-4.5",


### PR DESCRIPTION
## Summary
- Adds `gpt-5.6`, `gpt-5.6-luna`, `gpt-5.6-terral`, `gpt-5.6-sol` to the `codex`, `copilot`, and `copilot-sdk` runtime model lists in `model-manifest.json`
- Adds `claude-sonnet-5`, `claude-fable-5` to the `claude`, `claude-sdk`, `copilot`, and `copilot-sdk` runtime model lists
- Mirrors the same additions into the static `CODEX_MODELS`/`CLAUDE_MODELS` dicts in `agent_manager.py` as a fallback for when the manifest is unavailable

## Why
`model-manifest.json` is the live source of truth read by `/api/v1/models` on every request (no restart needed). All three clients — iOS app, macOS app, and WebUI — fetch their model picker options from this endpoint dynamically, so this one file covers all three surfaces with no client-side code changes required.

## Verification
- `tests/test_model_manifest_source.py` and the model-resolution tests in `tests/test_agent_manager.py` — 53/53 pass
- Manually verified `SessionManager.get_models_for_runtime()` returns the new ids for `codex`, `copilot`, `claude`, `claude-sdk`
- Verified auto-derived labels/groups render sensibly (e.g. `gpt-5.6-luna` → "GPT 5.6 Luna" / GPT Models; `claude-sonnet-5` → "Claude Sonnet 5" / Claude Models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)