### PR TITLE
fix(wee): register a python tool and catch unexecuted-call phrasing (#453)

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9694,6 +9694,39 @@ User Request:
                 handler=search_handler,
             )
 
+            async def python_handler(invocation):
+                return await asyncio.to_thread(
+                    self._wee_execute_tool,
+                    "python",
+                    dict(invocation.arguments or {}),
+                    agent,
+                    n8n_session_id,
+                )
+
+            # Issue #453: the SDK provides a shell built-in but nothing for
+            # Python, so models improvised "<python>...</python>" in prose and
+            # no computation ever ran. Registering it explicitly gives that
+            # intent a real target.
+            python_tool = Tool(
+                name="python",
+                description=(
+                    "Execute a Python 3 snippet and return its stdout and stderr. "
+                    "Use this for calculation, parsing and data work rather than "
+                    "answering from memory."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string",
+                            "description": "The Python source to run.",
+                        }
+                    },
+                    "required": ["code"],
+                },
+                handler=python_handler,
+            )
+
             async def browser_handler(invocation):
                 return await asyncio.to_thread(
                     self._wee_execute_tool,
@@ -9775,7 +9808,7 @@ User Request:
                 timeout=float(effective_timeout),
                 session_id=saved_sdk_session,
                 resume=bool(resume and saved_sdk_session),
-                tools=[search_tool, call_agent_tool, browser_tool],
+                tools=[search_tool, python_tool, call_agent_tool, browser_tool],
                 enable_tools=True,
                 event_callback=on_sdk_event,
             )
@@ -9804,7 +9837,7 @@ User Request:
                         timeout=float(effective_timeout),
                         session_id=retry_session,
                         resume=bool(retry_session),
-                        tools=[search_tool, call_agent_tool, browser_tool],
+                        tools=[search_tool, python_tool, call_agent_tool, browser_tool],
                         enable_tools=True,
                         event_callback=on_sdk_event,
                     )
@@ -9860,7 +9893,17 @@ User Request:
         r"(?:now\s+|just\s+|quickly\s+|first\s+)*"
         r"(?:web\s+)?"
         r"(?:search|look\s+(?:up|at|into)|check|read|open|fetch|browse|run|execute|"
-        r"inspect|grep|find|list|delegate|ask\s+\w+|call\s+\w+)\b"
+        r"inspect|grep|find|list|delegate|ask\s+\w+|call\s+\w+|"
+        # Issue #453: "compute"/"calculate" cover a python-tool request
+        # ("I'll compute that multiplication using Python:") the way
+        # "search" already covers a search-tool one.
+        r"compute|calculate|"
+        # Issue #453: the reported failure said "I will use the `search` tool
+        # now" — a promise whose verb is "use", which every branch above
+        # missed. Requiring the word "tool" keeps "I will use a different
+        # approach" from matching. Intervening tokens absorb the backticks
+        # models put around the tool name.
+        r"use\s+(?:the\s+|my\s+|a\s+|its\s+)?(?:\S+\s+){0,2}tools?)\b"
     )
 
     # Phrases that mean the work already happened, or that the model is
@@ -9876,6 +9919,41 @@ User Request:
         r"(?:\s+\w+){0,3}\s+(?:search|browse|access|read|run))\b"
     )
 
+    # Issue #453: a local model that cannot reach a tool often writes the
+    # command it *would* have run instead of invoking it — as a fenced block,
+    # a pseudo-XML tag, or an inline pseudo-call mimicking the tool's own
+    # signature. All three were observed live against local Ollama models:
+    #   ```bash\necho -n TOKEN > /tmp/f```
+    #   <python>print(2+2)</python>
+    #   `python(code="print(7919 * 104729)")`
+    # Each is the same incomplete turn #398 describes, but the promise regex
+    # cannot catch any of them — there is no promise sentence to match.
+    _WEE_UNEXECUTED_CALL_RE = re.compile(
+        r"```(?:bash|sh|shell|zsh|python|py)\b.*?```"
+        r"|<(python|bash|shell|tool_call)\b[^>]*>.*?</\1>"
+        r"|`?\b(?:python|search|bash|shell|call_agent|browser)\("
+        r"\s*\w+\s*=\s*[\"'].*?[\"'](?:\s*,\s*\w+\s*=\s*[\"'].*?[\"'])*\s*\)`?",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    @classmethod
+    def _wee_shows_unexecuted_call(cls, text: str) -> bool:
+        """Whether a turn displays a command it never actually ran.
+
+        Deliberately conservative: the block has to dominate the reply. A
+        genuine "here is a script you could use", with real explanation around
+        it, stays a legitimate answer — only a response that is mostly raw
+        command text reads as an invocation the model failed to make.
+        """
+        raw = text or ""
+        blocks = [m.group(0) for m in cls._WEE_UNEXECUTED_CALL_RE.finditer(raw)]
+        if not blocks:
+            return False
+        stripped = len(raw.strip())
+        if not stripped:
+            return False
+        return sum(len(b) for b in blocks) / stripped >= 0.30
+
     @classmethod
     def _wee_turn_is_incomplete(cls, text: str, tool_calls_made: int) -> bool:
         """Return whether a finished turn only *promised* to act.
@@ -9883,7 +9961,9 @@ User Request:
         Issue #398. Two conditions must hold:
 
         * the model performed no tool call at all during the turn, and
-        * its final text announces an action it was equipped to take.
+        * its final text announces an action it was equipped to take — either
+          in prose ("I'll search for that"), or by printing the command itself
+          rather than invoking it (issue #453).
 
         A turn that used any tool is left alone even if its prose still reads
         like a promise — the model did work, and re-prompting it risks
@@ -9896,7 +9976,9 @@ User Request:
             return False
         if cls._WEE_COMPLETED_OR_REFUSED_RE.search(normalized):
             return False
-        return bool(cls._WEE_PROMISED_ACTION_RE.search(normalized))
+        if cls._WEE_PROMISED_ACTION_RE.search(normalized):
+            return True
+        return cls._wee_shows_unexecuted_call(text)
 
     # Appended verbatim to the retry so the instruction is auditable and the
     # model is told to act rather than narrate.
@@ -10017,6 +10099,11 @@ User Request:
             '  Call: search tool with {"q": "your query", "count": 5}\n'
             "  Use for: current information you do not already have a URL for. "
             "Prefer this over web_fetch unless you already know the exact URL.\n"
+            "\n"
+            "**python** -- Run a Python 3 snippet and get its output.\n"
+            '  Call: python tool with {"code": "print(2 + 2)"}\n'
+            "  Use for: arithmetic, parsing and data work, rather than "
+            "answering from memory.\n"
             "\n"
             "**call_agent** -- Delegate tasks to other specialized Wee agents (PREFERRED for background tasks).\n"
             '  Call: call_agent tool with {"agent": "agent_name", "prompt": "task", "mode": "background", ...}\n'
@@ -10505,6 +10592,11 @@ User Request:
                 from wee_runtime import _execute_search
 
                 return _execute_search(func_args)
+            elif func_name == "python":
+                # Issue #453: the SDK ships a shell built-in but no Python
+                # one, so a local model asked to compute something emitted
+                # "<python>print(...)</python>" as prose and nothing ran.
+                return self._wee_run_python(func_args)
             elif func_name == "call_agent":
                 # Issue #343: Delegate to sub-agent via orchestrator API
                 # Issue #444: propagate the originating chat session so the
@@ -10523,10 +10615,49 @@ User Request:
             else:
                 return (
                     f"Error: Unknown tool '{func_name}'. "
-                    "Available: search, call_agent, browser"
+                    "Available: search, python, call_agent, browser"
                 )
         except Exception as e:
             return f"Error executing {func_name}: {e}"
+
+    def _wee_run_python(self, func_args: dict) -> str:
+        """Run a Python snippet for the wee runtime and return its output.
+
+        Issue #443 removed the previous implementation because it passed the
+        model's code to `python3 -c`, where one mis-escaped quote surfaced as an
+        opaque SyntaxError. Writing to a temp file instead keeps the source
+        exactly as the model wrote it, so a traceback points at a real line.
+        """
+        code = (func_args.get("code") or func_args.get("raw") or "").strip()
+        if not code:
+            return "Error: python tool requires 'code'"
+
+        import tempfile
+        import textwrap
+
+        path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".py", delete=False, encoding="utf-8"
+            ) as handle:
+                handle.write(textwrap.dedent(code))
+                path = handle.name
+            proc = subprocess.run(
+                [sys.executable, path],
+                capture_output=True,
+                text=True,
+                timeout=min(float(self.command_timeout), 120.0),
+            )
+            output = ((proc.stdout or "") + (proc.stderr or "")).strip()
+            return output or "(no output)"
+        except subprocess.TimeoutExpired:
+            return "Error: python execution timed out"
+        finally:
+            if path:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
 
     def _wee_call_agent(
         self, func_args: dict, origin_session_id: Optional[str] = None

--- a/tests/test_issue_453_wee_local_tools.py
+++ b/tests/test_issue_453_wee_local_tools.py
@@ -1,0 +1,164 @@
+"""Regression tests for issue #453.
+
+On the wee runtime with a local Ollama model, only search/call_agent/browser
+were registered. With no Python tool and no reliable way to reach the SDK's
+shell built-in, models printed the command they *would* have run and the turn
+ended with nothing executed:
+
+    filesystem-write -> ```bash\necho -n 'WEE-WROTE-5K2M8' > /tmp/probe```
+    python-compute   -> <python>print(7919 * 104729)</python>
+    shell-fact       -> ```bash\nctx_execute(language: "shell", ...)```
+
+#398's retry could not rescue these because its detector only matched prose
+promises ("I'll search for that"), and none of the above contains one.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_453")
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "9453")
+
+from agent_manager import SessionManager  # noqa: E402
+
+
+def _make_sm():
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    json.dump({"agents": []}, tmp)
+    tmp.close()
+    return SessionManager(tmp.name)
+
+
+class TestUnexecutedCallDetection(unittest.TestCase):
+    """A printed command must count as an incomplete turn."""
+
+    def test_fenced_bash_block_with_no_tool_call_is_incomplete(self):
+        text = (
+            "Writing the exact text `WEE-WROTE-5K2M8` into `/tmp/wee_write_probe.txt`:\n\n"
+            "```bash\necho -n 'WEE-WROTE-5K2M8' > /tmp/wee_write_probe.txt\n```"
+        )
+        self.assertTrue(SessionManager._wee_turn_is_incomplete(text, 0))
+
+    def test_pseudo_xml_python_tag_is_incomplete(self):
+        text = "<python>print(7919 * 104729)</python>"
+        self.assertTrue(SessionManager._wee_turn_is_incomplete(text, 0))
+
+    def test_invented_tool_name_in_a_block_is_incomplete(self):
+        text = '```bash\nctx_execute(language: "shell", code: "uname -s")\n```'
+        self.assertTrue(SessionManager._wee_turn_is_incomplete(text, 0))
+
+    def test_inline_pseudo_call_is_incomplete(self):
+        """Live-observed after the python tool was registered: the model wrote
+        the call's own signature back as text instead of invoking it."""
+        text = '`python(code="print(7919 * 104729)")`, **compute product**.'
+        self.assertTrue(SessionManager._wee_turn_is_incomplete(text, 0))
+
+    def test_compute_promise_is_incomplete(self):
+        """Live-observed: 'compute'/'calculate' weren't in the original verb
+        list, so a python-tool promise slipped through with no retry."""
+        text = "I'll compute that multiplication using Python:"
+        self.assertTrue(SessionManager._wee_turn_is_incomplete(text, 0))
+
+    def test_a_turn_that_used_a_tool_is_never_incomplete(self):
+        """Re-prompting after real work risks repeating a side effect."""
+        text = "```bash\nrm -rf /tmp/scratch\n```"
+        self.assertFalse(SessionManager._wee_turn_is_incomplete(text, 1))
+
+    def test_explained_snippet_is_left_alone(self):
+        """Answering "show me a script" must not be mistaken for a failed call."""
+        text = (
+            "You can rotate the logs with a short shell script. The idea is to "
+            "move the current file aside, signal the daemon so it reopens its "
+            "handle, and then compress whatever was rotated out last time. Keep "
+            "roughly two weeks of history so a bad deploy is still diagnosable "
+            "days later, and run it from cron rather than a timer so the output "
+            "lands in the mail spool you already read.\n\n"
+            "```bash\nmv app.log app.log.1\n```\n\n"
+            "Adjust the retention window to taste; anything past a fortnight is "
+            "usually noise, and the compression step keeps the directory small."
+        )
+        self.assertFalse(SessionManager._wee_turn_is_incomplete(text, 0))
+
+    def test_prose_promise_still_detected(self):
+        """#398's original behaviour must survive the #453 addition."""
+        self.assertTrue(
+            SessionManager._wee_turn_is_incomplete("I will use the search tool now.", 0)
+        )
+
+    def test_reported_phrasing_with_backticks_is_detected(self):
+        """The verbatim reply from the bug report, backticks included.
+
+        #398's verb list had no "use" branch, so the exact sentence users hit
+        most often slipped through and no retry ever fired.
+        """
+        text = (
+            "The best way to start is by doing some research on the available "
+            "options and what factors I should consider (like whether the cart "
+            "uses lead-acid, lithium-ion, etc.). I will use the `search` tool now."
+        )
+        self.assertTrue(SessionManager._wee_turn_is_incomplete(text, 0))
+
+    def test_use_without_a_tool_noun_is_not_a_promise(self):
+        """"I'll use a different approach" is prose, not an abandoned call."""
+        self.assertFalse(
+            SessionManager._wee_turn_is_incomplete(
+                "I will use a different approach for this problem.", 0
+            )
+        )
+
+    def test_completed_work_is_not_incomplete(self):
+        text = "Search completed.\n\n```bash\nuname -s\n```"
+        self.assertFalse(SessionManager._wee_turn_is_incomplete(text, 0))
+
+    def test_empty_and_plain_text_are_not_incomplete(self):
+        self.assertFalse(SessionManager._wee_turn_is_incomplete("", 0))
+        self.assertFalse(SessionManager._wee_turn_is_incomplete("Hello there!", 0))
+
+
+class TestPythonTool(unittest.TestCase):
+    """The python tool must exist and actually execute."""
+
+    def setUp(self):
+        self.sm = _make_sm()
+
+    def test_python_tool_runs_code_and_returns_output(self):
+        out = self.sm._wee_execute_tool(
+            "python", {"code": "print(7919 * 104729)"}, "orchestrator", None
+        )
+        self.assertIn("829348951", out)
+
+    def test_python_tool_reports_a_real_traceback_line(self):
+        """#443 removed the old tool because `python3 -c` gave opaque errors."""
+        out = self.sm._wee_execute_tool(
+            "python", {"code": "print('unterminated)"}, "orchestrator", None
+        )
+        self.assertIn("SyntaxError", out)
+
+    def test_python_tool_requires_code(self):
+        out = self.sm._wee_execute_tool("python", {}, "orchestrator", None)
+        self.assertIn("requires 'code'", out)
+
+    def test_python_is_advertised_in_the_capability_prompt(self):
+        prompt = self.sm._wee_augment_system_prompt_with_tools("BASE")
+        self.assertIn("**python**", prompt)
+
+    def test_unknown_tool_message_lists_python(self):
+        out = self.sm._wee_execute_tool("nope", {}, "orchestrator", None)
+        self.assertIn("python", out)
+
+    def test_python_tool_is_registered_on_the_sdk_session(self):
+        """Both the first turn and the #398 retry must offer the same tools."""
+        import inspect
+
+        source = inspect.getsource(self.sm.run_wee_native)
+        self.assertEqual(source.count("tools=[search_tool, python_tool"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the core cause of #453: on the wee runtime with a local Ollama model,
only `search`/`call_agent`/`browser` were registered. A `python` tool now
exists and executes real code, and #398's incomplete-turn detector — which
only matched prose promises — now also catches a command the model displayed
but never ran.

## What's fixed

- **`python` tool registered.** Writes the model's code to a temp file and
  runs it (rather than `python3 -c`), so a mis-escaped quote surfaces as a
  real traceback line instead of the opaque `SyntaxError` that was #443's
  reason for removing the previous implementation.
- **Broader incomplete-turn detection.** In addition to prose promises
  ("I'll search for that"), now catches:
  - a fenced ```` ```bash ```` / ```` ```python ```` block
  - a pseudo-XML tag the model invented (`<python>...</python>`)
  - an inline pseudo-call mimicking the tool's own signature
    (`` `python(code="...")` ``)
  - "compute"/"calculate" promise verbs, and a bare "use ... tool" promise —
    the exact reported phrasing, "I will use the `search` tool now", used
    none of the previously-covered verbs
- `python` advertised in the capability prompt alongside the other three.

## Testing

18 new tests in `tests/test_issue_453_wee_local_tools.py`, including the
verbatim reported phrasing. Scoped run across the wee/#111/#397/#398/#425/#446
test files passes; failures elsewhere in the full suite are pre-existing on
`main` (stale tests targeting the loop #443 already deleted) — confirmed
identical via `git stash` before/after.

Also verified live against the macOS app's Local API with `qwen3.5` and
`gemma4` variants with `num_ctx` set.

## Known residual gap (documented on #453, not closed by this PR)

The Copilot SDK exposes no `tool_choice="required"` — no way to force real
tool use. A model can still emit a confident, well-formed wrong answer while
claiming to have used a tool (observed live: a fabricated arithmetic result
presented as computed). No output-side text pattern can distinguish that from
a genuine answer, so this class of failure isn't closed by this PR. Given the
SDK is a closed-source CLI the Python code only RPCs into, output-side
detection is the only lever available.

Closes the tool-registration and detectable-narration parts of #453.
