### PR TITLE
Retry truncated native Ollama tool streams

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9894,7 +9894,7 @@ User Request:
                 # rejects the tools parameter outright (#434).
                 if (
                     round_num == 0
-                    and not content_text.strip()
+                    and len(content_text.strip()) <= 1
                     and not tool_calls_acc
                     and "tools" in create_kwargs
                 ):

--- a/tests/test_wee_native_runtime.py
+++ b/tests/test_wee_native_runtime.py
@@ -163,11 +163,18 @@ class TestWeeRuntimeDispatch(unittest.TestCase):
         mock_client = MagicMock()
         mock_openai_cls.return_value = mock_client
 
-        chunk = MagicMock()
-        chunk.choices = [MagicMock()]
-        chunk.choices[0].delta.content = "plain retry response"
-        chunk.choices[0].delta.tool_calls = None
-        mock_client.chat.completions.create.side_effect = [[], [chunk]]
+        truncated_chunk = MagicMock()
+        truncated_chunk.choices = [MagicMock()]
+        truncated_chunk.choices[0].delta.content = "W"
+        truncated_chunk.choices[0].delta.tool_calls = None
+        retry_chunk = MagicMock()
+        retry_chunk.choices = [MagicMock()]
+        retry_chunk.choices[0].delta.content = "plain retry response"
+        retry_chunk.choices[0].delta.tool_calls = None
+        mock_client.chat.completions.create.side_effect = [
+            [truncated_chunk],
+            [retry_chunk],
+        ]
 
         test_session = "test_wee_empty_tool_stream"
         mgr.session_map[test_session] = {


### PR DESCRIPTION
Closes #434.

Extends the native Ollama fallback retry to zero- or one-character tool-enabled responses. Dev-host regression gate: 35 passed in 1.29s.