### PR TITLE
Release session-scoped browser runtime

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9402,6 +9402,49 @@ User Request:
                 handler=call_agent_handler,
             )
 
+            async def browser_handler(invocation):
+                return await asyncio.to_thread(
+                    self._wee_execute_tool,
+                    "browser",
+                    dict(invocation.arguments or {}),
+                    agent,
+                    n8n_session_id,
+                )
+
+            browser_tool = Tool(
+                name="browser",
+                description=(
+                    "Control the browser attached to this chat session. Use it to "
+                    "navigate, inspect page text and links, click, type, go back or "
+                    "forward, reload, or evaluate JavaScript."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "navigate",
+                                "snapshot",
+                                "click",
+                                "type",
+                                "evaluate",
+                                "back",
+                                "forward",
+                                "reload",
+                            ],
+                        },
+                        "url": {"type": "string"},
+                        "selector": {"type": "string"},
+                        "text": {"type": "string"},
+                        "script": {"type": "string"},
+                        "submit": {"type": "boolean"},
+                    },
+                    "required": ["action"],
+                },
+                handler=browser_handler,
+            )
+
             def on_sdk_event(kind, payload):
                 if not stream_buffer:
                     return
@@ -9439,7 +9482,7 @@ User Request:
                 timeout=float(effective_timeout),
                 session_id=saved_sdk_session,
                 resume=bool(resume and saved_sdk_session),
-                tools=[call_agent_tool],
+                tools=[call_agent_tool, browser_tool],
                 enable_tools=True,
                 event_callback=on_sdk_event,
             )
@@ -9775,6 +9818,41 @@ User Request:
                     },
                 },
             },
+            {
+                "type": "function",
+                "function": {
+                    "name": "browser",
+                    "description": (
+                        "Control the browser attached to this chat session, or a "
+                        "session-scoped Playwright browser when no native browser "
+                        "is connected."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "action": {
+                                "type": "string",
+                                "enum": [
+                                    "navigate",
+                                    "snapshot",
+                                    "click",
+                                    "type",
+                                    "evaluate",
+                                    "back",
+                                    "forward",
+                                    "reload",
+                                ],
+                            },
+                            "url": {"type": "string"},
+                            "selector": {"type": "string"},
+                            "text": {"type": "string"},
+                            "script": {"type": "string"},
+                            "submit": {"type": "boolean"},
+                        },
+                        "required": ["action"],
+                    },
+                },
+            },
         ]
 
         collected_output = []
@@ -9995,7 +10073,9 @@ User Request:
                     )
 
                     # Execute the tool
-                    tool_result = self._wee_execute_tool(func_name, func_args, agent)
+                    tool_result = self._wee_execute_tool(
+                        func_name, func_args, agent, n8n_session_id
+                    )
 
                     # Issue #109: Emit tool complete event to SSE stream
                     tc_done_event = {
@@ -10662,7 +10742,13 @@ User Request:
             resolved_key = "ollama"
         return resolved_base, resolved_key, resolved_model
 
-    def _wee_execute_tool(self, func_name: str, func_args: dict, agent: str) -> str:
+    def _wee_execute_tool(
+        self,
+        func_name: str,
+        func_args: dict,
+        agent: str,
+        n8n_session_id: Optional[str] = None,
+    ) -> str:
         """Execute a tool call from the wee runtime agentic loop.
 
         Issue #107: Supports bash, python, and web search tools. Uses the same
@@ -10707,8 +10793,18 @@ User Request:
             elif func_name == "call_agent":
                 # Issue #343: Delegate to sub-agent via orchestrator API
                 return self._wee_call_agent(func_args)
+            elif func_name == "browser":
+                if not n8n_session_id:
+                    return "Error: Browser tool requires a chat session"
+                from browser_bridge import execute_browser_command
+
+                return execute_browser_command(
+                    n8n_session_id,
+                    func_args,
+                    timeout=min(float(self.command_timeout), 90.0),
+                )
             else:
-                return f"Error: Unknown tool '{func_name}'. Available: bash, python, search, call_agent"
+                return f"Error: Unknown tool '{func_name}'. Available: bash, python, search, call_agent, browser"
         except subprocess.TimeoutExpired:
             return f"Error: Tool '{func_name}' timed out"
         except Exception as e:
@@ -12316,6 +12412,107 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             "active_sessions": len(session_mgr.load_session_map()),
             "remote_api_url": REMOTE_API_URL or None,
         }
+
+    def _assert_browser_session_owner(session_id: str, user: dict) -> None:
+        data = session_mgr.load_session_data(session_id)
+        if not data:
+            raise HTTPException(status_code=404, detail="Session not found")
+        owner = data.get("identity")
+        channel = data.get("channel")
+        if owner and owner != user["identity"]:
+            raise HTTPException(
+                status_code=403, detail="Browser session belongs to another user"
+            )
+        if channel and channel != user["channel"]:
+            raise HTTPException(
+                status_code=403, detail="Browser session belongs to another channel"
+            )
+
+    @app.post("/api/v1/browser/sessions/{session_id}/register")
+    async def register_native_browser(session_id: str, request: Request):
+        """Attach a native browser controller to one authenticated chat session."""
+        from browser_bridge import native_browser_broker
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_browser_session_owner(session_id, user)
+        body = await request.json()
+        client_id = str(body.get("client_id") or "").strip()
+        if not client_id:
+            raise HTTPException(status_code=400, detail="client_id is required")
+        try:
+            native_browser_broker.register(
+                session_id, user["identity"], user["channel"], client_id
+            )
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        return {"registered": True, "session_id": session_id}
+
+    @app.get("/api/v1/browser/sessions/{session_id}/commands")
+    async def poll_native_browser_commands(
+        session_id: str, request: Request, client_id: str, timeout: float = 25.0
+    ):
+        """Long-poll the next command for a native session browser."""
+        from browser_bridge import native_browser_broker
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_browser_session_owner(session_id, user)
+        try:
+            command = await asyncio.to_thread(
+                native_browser_broker.poll,
+                session_id,
+                user["identity"],
+                user["channel"],
+                client_id,
+                timeout,
+            )
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        return {"command": command}
+
+    @app.post("/api/v1/browser/sessions/{session_id}/results")
+    async def submit_native_browser_result(session_id: str, request: Request):
+        """Return a native WKWebView command result to the waiting Wee tool."""
+        from browser_bridge import native_browser_broker
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_browser_session_owner(session_id, user)
+        body = await request.json()
+        client_id = str(body.get("client_id") or "").strip()
+        command_id = str(body.get("command_id") or "").strip()
+        if not client_id or not command_id:
+            raise HTTPException(
+                status_code=400, detail="client_id and command_id are required"
+            )
+        try:
+            native_browser_broker.submit_result(
+                session_id,
+                user["identity"],
+                user["channel"],
+                client_id,
+                command_id,
+                result=body.get("result"),
+                error=body.get("error"),
+                url=body.get("url"),
+                title=body.get("title"),
+            )
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        return {"accepted": True}
 
     @app.get("/api/v1/service-status")
     async def get_service_status():

--- a/browser_bridge.py
+++ b/browser_bridge.py
@@ -1,0 +1,237 @@
+"""Session-scoped browser control for Wee native clients and WebUI.
+
+Native clients long-poll a small authenticated command queue. When no native
+browser is attached to a chat session, the same tool contract falls back to a
+Playwright page if Playwright is installed on the API host.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Any, Optional
+from uuid import uuid4
+
+
+@dataclass
+class BrowserRegistration:
+    identity: str
+    channel: str
+    client_id: str
+    last_seen: float = field(default_factory=time.monotonic)
+
+
+class NativeBrowserBroker:
+    def __init__(self, active_ttl: float = 45.0):
+        self.active_ttl = active_ttl
+        self._condition = threading.Condition()
+        self._registrations: dict[str, BrowserRegistration] = {}
+        self._commands: dict[str, deque[dict[str, Any]]] = defaultdict(deque)
+        self._results: dict[str, dict[str, Any]] = {}
+
+    def register(
+        self, session_id: str, identity: str, channel: str, client_id: str
+    ) -> None:
+        with self._condition:
+            current = self._registrations.get(session_id)
+            if current and (current.identity, current.channel) != (identity, channel):
+                raise PermissionError("Browser session belongs to another user")
+            self._registrations[session_id] = BrowserRegistration(
+                identity=identity, channel=channel, client_id=client_id
+            )
+            self._condition.notify_all()
+
+    def _registration(
+        self, session_id: str, identity: str, channel: str, client_id: str
+    ) -> BrowserRegistration:
+        registration = self._registrations.get(session_id)
+        if not registration or (
+            registration.identity,
+            registration.channel,
+            registration.client_id,
+        ) != (identity, channel, client_id):
+            raise PermissionError("Native browser is not registered for this session")
+        return registration
+
+    def poll(
+        self,
+        session_id: str,
+        identity: str,
+        channel: str,
+        client_id: str,
+        timeout: float = 25.0,
+    ) -> Optional[dict[str, Any]]:
+        deadline = time.monotonic() + max(0.0, min(timeout, 30.0))
+        with self._condition:
+            registration = self._registration(
+                session_id, identity, channel, client_id
+            )
+            registration.last_seen = time.monotonic()
+            while not self._commands[session_id]:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    registration.last_seen = time.monotonic()
+                    return None
+                self._condition.wait(remaining)
+                registration = self._registration(
+                    session_id, identity, channel, client_id
+                )
+                registration.last_seen = time.monotonic()
+            return self._commands[session_id].popleft()
+
+    def submit_result(
+        self,
+        session_id: str,
+        identity: str,
+        channel: str,
+        client_id: str,
+        command_id: str,
+        result: Any = None,
+        error: Optional[str] = None,
+        url: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> None:
+        with self._condition:
+            registration = self._registration(
+                session_id, identity, channel, client_id
+            )
+            registration.last_seen = time.monotonic()
+            self._results[command_id] = {
+                "result": result,
+                "error": error,
+                "url": url,
+                "title": title,
+            }
+            self._condition.notify_all()
+
+    def is_active(self, session_id: str) -> bool:
+        with self._condition:
+            registration = self._registrations.get(session_id)
+            return bool(
+                registration
+                and time.monotonic() - registration.last_seen <= self.active_ttl
+            )
+
+    def execute(
+        self, session_id: str, command: dict[str, Any], timeout: float = 45.0
+    ) -> dict[str, Any]:
+        command_id = str(uuid4())
+        payload = {"id": command_id, **command}
+        deadline = time.monotonic() + max(1.0, min(timeout, 90.0))
+        with self._condition:
+            if not self.is_active(session_id):
+                raise RuntimeError("No native browser is connected to this session")
+            self._commands[session_id].append(payload)
+            self._condition.notify_all()
+            while command_id not in self._results:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("Native browser command timed out")
+                self._condition.wait(remaining)
+            result = self._results.pop(command_id)
+        if result.get("error"):
+            raise RuntimeError(str(result["error"]))
+        return result
+
+
+class PlaywrightBrowserManager:
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._playwright = None
+        self._browser = None
+        self._pages: dict[str, Any] = {}
+
+    def _page(self, session_id: str):
+        with self._lock:
+            if session_id in self._pages:
+                return self._pages[session_id]
+            try:
+                from playwright.sync_api import sync_playwright
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Browser control requires a connected macOS browser or "
+                    "Playwright (`pip install playwright && playwright install chromium`)"
+                ) from exc
+            if self._playwright is None:
+                self._playwright = sync_playwright().start()
+                self._browser = self._playwright.chromium.launch(headless=True)
+            context = self._browser.new_context()
+            page = context.new_page()
+            self._pages[session_id] = page
+            return page
+
+    def execute(self, session_id: str, command: dict[str, Any]) -> dict[str, Any]:
+        page = self._page(session_id)
+        action = str(command.get("action") or "snapshot").lower()
+        if action == "navigate":
+            url = str(command.get("url") or "").strip()
+            if not url:
+                raise ValueError("browser navigate requires url")
+            if "://" not in url:
+                url = "https://" + url
+            page.goto(url, wait_until="domcontentloaded", timeout=30_000)
+        elif action == "click":
+            selector = str(command.get("selector") or "").strip()
+            text = str(command.get("text") or "").strip()
+            if selector:
+                page.locator(selector).first.click(timeout=15_000)
+            elif text:
+                page.get_by_text(text, exact=False).first.click(timeout=15_000)
+            else:
+                raise ValueError("browser click requires selector or text")
+        elif action == "type":
+            selector = str(command.get("selector") or "").strip()
+            text = str(command.get("text") or "")
+            if not selector:
+                raise ValueError("browser type requires selector")
+            page.locator(selector).first.fill(text, timeout=15_000)
+            if command.get("submit"):
+                page.locator(selector).first.press("Enter")
+        elif action == "evaluate":
+            script = str(command.get("script") or "").strip()
+            if not script:
+                raise ValueError("browser evaluate requires script")
+            value = page.evaluate(script)
+            return self._state(page, value)
+        elif action == "back":
+            page.go_back(wait_until="domcontentloaded")
+        elif action == "forward":
+            page.go_forward(wait_until="domcontentloaded")
+        elif action == "reload":
+            page.reload(wait_until="domcontentloaded")
+        elif action != "snapshot":
+            raise ValueError(f"Unknown browser action: {action}")
+        return self._state(page)
+
+    @staticmethod
+    def _state(page, value: Any = None) -> dict[str, Any]:
+        text = page.locator("body").inner_text(timeout=10_000)[:12_000]
+        links = page.locator("a").evaluate_all(
+            "els => els.slice(0, 50).map(a => ({text:(a.innerText||'').trim(), href:a.href}))"
+        )
+        return {
+            "result": value,
+            "url": page.url,
+            "title": page.title(),
+            "text": text,
+            "links": links,
+        }
+
+
+native_browser_broker = NativeBrowserBroker()
+playwright_browser_manager = PlaywrightBrowserManager()
+
+
+def execute_browser_command(
+    session_id: str, command: dict[str, Any], timeout: float = 45.0
+) -> str:
+    if native_browser_broker.is_active(session_id):
+        response = native_browser_broker.execute(session_id, command, timeout=timeout)
+        source = "native-macos"
+    else:
+        response = playwright_browser_manager.execute(session_id, command)
+        source = "playwright"
+    return json.dumps({"source": source, **response}, ensure_ascii=False)[:16_000]

--- a/tests/test_issue440_browser_bridge.py
+++ b/tests/test_issue440_browser_bridge.py
@@ -1,0 +1,127 @@
+import os
+import threading
+import time
+
+import pytest
+
+from browser_bridge import NativeBrowserBroker, execute_browser_command
+
+
+def test_native_browser_commands_are_session_scoped():
+    broker = NativeBrowserBroker(active_ttl=10)
+    broker.register("session-a", "user", "macos", "client-a")
+    broker.register("session-b", "user", "macos", "client-b")
+    received = {}
+
+    def client():
+        command = broker.poll("session-a", "user", "macos", "client-a", 2)
+        received.update(command)
+        broker.submit_result(
+            "session-a",
+            "user",
+            "macos",
+            "client-a",
+            command["id"],
+            result={"text": "Session A"},
+            url="https://example.com/a",
+        )
+
+    thread = threading.Thread(target=client)
+    thread.start()
+    result = broker.execute("session-a", {"action": "snapshot"}, timeout=2)
+    thread.join(timeout=2)
+
+    assert received["action"] == "snapshot"
+    assert result["result"] == {"text": "Session A"}
+    assert broker.poll("session-b", "user", "macos", "client-b", 0) is None
+
+
+def test_registration_cannot_be_claimed_by_another_user():
+    broker = NativeBrowserBroker()
+    broker.register("session-a", "alice", "macos", "client-a")
+    with pytest.raises(PermissionError):
+        broker.register("session-a", "bob", "macos", "client-b")
+
+
+def test_inactive_native_browser_falls_back_to_playwright(monkeypatch):
+    from browser_bridge import native_browser_broker, playwright_browser_manager
+
+    monkeypatch.setattr(native_browser_broker, "is_active", lambda _session: False)
+    monkeypatch.setattr(
+        playwright_browser_manager,
+        "execute",
+        lambda session, command: {"result": session, "url": command["url"]},
+    )
+
+    result = execute_browser_command(
+        "web-session", {"action": "navigate", "url": "https://example.com"}
+    )
+    assert '"source": "playwright"' in result
+    assert '"result": "web-session"' in result
+
+
+def test_native_poll_refreshes_liveness():
+    broker = NativeBrowserBroker(active_ttl=0.05)
+    broker.register("session-a", "user", "macos", "client-a")
+    time.sleep(0.03)
+    assert broker.poll("session-a", "user", "macos", "client-a", 0) is None
+    assert broker.is_active("session-a")
+
+
+def test_browser_api_requires_a_real_owned_session(monkeypatch, tmp_path):
+    os.environ["API_SHARED_KEY"] = "issue440"
+    os.environ["APP_ENV"] = "DEV"
+
+    import agent_manager
+    from fastapi.testclient import TestClient
+
+    session_file = tmp_path / "sessions.json"
+    monkeypatch.setattr(agent_manager, "SESSION_MAP_FILE", str(session_file))
+    client = TestClient(agent_manager.create_api_app())
+    headers = {"Authorization": "Bearer shared_issue440"}
+
+    missing = client.post(
+        "/api/v1/browser/sessions/not-real/register",
+        headers=headers,
+        json={"client_id": "mac-a"},
+    )
+    assert missing.status_code == 404
+
+    created = client.post(
+        "/api/v1/sessions/create",
+        headers=headers,
+        json={"session_id": "issue440-a"},
+    )
+    assert created.status_code == 200
+
+    registered = client.post(
+        "/api/v1/browser/sessions/issue440-a/register",
+        headers=headers,
+        json={"client_id": "mac-a"},
+    )
+    assert registered.status_code == 200
+
+    polled = client.get(
+        "/api/v1/browser/sessions/issue440-a/commands",
+        headers=headers,
+        params={"client_id": "mac-a", "timeout": 0},
+    )
+    assert polled.status_code == 200
+    assert polled.json() == {"command": None}
+
+
+def test_browser_api_rejects_unauthenticated_registration(monkeypatch, tmp_path):
+    os.environ["API_SHARED_KEY"] = "issue440-auth"
+    os.environ["APP_ENV"] = "DEV"
+
+    import agent_manager
+    from fastapi.testclient import TestClient
+
+    session_file = tmp_path / "sessions.json"
+    monkeypatch.setattr(agent_manager, "SESSION_MAP_FILE", str(session_file))
+    client = TestClient(agent_manager.create_api_app())
+    response = client.post(
+        "/api/v1/browser/sessions/anything/register",
+        json={"client_id": "mac-a"},
+    )
+    assert response.status_code == 401

--- a/tests/test_issue440_browser_bridge.py
+++ b/tests/test_issue440_browser_bridge.py
@@ -75,9 +75,10 @@ def test_browser_api_requires_a_real_owned_session(monkeypatch, tmp_path):
     import agent_manager
     from fastapi.testclient import TestClient
 
-    session_file = tmp_path / "sessions.json"
-    monkeypatch.setattr(agent_manager, "SESSION_MAP_FILE", str(session_file))
     client = TestClient(agent_manager.create_api_app())
+    session_file = tmp_path / "sessions.json"
+    agent_manager._session_mgr.session_map_file = session_file
+    agent_manager._api_auth_manager.shared_key = "issue440"
     headers = {"Authorization": "Bearer shared_issue440"}
 
     missing = client.post(
@@ -117,9 +118,10 @@ def test_browser_api_rejects_unauthenticated_registration(monkeypatch, tmp_path)
     import agent_manager
     from fastapi.testclient import TestClient
 
-    session_file = tmp_path / "sessions.json"
-    monkeypatch.setattr(agent_manager, "SESSION_MAP_FILE", str(session_file))
     client = TestClient(agent_manager.create_api_app())
+    session_file = tmp_path / "sessions.json"
+    agent_manager._session_mgr.session_map_file = session_file
+    agent_manager._api_auth_manager.shared_key = "issue440-auth"
     response = client.post(
         "/api/v1/browser/sessions/anything/register",
         json={"client_id": "mac-a"},


### PR DESCRIPTION
Closes #440. Promotes the already dev-validated session-scoped native browser bridge and Playwright fallback to main for the macOS v0.5.0 release.