### PR TITLE
Reject truncated Ollama SDK responses

### DIFF
--- a/tests/test_issue425_wee_copilot_byok.py
+++ b/tests/test_issue425_wee_copilot_byok.py
@@ -144,6 +144,67 @@ def test_sdk_session_receives_byok_provider_and_resolved_model(monkeypatch):
     assert recorded["disconnected"] is True
 
 
+def test_unusably_short_ollama_sdk_response_triggers_fallback(monkeypatch):
+    """A truncated one-character Ollama SDK result must not reach the user."""
+
+    class Events:
+        ASSISTANT_STREAMING_DELTA = "assistant.delta"
+        ASSISTANT_MESSAGE_DELTA = "assistant.message_delta"
+        ASSISTANT_MESSAGE = "assistant.message"
+        TOOL_EXECUTION_START = "tool.start"
+        TOOL_EXECUTION_COMPLETE = "tool.complete"
+        COMMAND_EXECUTE = "command.execute"
+        SESSION_ERROR = "session.error"
+        MODEL_CALL_FAILURE = "model.failure"
+
+    class PermissionHandler:
+        approve_all = object()
+
+    class Session:
+        session_id = "sdk-session-short"
+
+        async def send_and_wait(self, prompt, timeout):
+            return types.SimpleNamespace(data=types.SimpleNamespace(content="I"))
+
+        def disconnect(self):
+            return None
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def create_session(self, **kwargs):
+            return Session()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "copilot",
+        types.SimpleNamespace(
+            CopilotClient=Client,
+            PermissionHandler=PermissionHandler,
+            SessionEventType=Events,
+        ),
+    )
+    monkeypatch.setenv("WEE_OLLAMA_HOST", "http://ollama-dev.example:11434")
+    route = resolve_wee_provider("ollama/gemma4:e4b")
+
+    with pytest.raises(
+        wee_copilot_sdk.WeeCopilotSDKError,
+        match="unusably short response",
+    ):
+        asyncio.run(
+            execute_wee_copilot_async(
+                prompt="hello",
+                route=route,
+                working_directory="/tmp",
+                timeout=42,
+            )
+        )
+
+
 def test_api_wee_runtime_uses_shared_sdk_executor(monkeypatch):
     from agent_manager import SessionManager
 

--- a/wee_copilot_sdk.py
+++ b/wee_copilot_sdk.py
@@ -279,6 +279,10 @@ async def execute_wee_copilot_async(
             disconnect_result = session.disconnect()
             if asyncio.iscoroutine(disconnect_result):
                 await disconnect_result
+            if route.provider == "ollama" and len(result_text.strip()) <= 1:
+                raise WeeCopilotSDKError(
+                    "Ollama Copilot SDK returned an unusably short response"
+                )
             return result_text, str(actual_session_id) if actual_session_id else None
         except Exception as exc:
             if isinstance(exc, WeeCopilotSDKError):


### PR DESCRIPTION
Closes #434.

Treats a zero/one-character Ollama Copilot SDK response as provider failure so the Wee runtime uses its OpenAI-compatible fallback instead of returning a broken answer.

Dev-host regression gate: 35 passed in 1.24s.