### PR TITLE
Retry sub-four-character Ollama tool responses

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9894,7 +9894,7 @@ User Request:
                 # rejects the tools parameter outright (#434).
                 if (
                     round_num == 0
-                    and len(content_text.strip()) <= 1
+                    and len(content_text.strip()) < 16
                     and not tool_calls_acc
                     and "tools" in create_kwargs
                 ):

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9894,7 +9894,7 @@ User Request:
                 # rejects the tools parameter outright (#434).
                 if (
                     round_num == 0
-                    and len(content_text.strip()) < 16
+                    and len(content_text.strip()) < 4
                     and not tool_calls_acc
                     and "tools" in create_kwargs
                 ):

--- a/tests/test_issue425_wee_copilot_byok.py
+++ b/tests/test_issue425_wee_copilot_byok.py
@@ -164,7 +164,7 @@ def test_unusably_short_ollama_sdk_response_triggers_fallback(monkeypatch):
         session_id = "sdk-session-short"
 
         async def send_and_wait(self, prompt, timeout):
-            return types.SimpleNamespace(data=types.SimpleNamespace(content="I"))
+            return types.SimpleNamespace(data=types.SimpleNamespace(content="To"))
 
         def disconnect(self):
             return None

--- a/tests/test_wee_native_runtime.py
+++ b/tests/test_wee_native_runtime.py
@@ -165,7 +165,7 @@ class TestWeeRuntimeDispatch(unittest.TestCase):
 
         truncated_chunk = MagicMock()
         truncated_chunk.choices = [MagicMock()]
-        truncated_chunk.choices[0].delta.content = "W"
+        truncated_chunk.choices[0].delta.content = "To"
         truncated_chunk.choices[0].delta.tool_calls = None
         retry_chunk = MagicMock()
         retry_chunk.choices = [MagicMock()]

--- a/wee_copilot_sdk.py
+++ b/wee_copilot_sdk.py
@@ -279,7 +279,7 @@ async def execute_wee_copilot_async(
             disconnect_result = session.disconnect()
             if asyncio.iscoroutine(disconnect_result):
                 await disconnect_result
-            if route.provider == "ollama" and len(result_text.strip()) <= 1:
+            if route.provider == "ollama" and len(result_text.strip()) < 16:
                 raise WeeCopilotSDKError(
                     "Ollama Copilot SDK returned an unusably short response"
                 )

--- a/wee_copilot_sdk.py
+++ b/wee_copilot_sdk.py
@@ -279,7 +279,7 @@ async def execute_wee_copilot_async(
             disconnect_result = session.disconnect()
             if asyncio.iscoroutine(disconnect_result):
                 await disconnect_result
-            if route.provider == "ollama" and len(result_text.strip()) < 16:
+            if route.provider == "ollama" and len(result_text.strip()) < 4:
                 raise WeeCopilotSDKError(
                     "Ollama Copilot SDK returned an unusably short response"
                 )


### PR DESCRIPTION
Closes #434.

Retries the observed one- and two-character Ollama tool-transport truncations without treating normal short answers as failures. Dev-host regression gate: 35 passed in 1.29s.