### PR TITLE
Add model catalog editor to WebUI settings, matching the macOS app

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -17506,6 +17506,119 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to save .env: {e}")
 
+    @app.get("/api/v1/settings/model-manifest")
+    async def get_model_manifest_settings(request: Request, runtime: str = "claude"):
+        """Return the editable model list for a runtime.
+
+        `wee` is excluded — its catalog is assembled dynamically from local
+        Ollama and OpenRouter discovery, not the static manifest.
+        """
+        auth = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        runtime_key = _model_manifest_runtime_key(runtime)
+        if runtime_key == "wee":
+            raise HTTPException(
+                status_code=400,
+                detail="The wee runtime catalog is discovered dynamically and is not editable here.",
+            )
+        try:
+            manifest = load_model_manifest()
+            runtimes = manifest.get("runtimes", {})
+            available_runtimes = sorted(k for k in runtimes.keys() if k != "wee")
+            models = runtimes.get(runtime_key)
+            if models is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"{runtime_key} is not a configured runtime in model-manifest.json",
+                )
+            return {
+                "runtime": runtime_key,
+                "models": models,
+                "available_runtimes": available_runtimes,
+            }
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to read model-manifest.json: {e}"
+            )
+
+    @app.put("/api/v1/settings/model-manifest")
+    async def put_model_manifest_settings(request: Request):
+        """Save an updated model list for one runtime.
+
+        Preserves every other runtime's list and the rest of the manifest
+        document. `wee` is rejected for the same reason it's excluded from
+        the GET above.
+        """
+        auth = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        body = await request.json()
+        runtime = body.get("runtime", "")
+        models = body.get("models", [])
+        runtime_key = _model_manifest_runtime_key(runtime)
+        if runtime_key == "wee":
+            raise HTTPException(
+                status_code=400,
+                detail="The wee runtime catalog is discovered dynamically and is not editable here.",
+            )
+        if not isinstance(models, list) or not all(isinstance(m, str) for m in models):
+            raise HTTPException(status_code=400, detail="models must be a list of strings")
+
+        normalized: List[str] = []
+        for candidate in models:
+            model_id = candidate.strip()
+            if model_id and model_id not in normalized:
+                normalized.append(model_id)
+        if not normalized:
+            raise HTTPException(status_code=400, detail="Add at least one model before saving.")
+
+        try:
+            if MODEL_MANIFEST_PATH.exists():
+                document = json.loads(MODEL_MANIFEST_PATH.read_text())
+            else:
+                document = {"runtimes": {}}
+            runtimes = document.get("runtimes", {})
+            if runtime_key not in runtimes:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{runtime_key} is not a configured runtime in model-manifest.json",
+                )
+
+            # Backup before overwrite, mirroring the .env editor's safety net.
+            if MODEL_MANIFEST_PATH.exists():
+                backup_path = Path(str(MODEL_MANIFEST_PATH) + ".bak")
+                shutil.copy2(MODEL_MANIFEST_PATH, backup_path)
+
+            from datetime import datetime, timezone
+
+            runtimes[runtime_key] = normalized
+            document["runtimes"] = runtimes
+            document["last_updated"] = (
+                datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            )
+            MODEL_MANIFEST_PATH.write_text(
+                json.dumps(document, indent=2, sort_keys=True) + "\n"
+            )
+            # Drop the mtime cache so the next /api/v1/models read picks this up
+            # immediately instead of waiting on the next file-change poll.
+            load_model_manifest._cache_key = None
+            return {"saved": True, "runtime": runtime_key, "models": normalized}
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to save model-manifest.json: {e}"
+            )
+
     @app.post("/api/v1/settings/restart-services")
     async def restart_services(request: Request):
         """Restart dev services (agent-manager-api-dev, etc.)."""

--- a/tests/test_settings_model_manifest.py
+++ b/tests/test_settings_model_manifest.py
@@ -1,0 +1,129 @@
+"""Tests for the /api/v1/settings/model-manifest endpoints."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ["API_SHARED_KEY"] = "test_key_123"
+os.environ["APP_ENV"] = "DEV"
+os.environ["API_PORT"] = "8098"
+
+
+class TestSettingsModelManifest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        cls.manifest_path = os.path.join(cls.tmpdir.name, "model-manifest.json")
+        with open(cls.manifest_path, "w") as f:
+            json.dump(
+                {
+                    "runtimes": {
+                        "claude": ["sonnet", "haiku"],
+                        "codex": ["gpt-5.5", "gpt-5.4"],
+                        "wee": ["ollama/gemma4:e4b"],
+                    }
+                },
+                f,
+            )
+
+        cls._manifest_patch = patch.object(
+            agent_manager, "MODEL_MANIFEST_PATH", __import__("pathlib").Path(cls.manifest_path)
+        )
+        cls._manifest_patch.start()
+
+        cls.app = agent_manager.create_api_app()
+        cls.client = TestClient(cls.app)
+        cls.shared_header = {"Authorization": "Bearer shared_test_key_123"}
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._manifest_patch.stop()
+        cls.tmpdir.cleanup()
+
+    def _read_manifest(self):
+        with open(self.manifest_path) as f:
+            return json.load(f)
+
+    def test_get_returns_models_and_excludes_wee_from_available(self):
+        resp = self.client.get(
+            "/api/v1/settings/model-manifest?runtime=claude", headers=self.shared_header
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["runtime"], "claude")
+        self.assertEqual(data["models"], ["sonnet", "haiku"])
+        self.assertNotIn("wee", data["available_runtimes"])
+        self.assertIn("claude", data["available_runtimes"])
+        self.assertIn("codex", data["available_runtimes"])
+
+    def test_get_wee_is_rejected(self):
+        resp = self.client.get(
+            "/api/v1/settings/model-manifest?runtime=wee", headers=self.shared_header
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_get_unknown_runtime_404s(self):
+        resp = self.client.get(
+            "/api/v1/settings/model-manifest?runtime=nonexistent",
+            headers=self.shared_header,
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_put_normalizes_and_persists(self):
+        resp = self.client.put(
+            "/api/v1/settings/model-manifest",
+            headers=self.shared_header,
+            json={
+                "runtime": "codex",
+                "models": ["gpt-5.6", "  gpt-5.6-luna  ", "", "gpt-5.6", "gpt-5.5"],
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["models"], ["gpt-5.6", "gpt-5.6-luna", "gpt-5.5"])
+
+        # Persisted to disk, and other runtimes untouched.
+        on_disk = self._read_manifest()
+        self.assertEqual(
+            on_disk["runtimes"]["codex"], ["gpt-5.6", "gpt-5.6-luna", "gpt-5.5"]
+        )
+        self.assertEqual(on_disk["runtimes"]["claude"], ["sonnet", "haiku"])
+        self.assertEqual(on_disk["runtimes"]["wee"], ["ollama/gemma4:e4b"])
+
+    def test_put_wee_is_rejected(self):
+        resp = self.client.put(
+            "/api/v1/settings/model-manifest",
+            headers=self.shared_header,
+            json={"runtime": "wee", "models": ["something"]},
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_put_empty_models_rejected(self):
+        resp = self.client.put(
+            "/api/v1/settings/model-manifest",
+            headers=self.shared_header,
+            json={"runtime": "claude", "models": ["   ", ""]},
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_put_unconfigured_runtime_rejected(self):
+        resp = self.client.put(
+            "/api/v1/settings/model-manifest",
+            headers=self.shared_header,
+            json={"runtime": "nonexistent", "models": ["foo"]},
+        )
+        self.assertEqual(resp.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui/dist/app.js
+++ b/webui/dist/app.js
@@ -7203,6 +7203,68 @@ if (document.readyState !== 'loading') {
   if (btnEnvSave)    btnEnvSave.addEventListener('click', saveEnvFile);
   if (btnEnvRestart) btnEnvRestart.addEventListener('click', restartDevServices);
 
+
+  /* ── Model Catalog Editor ──────────────────────────────────────────────── */
+  const modelCatalogRuntimeSelect = document.getElementById('asf-model-catalog-runtime');
+  const modelCatalogEditor        = document.getElementById('asf-model-catalog-editor');
+  const btnModelCatalogLoad       = document.getElementById('btn-model-catalog-load');
+  const btnModelCatalogSave       = document.getElementById('btn-model-catalog-save');
+  const modelCatalogStatus        = document.getElementById('asf-model-catalog-status');
+
+  function showModelCatalogStatus(msg, isError) {
+    if (!modelCatalogStatus) return;
+    modelCatalogStatus.textContent = msg;
+    modelCatalogStatus.className = 'asf-env-status' + (isError ? ' asf-env-error' : ' asf-env-ok');
+    modelCatalogStatus.classList.remove('hidden');
+    setTimeout(() => modelCatalogStatus.classList.add('hidden'), 5000);
+  }
+
+  function populateModelCatalogRuntimes(runtimes, selected) {
+    if (!modelCatalogRuntimeSelect || !runtimes || !runtimes.length) return;
+    const current = selected || modelCatalogRuntimeSelect.value || runtimes[0];
+    modelCatalogRuntimeSelect.innerHTML = '';
+    runtimes.forEach(rt => {
+      const opt = document.createElement('option');
+      opt.value = rt;
+      opt.textContent = rt;
+      modelCatalogRuntimeSelect.appendChild(opt);
+    });
+    if (runtimes.includes(current)) modelCatalogRuntimeSelect.value = current;
+  }
+
+  async function loadModelCatalog(runtime) {
+    if (!modelCatalogEditor) return;
+    const rt = runtime || (modelCatalogRuntimeSelect && modelCatalogRuntimeSelect.value) || 'claude';
+    modelCatalogEditor.value = 'Loading...';
+    try {
+      const data = await apiRequest('GET', '/settings/model-manifest?runtime=' + encodeURIComponent(rt));
+      populateModelCatalogRuntimes(data.available_runtimes, data.runtime);
+      modelCatalogEditor.value = (data.models || []).join('\n');
+    } catch (e) {
+      modelCatalogEditor.value = '';
+      showModelCatalogStatus('Failed to load models: ' + e.message, true);
+    }
+  }
+
+  async function saveModelCatalog() {
+    if (!modelCatalogEditor || !modelCatalogRuntimeSelect) return;
+    const runtime = modelCatalogRuntimeSelect.value;
+    const models = modelCatalogEditor.value.split('\n');
+    try {
+      const data = await apiRequest('PUT', '/settings/model-manifest', { runtime, models });
+      modelCatalogEditor.value = (data.models || []).join('\n');
+      showModelCatalogStatus('✓ Saved ' + (data.models || []).length + ' models for ' + data.runtime, false);
+    } catch (e) {
+      showModelCatalogStatus('Failed to save: ' + e.message, true);
+    }
+  }
+
+  if (btnModelCatalogLoad) btnModelCatalogLoad.addEventListener('click', () => loadModelCatalog());
+  if (btnModelCatalogSave) btnModelCatalogSave.addEventListener('click', saveModelCatalog);
+  if (modelCatalogRuntimeSelect) {
+    modelCatalogRuntimeSelect.addEventListener('change', () => loadModelCatalog(modelCatalogRuntimeSelect.value));
+  }
+
   function showKanbanSettingsStatus(msg, isError) {
     if (!kanbanStatus) return;
     kanbanStatus.textContent = msg;
@@ -7470,6 +7532,19 @@ if (document.readyState !== 'loading') {
     if (btnSettings) {
       btnSettings.removeEventListener('click', openSettings);
       btnSettings.addEventListener('click', _wrappedOpenInstr);
+    }
+  }
+
+  // Auto-load the model catalog when settings panel opens
+  const _origOpenSettingsModels = typeof openSettings === 'function' ? openSettings : null;
+  if (_origOpenSettingsModels) {
+    const _wrappedOpenModels = async function() {
+      await _origOpenSettingsModels();
+      loadModelCatalog();
+    };
+    if (btnSettings) {
+      btnSettings.removeEventListener('click', openSettings);
+      btnSettings.addEventListener('click', _wrappedOpenModels);
     }
   }
 

--- a/webui/dist/index.html
+++ b/webui/dist/index.html
@@ -859,6 +859,27 @@
           </div>
         </div>
 
+        <!-- Model Catalog Editor -->
+        <div class="asf-section">
+          <div class="asf-section-title">🧠 Model Catalog</div>
+          <p class="asf-hint" style="margin:0 0 10px;">Edit the selectable model list for a runtime. The <code>wee</code> runtime is discovered automatically from Ollama and OpenRouter, so it isn't editable here.</p>
+          <div class="asf-grid">
+            <div class="asf-field asf-full">
+              <label class="asf-label" for="asf-model-catalog-runtime">Runtime</label>
+              <select id="asf-model-catalog-runtime" class="glass-input asf-input"></select>
+            </div>
+          </div>
+          <div class="asf-env-editor-wrap">
+            <div class="asf-env-toolbar">
+              <button id="btn-model-catalog-load" class="btn btn-ghost btn-xs">📥 Load</button>
+              <button id="btn-model-catalog-save" class="btn btn-primary btn-xs">💾 Save Models</button>
+            </div>
+            <textarea id="asf-model-catalog-editor" class="glass-input asf-env-textarea" rows="10" placeholder="One model id per line..." spellcheck="false"></textarea>
+            <div id="asf-model-catalog-status" class="asf-env-status hidden"></div>
+            <p class="asf-env-warning">⚠️ One model id per line. Blank lines and duplicates are removed automatically on save.</p>
+          </div>
+        </div>
+
 
 
 


### PR DESCRIPTION
## Summary
- New `GET`/`PUT /api/v1/settings/model-manifest` endpoints (excludes `wee`, same as macOS — its catalog is discovered dynamically from Ollama/OpenRouter)
- New "Model Catalog" section in the WebUI agent settings modal: runtime picker + one-model-per-line textarea + Save, reusing the existing `.env` editor's markup/CSS/JS patterns
- Auto-loads when the settings panel opens, consistent with the other sections there (Kanban source, `.env`, AGENTS.md)

## Why
The macOS app already lets you view/edit each runtime's model list from Settings, but it does so via a direct file edit against a locally-running checkout (only available in the "Local" environment). WebUI always talks to a real backend over HTTP with no filesystem access, so it needed a proper API-backed equivalent to get the same capability.

## Test plan
- [x] `tests/test_settings_model_manifest.py` (7 new tests) — GET/PUT happy path, `wee` rejected on both, unconfigured-runtime rejected, empty-after-normalization rejected, normalization (trim/dedupe/drop-blank), other runtimes' lists untouched on save
- [x] `tests/test_model_manifest_source.py` + `tests/test_api_endpoints.py` — no regressions (20/20 pass)
- [x] `node --check webui/dist/app.js` — syntax valid
- [x] Manually reviewed the inserted HTML for balanced tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)