### PR TITLE
Fix local Ollama context window for agents

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9423,8 +9423,14 @@ User Request:
             if context_prompt:
                 messages.append({"role": "system", "content": context_prompt})
         messages.append({"role": "user", "content": prompt})
+        context_window = self._wee_get_context_limit_for_api(resolved_model, api_base)
         messages = self._wee_maybe_compact(
-            client, n8n_session_id, messages, resolved_model, context_prompt
+            client,
+            n8n_session_id,
+            messages,
+            resolved_model,
+            context_prompt,
+            context_window=context_window,
         )
 
         # -- Tool definitions for agentic loop (Issue #107) --
@@ -9576,6 +9582,14 @@ User Request:
                     "messages": messages,
                     "stream": True,
                 }
+                # Ollama otherwise loads its conservative 4K default context.
+                # Local agent runs need the configured long window for tool
+                # transcripts and multi-turn planning to remain usable.
+                ollama_num_ctx = self._wee_ollama_context_window_for_api(api_base)
+                if ollama_num_ctx:
+                    create_kwargs["extra_body"] = {
+                        "options": {"num_ctx": ollama_num_ctx}
+                    }
                 if round_num < MAX_TOOL_ROUNDS and "search" not in _last_tool_names:
                     create_kwargs["tools"] = _WEE_TOOLS
 
@@ -10005,11 +10019,39 @@ User Request:
         """Resolve the context window size for a wee model."""
         return self._wee_get_context_limit_for_api(model, "")
 
+    @staticmethod
+    def _wee_ollama_context_window_for_api(api_base: str) -> Optional[int]:
+        """Return the configured context window when ``api_base`` is Ollama.
+
+        Ollama defaults to 4K unless each generation supplies ``num_ctx``.
+        The desktop Local API sets this value to 64K, while server deployments
+        remain unchanged unless they explicitly opt in through the same env var.
+        """
+        configured = os.environ.get("WEE_OLLAMA_CONTEXT_WINDOW", "").strip()
+        if not configured:
+            return None
+        try:
+            context_window = int(configured)
+        except ValueError:
+            return None
+        if context_window < 4_096:
+            return None
+
+        endpoint = (api_base or "").rstrip("/").lower()
+        ollama_host = os.environ.get(
+            "WEE_OLLAMA_HOST", "http://192.168.1.101:11434"
+        ).rstrip("/").lower()
+        return context_window if endpoint.startswith(ollama_host) else None
+
     def _wee_get_context_limit_for_api(self, model: str, api_base: str) -> int:
         """Resolve the context window size for a wee model and endpoint."""
+        if configured_window := self._wee_ollama_context_window_for_api(api_base):
+            return configured_window
+
         normalized = (model or "").lower()
         known_windows = [
             ("gemma4", 128000),
+            ("gemma3", 131072),
             ("llama-4-scout", 131072),
             ("llama-3.1", 131072),
             ("64k", 65536),

--- a/tests/test_issue175_context_compaction.py
+++ b/tests/test_issue175_context_compaction.py
@@ -133,6 +133,37 @@ class TestWeeGetContextLimit(unittest.TestCase):
     def test_heuristic_32k(self):
         self.assertEqual(self.mgr._wee_get_context_limit("some-model-32k"), 32768)
 
+    def test_local_ollama_uses_configured_agent_context_window(self):
+        with patch.dict(
+            os.environ,
+            {
+                "WEE_OLLAMA_HOST": "http://127.0.0.1:11434",
+                "WEE_OLLAMA_CONTEXT_WINDOW": "65536",
+            },
+            clear=False,
+        ):
+            self.assertEqual(
+                self.mgr._wee_get_context_limit_for_api(
+                    "gemma3:27b", "http://127.0.0.1:11434/v1"
+                ),
+                65536,
+            )
+
+    def test_context_override_is_not_sent_to_non_ollama_endpoint(self):
+        with patch.dict(
+            os.environ,
+            {
+                "WEE_OLLAMA_HOST": "http://127.0.0.1:11434",
+                "WEE_OLLAMA_CONTEXT_WINDOW": "65536",
+            },
+            clear=False,
+        ):
+            self.assertIsNone(
+                self.mgr._wee_ollama_context_window_for_api(
+                    "https://openrouter.ai/api/v1"
+                )
+            )
+
 
 # ---------------------------------------------------------------------------
 # Transcript saving
@@ -506,6 +537,34 @@ class TestRunWeeNativeCompactionIntegration(unittest.TestCase):
         ) as mock_compact:
             _run_wee_native_test(self.mgr, self.session_id)
             mock_compact.assert_called_once()
+
+    @patch("openai.OpenAI")
+    def test_local_ollama_request_sets_agent_context_window(self, MockOpenAI):
+        mock_instance = MagicMock()
+        MockOpenAI.return_value = mock_instance
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = "response text"
+        chunk.choices[0].delta.tool_calls = None
+        chunk.usage = None
+        mock_instance.chat.completions.create.return_value = iter([chunk])
+
+        with patch.dict(
+            os.environ,
+            {
+                "WEE_OLLAMA_HOST": "http://127.0.0.1:11434",
+                "WEE_OLLAMA_CONTEXT_WINDOW": "65536",
+            },
+            clear=False,
+        ):
+            _run_wee_native_test(
+                self.mgr, self.session_id, model="ollama/gemma3:27b"
+            )
+
+        create_kwargs = mock_instance.chat.completions.create.call_args.kwargs
+        self.assertEqual(
+            create_kwargs.get("extra_body"), {"options": {"num_ctx": 65536}}
+        )
 
     @patch("openai.OpenAI")
     def test_usage_chunk_without_choices_updates_webui_runtime_state(self, MockOpenAI):


### PR DESCRIPTION
## Summary

- Send the configured Ollama `num_ctx` option for local Wee runtime completions.
- Use the same configured window for compaction and token accounting.
- Add regression coverage for local Ollama and non-Ollama endpoints.

## Root cause

Ollama defaults to a 4K context window unless each request specifies `num_ctx`, and unknown local model tags also fell back to 4K in the API tracker.

## Validation

`.venv/bin/python -m unittest tests.test_issue175_context_compaction.TestWeeGetContextLimit tests.test_issue175_context_compaction.TestRunWeeNativeCompactionIntegration.test_local_ollama_request_sets_agent_context_window`
