### PR TITLE
Fix Ollama empty tool streams and standalone Wee secret lookup

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9887,6 +9887,36 @@ User Request:
 
                 content_text = "".join(round_content)
 
+                # Some Ollama models accept an OpenAI-compatible `tools`
+                # payload but then produce an empty stream with no tool call.
+                # Treat that as provider incompatibility and retry the first
+                # turn once without tools, just as we do when the endpoint
+                # rejects the tools parameter outright (#434).
+                if (
+                    round_num == 0
+                    and not content_text.strip()
+                    and not tool_calls_acc
+                    and "tools" in create_kwargs
+                ):
+                    print(
+                        "[Wee Native] Empty tool-enabled response, retrying without tools",
+                        file=sys.stderr,
+                    )
+                    retry_kwargs = dict(create_kwargs)
+                    retry_kwargs.pop("tools", None)
+                    retry_stream = client.chat.completions.create(**retry_kwargs)
+                    retry_content = []
+                    for chunk in retry_stream:
+                        if not chunk.choices:
+                            continue
+                        delta = chunk.choices[0].delta
+                        if delta.content:
+                            token = delta.content
+                            retry_content.append(token)
+                            if stream_buffer:
+                                stream_buffer.push("chunk", {"text": token})
+                    content_text = "".join(retry_content)
+
                 # No tool calls — we have the final answer
                 if not tool_calls_acc:
                     # Issue #343: When call_agent was the last tool and model returns

--- a/tests/test_issue429_wee_webui_secret.py
+++ b/tests/test_issue429_wee_webui_secret.py
@@ -6,6 +6,7 @@ import types
 import pytest
 
 import wee_copilot_sdk
+import wee_runtime
 from secret_tool import secret_tool as secret_tool_module
 from wee_copilot_sdk import resolve_wee_provider
 
@@ -46,3 +47,48 @@ def test_missing_openrouter_secret_stops_before_unauthenticated_fallback(monkeyp
 
     with pytest.raises(ValueError, match="Save OPENROUTER_API_KEY in Wee Secrets"):
         resolve_wee_provider("openrouter/openai/gpt-5.6-terra")
+
+
+def test_wee_runtime_cli_uses_webui_secret_manager(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("WEE_API_KEY", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "keyring",
+        types.SimpleNamespace(get_password=lambda *_args: None),
+    )
+
+    class FakeFileBackend:
+        def get(self, name):
+            if name == "OPENROUTER_API_KEY":
+                return {"status": "success", "credential": "stored-webui-key"}
+            return {"status": "failure", "credential": None}
+
+    monkeypatch.setattr(secret_tool_module, "FileBackend", FakeFileBackend)
+
+    model, base, key = wee_runtime.resolve_model_and_endpoint(
+        "openrouter/openai/gpt-5.6-terra"
+    )
+
+    assert model == "openai/gpt-5.6-terra"
+    assert "openrouter" in base
+    assert key == "stored-webui-key"
+
+
+def test_wee_runtime_cli_still_exits_when_no_key_anywhere(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("WEE_API_KEY", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "keyring",
+        types.SimpleNamespace(get_password=lambda *_args: None),
+    )
+
+    class EmptyFileBackend:
+        def get(self, name):
+            return {"status": "failure", "credential": None}
+
+    monkeypatch.setattr(secret_tool_module, "FileBackend", EmptyFileBackend)
+
+    with pytest.raises(SystemExit):
+        wee_runtime.resolve_model_and_endpoint("openrouter/openai/gpt-5.6-terra")

--- a/tests/test_wee_native_runtime.py
+++ b/tests/test_wee_native_runtime.py
@@ -157,6 +157,35 @@ class TestWeeRuntimeDispatch(unittest.TestCase):
         self.assertEqual(call_kwargs["model"], "gemma4:e4b")
 
     @patch("openai.OpenAI")
+    def test_empty_tool_stream_retries_without_tools(self, mock_openai_cls):
+        """Ollama models that silently ignore tools get one plain retry (#434)."""
+        mgr = _make_mgr()
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = "plain retry response"
+        chunk.choices[0].delta.tool_calls = None
+        mock_client.chat.completions.create.side_effect = [[], [chunk]]
+
+        test_session = "test_wee_empty_tool_stream"
+        mgr.session_map[test_session] = {
+            "runtime": "wee",
+            "model": "ollama/gemma4:e4b",
+            "channel": "api",
+        }
+
+        result = _run_wee_native_test(mgr, test_session)
+
+        self.assertEqual(result, "plain retry response")
+        self.assertEqual(mock_client.chat.completions.create.call_count, 2)
+        first_kwargs = mock_client.chat.completions.create.call_args_list[0].kwargs
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        self.assertIn("tools", first_kwargs)
+        self.assertNotIn("tools", retry_kwargs)
+
+    @patch("openai.OpenAI")
     def test_run_wee_native_openrouter_model(self, mock_openai_cls):
         """OpenRouter model prefix should resolve to the correct API base."""
         mgr = _make_mgr()

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -89,10 +89,27 @@ _WEE_TOOLS = [
 ]
 
 
+def _webui_secret(name: str) -> "str | None":
+    """Read a credential stored by the WebUI Secret Manager."""
+    try:
+        from secret_tool.secret_tool import FileBackend
+
+        result = FileBackend().get(name)
+        if result.get("status") == "success":
+            credential = result.get("credential")
+            if isinstance(credential, str) and credential.strip():
+                return credential.strip()
+    except Exception:
+        pass
+    return None
+
+
 def fetch_openrouter_pricing():
     """Fetch OpenRouter model pricing from API and cache it."""
     try:
         api_key = os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            api_key = _webui_secret("OPENROUTER_API_KEY")
         if not api_key:
             try:
                 import keyring
@@ -1085,6 +1102,8 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
             resolved_key = os.environ.get("OPENROUTER_API_KEY")
         if not resolved_key:
             resolved_key = os.environ.get("WEE_API_KEY")
+        if not resolved_key and "openrouter" in (resolved_base or "").lower():
+            resolved_key = _webui_secret("OPENROUTER_API_KEY")
         # Try keyring for OpenRouter
         if not resolved_key and "openrouter" in (resolved_base or "").lower():
             try:
@@ -1097,8 +1116,9 @@ def resolve_model_and_endpoint(model: str, api_base: str = None, api_key: str = 
         if not resolved_key:
             if "openrouter" in (resolved_base or "").lower():
                 print(
-                    "Error: OpenRouter API key not found. Set "
-                    "OPENROUTER_API_KEY env var or store via keyring.",
+                    "Error: OpenRouter API key not found. Save OPENROUTER_API_KEY "
+                    "in Wee Secrets, set it in the service environment, or store "
+                    "it in the system keyring.",
                     file=sys.stderr,
                 )
                 sys.exit(1)


### PR DESCRIPTION
Closes #434.

Follow-up to #433:
- retries an empty Ollama tool-enabled stream once without tools
- preserves the validated issue #429 WebUI Secret Manager lookup in standalone/background `wee_runtime.py`

Validation on dev host: `34 passed in 1.57s` across native runtime, Copilot BYOK, and WebUI secret regression suites.