### PR TITLE
Fix macOS Codex runtime launch

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -2131,6 +2131,7 @@ class SessionManager:
         # Executable paths (resolved dynamically)
         self.copilot_bin = find_executable("copilot")
         self.claude_bin = find_executable("claude")
+        self.codex_bin = find_executable("codex")
         self.devin_bin = find_executable("devin")
         self.cursor_bin = find_executable("agent")
 
@@ -4654,8 +4655,11 @@ You can mention an agent in your prompt and it will auto-delegate:
             return cached
 
         try:
+            codex_bin = (
+                getattr(self, "codex_bin", None) or find_executable("codex") or "codex"
+            )
             status = subprocess.run(
-                ["codex", "login", "status"],
+                [codex_bin, "login", "status"],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -7078,6 +7082,19 @@ User Request:
         try:
             # Set WEE_SESSION_ID so agents can use wee_executor.py
             _sub_env = {**os.environ, "WEE_SESSION_ID": n8n_session_id}
+            # GUI-launched macOS processes receive a minimal system PATH.  CLI
+            # wrappers installed by Homebrew (including Codex, whose launcher
+            # invokes `env node`) need the Homebrew Node directory available to
+            # their child process as well as to the initial executable lookup.
+            _cli_paths = [
+                str(Path.home() / ".local" / "bin"),
+                "/opt/homebrew/bin",
+                "/usr/local/bin",
+            ]
+            _existing_paths = _sub_env.get("PATH", "").split(os.pathsep)
+            _sub_env["PATH"] = os.pathsep.join(
+                _cli_paths + [path for path in _existing_paths if path not in _cli_paths]
+            )
             if _pty_master is not None:
                 process = subprocess.Popen(
                     cmd,
@@ -7830,18 +7847,6 @@ User Request:
 
         agent_dir = self.AGENTS.get(agent, self.AGENTS["orchestrator"])["path"]
         effective_timeout = timeout if timeout is not None else self.command_timeout
-
-        if model and self._codex_uses_chatgpt_account():
-            # ChatGPT OAuth does not accept client-selected model IDs. Let the
-            # Codex service select the account's supported default instead of
-            # issuing `-m <unsupported-model>` and returning an empty turn.
-            requested_model = model
-            model = ""
-            self.update_session_field(n8n_session_id, "model", "default")
-            print(
-                f"[Codex] Ignoring requested model '{requested_model}' for ChatGPT-authenticated Codex; using account default.",
-                file=sys.stderr,
-            )
 
         # Get channel for file handling instructions
         channel = session_data.get("channel", "webui")
@@ -8932,8 +8937,24 @@ User Request:
         # Resolve permission mode from session data (backward compat with yolo_mode)
         mode = self._resolve_permission_mode(session_data, mode)
 
+        codex_bin = getattr(self, "codex_bin", None) or find_executable("codex")
+        if not codex_bin:
+            return "Error: Codex executable not found. Install Codex or add it to PATH."
+
         agent_dir = self.AGENTS.get(agent, self.AGENTS["orchestrator"])["path"]
         effective_timeout = timeout if timeout is not None else self.command_timeout
+
+        if model and self._codex_uses_chatgpt_account():
+            # ChatGPT OAuth does not accept client-selected model IDs. Let the
+            # Codex service select the account's supported default instead of
+            # issuing `-m <unsupported-model>` and returning an empty turn.
+            requested_model = model
+            model = ""
+            self.update_session_field(n8n_session_id, "model", "default")
+            print(
+                f"[Codex] Ignoring requested model '{requested_model}' for ChatGPT-authenticated Codex; using account default.",
+                file=sys.stderr,
+            )
 
         # Get channel for file handling instructions
         channel = session_data.get("channel", "webui")
@@ -8979,7 +9000,7 @@ User Request:
 
         if resume and session_id:
             # Resume existing session — v0.125.0+ uses `codex exec resume` subcommand
-            cmd = ["codex", "exec", "--json", "--skip-git-repo-check", "resume"]
+            cmd = [codex_bin, "exec", "--json", "--skip-git-repo-check", "resume"]
             if mode == "elevated":
                 # Apply sandbox bypass and environment inheritance for elevated sessions
                 cmd.append("--dangerously-bypass-approvals-and-sandbox")
@@ -8994,7 +9015,7 @@ User Request:
         else:
             # Start new session — v0.125.0+: --full-auto for normal mode,
             # --dangerously-bypass-approvals-and-sandbox for elevated (they are mutually exclusive)
-            cmd = ["codex", "exec", "--json", "--skip-git-repo-check"]
+            cmd = [codex_bin, "exec", "--json", "--skip-git-repo-check"]
             if mode == "elevated":
                 # Bypass all sandbox restrictions (sudo, DNS, network, filesystem)
                 cmd.append("--dangerously-bypass-approvals-and-sandbox")
@@ -11089,6 +11110,12 @@ User Request:
                     "", current_runtime, n8n_session_id=n8n_session_id
                 )
             )
+        elif current_runtime == "codex":
+            # Codex Desktop and the local API share ~/.codex/sessions. A
+            # filesystem scan can therefore select an unrelated Desktop task
+            # and make `codex exec resume` hang or return its context. Until
+            # the API owns isolated Codex session state, start a clean turn.
+            can_resume = False
         elif current_runtime == "wee":
             # Issue #108 fix: Wee has no external session_id — history is keyed
             # by n8n_session_id in session_map.  Must pass n8n_session_id so
@@ -11124,7 +11151,6 @@ User Request:
             "copilot",
             "opencode",
             "gemini",
-            "codex",
         ):
             new_id = self.get_most_recent_session_id(current_runtime, agent)
             if new_id:
@@ -13995,7 +14021,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 )
                 _cmd = [_oc_bin, "run", "--model", mdl, ctx_prompt]
             elif rt == "codex":
-                _codex_bin = _which_bin("codex") or "codex"
+                _codex_bin = find_executable("codex") or "codex"
                 _cmd = [_codex_bin, "exec", "--json", "--skip-git-repo-check"]
                 if perm_mode == "elevated":
                     _cmd.extend([
@@ -14148,7 +14174,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                     )
                     _cmd = [_oc_bin, "run", "--model", model, context_prompt]
                 elif runtime == "codex":
-                    _codex_bin = _which_bin("codex") or "codex"
+                    _codex_bin = find_executable("codex") or "codex"
                     _cmd = [
                         _codex_bin,
                         "exec",

--- a/tests/test_issue_284_codex_v0125_compat.py
+++ b/tests/test_issue_284_codex_v0125_compat.py
@@ -25,8 +25,16 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
             "orchestrator": {"path": self.tmpdir},
         }
         self.mgr.command_timeout = 60
+        self.mgr.codex_bin = "codex"
         self.mgr.codex_session_dir = Path(self.tmpdir) / ".codex" / "sessions"
         self.mgr.codex_session_dir.mkdir(parents=True)
+        self.mgr._codex_uses_chatgpt_account = lambda: False
+        self.model_updates = []
+        self.mgr.update_session_field = (
+            lambda session_id, field, value: self.model_updates.append(
+                (session_id, field, value)
+            )
+        )
 
     # ------------------------------------------------------------------
     # Flag tests
@@ -165,6 +173,32 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
         exec_idx = cmd.index("exec")
         resume_idx = cmd.index("resume")
         self.assertGreater(resume_idx, exec_idx)
+
+    def test_chatgpt_auth_uses_account_default_for_new_codex_session(self):
+        """ChatGPT-authenticated Codex must not receive a catalog model ID."""
+        self.mgr._codex_uses_chatgpt_account = lambda: True
+
+        cmd = self._capture_cmd_new_session()
+
+        self.assertNotIn("-m", cmd)
+        self.assertIn(("test-session", "model", "default"), self.model_updates)
+
+    def test_chatgpt_auth_uses_account_default_for_resumed_codex_session(self):
+        """The same normalization applies before a Codex resume command."""
+        self.mgr._codex_uses_chatgpt_account = lambda: True
+
+        cmd = self._capture_cmd_resume_session()
+
+        self.assertNotIn("-m", cmd)
+        self.assertIn(("test-session", "model", "default"), self.model_updates)
+
+    def test_new_session_uses_resolved_codex_executable(self):
+        """The macOS app has a minimal PATH, so use the resolved binary path."""
+        self.mgr.codex_bin = "/opt/homebrew/bin/codex"
+
+        cmd = self._capture_cmd_new_session()
+
+        self.assertEqual(cmd[0], "/opt/homebrew/bin/codex")
 
     # ------------------------------------------------------------------
     # strip_metadata: JSONL parsing
@@ -321,14 +355,15 @@ class TestIssue284CodexV0125Compat(unittest.TestCase):
         source = inspect.getsource(agent_manager)
         start = source.find("def _build_bg_cmd(")
         self.assertGreater(start, 0, "_build_bg_cmd function not found")
-        codex_branch_start = source.find('elif eff_runtime == "codex":', start)
+        codex_branch_start = source.find('elif rt == "codex":', start)
         self.assertGreater(
             codex_branch_start, 0, "codex runtime branch not found in _build_bg_cmd"
         )
-        next_branch = source.find("elif eff_runtime ==", codex_branch_start + 1)
-        if next_branch == -1:
-            next_branch = source.find("else:", codex_branch_start + 1)
-        codex_block = source[codex_branch_start:next_branch]
+        command_return = source.find('elif rt == "claude":', codex_branch_start)
+        self.assertGreater(
+            command_return, codex_branch_start, "next background runtime branch not found"
+        )
+        codex_block = source[codex_branch_start:command_return]
 
         self.assertIn('"--json"', codex_block)
         self.assertIn('"--skip-git-repo-check"', codex_block)


### PR DESCRIPTION
## Summary

Fixes the local macOS API path to the Codex CLI and prevents it from adopting unrelated Codex Desktop sessions.

## Root cause

The macOS app launches the Local API with a minimal PATH, so Homebrew Codex could not locate Node. The API also scanned the shared `~/.codex/sessions` directory and could resume an unrelated desktop task.

## Changes

- resolve Codex with the existing cross-platform executable resolver
- add common CLI locations to subprocess PATH
- use the resolved binary for foreground and background Codex work
- use the account-default model for ChatGPT-authenticated Codex
- disable unsafe Codex auto-resume until it has isolated session ownership

## Validation

- `python3 -m unittest tests/test_issue_284_codex_v0125_compat.py` (18 passed)
- `python3 -m py_compile agent_manager.py`
- verified a local macOS app response end-to-end

Closes #419.