### PR TITLE
feat(auth): per-device session tokens, hashed at rest

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -668,7 +668,12 @@ class AuthManager:
             "sessions.json",
         )
         self.pairing_codes: Dict[str, dict] = {}
+        # Keyed by token_id (uuid4), NOT the raw token. Only a SHA-256 hash
+        # of the raw token is persisted — the raw token is handed to the
+        # client exactly once (at pairing/refresh time) and never stored.
         self.session_tokens: Dict[str, dict] = {}
+        # token_hash -> token_id, rebuilt from self.session_tokens on load.
+        self._hash_index: Dict[str, str] = {}
         self._lock = threading.Lock()
         self._load_sessions()
 
@@ -678,36 +683,75 @@ class AuthManager:
             return False
         return token[7:] == self.shared_key
 
+    @staticmethod
+    def _hash_token(token: str) -> str:
+        return hashlib.sha256(token.encode()).hexdigest()
+
     def _load_sessions(self):
-        """Load persisted sessions from file on startup."""
+        """Load persisted device sessions from file on startup.
+
+        Transparently migrates the legacy format (raw token as the dict
+        key, stored in plaintext) to the per-device, hash-at-rest format
+        the first time it's loaded, then rewrites the file so raw tokens
+        never touch disk again.
+        """
         if not os.path.exists(self.sessions_file):
             return
         try:
             with open(self.sessions_file) as f:
                 data = json.load(f)
-                now = time.time()
-                with self._lock:
-                    for token, entry in data.items():
-                        created_at = entry.get("created_at", now)
-                        absolute_expires_at = entry.get(
-                            "absolute_expires_at",
-                            created_at + self.session_token_absolute_ttl,
-                        )
-                        entry["absolute_expires_at"] = absolute_expires_at
-                        if (
-                            entry.get("expires_at", 0) > now
-                            and absolute_expires_at > now
-                        ):
-                            self.session_tokens[token] = entry
         except Exception:
-            pass
+            return
+
+        now = time.time()
+        migrated = False
+        with self._lock:
+            for key, entry in data.items():
+                created_at = entry.get("created_at", now)
+                absolute_expires_at = entry.get(
+                    "absolute_expires_at",
+                    created_at + self.session_token_absolute_ttl,
+                )
+                if entry.get("expires_at", 0) <= now or absolute_expires_at <= now:
+                    continue
+
+                if "token_hash" in entry and "token_id" in entry:
+                    token_id = entry["token_id"]
+                    entry["absolute_expires_at"] = absolute_expires_at
+                    self.session_tokens[token_id] = entry
+                    self._hash_index[entry["token_hash"]] = token_id
+                else:
+                    # Legacy format: `key` IS the raw plaintext token.
+                    migrated = True
+                    token_id = str(uuid4())
+                    token_hash = self._hash_token(key)
+                    new_entry = {
+                        "token_id": token_id,
+                        "token_hash": token_hash,
+                        "identity": entry.get("identity"),
+                        "channel": entry.get("channel"),
+                        "device_name": entry.get("device_name") or "Legacy device",
+                        "platform": entry.get("platform") or "unknown",
+                        "created_at": created_at,
+                        "last_used": entry.get("last_used", created_at),
+                        "expires_at": entry["expires_at"],
+                        "absolute_expires_at": absolute_expires_at,
+                    }
+                    self.session_tokens[token_id] = new_entry
+                    self._hash_index[token_hash] = token_id
+
+        if migrated:
+            self._save_sessions()
 
     def _save_sessions(self):
-        """Persist sessions to file."""
+        """Persist device sessions to file, keyed by token_id. Raw tokens
+        are never written — only the SHA-256 hash used to look them up."""
         try:
             os.makedirs(os.path.dirname(self.sessions_file), exist_ok=True)
-            with open(self.sessions_file, "w") as f:
+            tmp_path = f"{self.sessions_file}.tmp"
+            with open(tmp_path, "w") as f:
                 json.dump(self.session_tokens, f)
+            os.replace(tmp_path, self.sessions_file)
         except Exception:
             pass
 
@@ -726,8 +770,19 @@ class AuthManager:
             }
         return code
 
-    def verify_pairing_code(self, code: str, identity: str) -> Optional[str]:
-        """Verify pairing code. Returns session token on success, None on failure."""
+    def verify_pairing_code(
+        self,
+        code: str,
+        identity: str,
+        device_name: Optional[str] = None,
+        platform: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Verify pairing code and issue a new per-device token.
+
+        Returns {"token", "token_id", "channel"} on success, None on
+        failure. The raw token is generated here and returned exactly
+        once to the caller — only its hash is retained afterwards.
+        """
         with self._lock:
             entry = self.pairing_codes.get(code)
             if not entry:
@@ -738,24 +793,41 @@ class AuthManager:
                 del self.pairing_codes[code]
                 return None
             del self.pairing_codes[code]
+
         token = f"session_{_secrets.token_urlsafe(32)}"
+        token_id = str(uuid4())
+        token_hash = self._hash_token(token)
         now = time.time()
         with self._lock:
-            self.session_tokens[token] = {
+            self.session_tokens[token_id] = {
+                "token_id": token_id,
+                "token_hash": token_hash,
                 "identity": identity,
                 "channel": entry["channel"],
+                "device_name": (device_name or "Unknown device")[:100],
+                "platform": (platform or "unknown")[:50],
                 "created_at": now,
                 "last_used": now,
                 "expires_at": now + self.session_token_ttl,
                 "absolute_expires_at": now + self.session_token_absolute_ttl,
             }
+            self._hash_index[token_hash] = token_id
         self._save_sessions()
-        return token
+        return {"token": token, "token_id": token_id, "channel": entry["channel"]}
 
     def validate_session_token(self, token: str) -> Optional[dict]:
-        """Validate session token. Returns identity info or None."""
+        """Validate a raw session token against the stored hash.
+
+        Returns identity info on success (also refreshing the sliding
+        expiration window, capped by the absolute TTL), or None. This
+        sliding refresh is what lets a device stay signed in indefinitely
+        as long as it's used at least once per window, without needing a
+        separate explicit refresh call.
+        """
+        token_hash = self._hash_token(token)
         with self._lock:
-            entry = self.session_tokens.get(token)
+            token_id = self._hash_index.get(token_hash)
+            entry = self.session_tokens.get(token_id) if token_id else None
             if not entry:
                 return None
             now = time.time()
@@ -765,14 +837,76 @@ class AuthManager:
             )
             entry["absolute_expires_at"] = absolute_expires_at
             if now > entry["expires_at"] or now > absolute_expires_at:
-                del self.session_tokens[token]
+                del self.session_tokens[token_id]
+                self._hash_index.pop(token_hash, None)
                 self._save_sessions()
                 return None
             entry["last_used"] = now
             # Sliding expiration still applies, but it cannot pass the hard cap.
             entry["expires_at"] = min(now + self.session_token_ttl, absolute_expires_at)
             self._save_sessions()
-            return {"identity": entry["identity"], "channel": entry["channel"]}
+            return {
+                "identity": entry["identity"],
+                "channel": entry["channel"],
+                "token_id": token_id,
+                "expires_at": entry["expires_at"],
+            }
+
+    def list_device_tokens(self, identity: str) -> List[dict]:
+        """List the caller's own long-lived device tokens.
+
+        Returns safe metadata only — never the raw token or its hash —
+        sorted most-recently-used first.
+        """
+        with self._lock:
+            entries = [
+                {
+                    "token_id": e["token_id"],
+                    "device_name": e.get("device_name", "Unknown device"),
+                    "platform": e.get("platform", "unknown"),
+                    "channel": e.get("channel"),
+                    "created_at": e.get("created_at"),
+                    "last_used": e.get("last_used"),
+                    "expires_at": e.get("expires_at"),
+                    "absolute_expires_at": e.get("absolute_expires_at"),
+                }
+                for e in self.session_tokens.values()
+                if e.get("identity") == identity
+            ]
+        entries.sort(key=lambda e: e.get("last_used") or 0, reverse=True)
+        return entries
+
+    def revoke_device_token(self, identity: str, token_id: str) -> bool:
+        """Revoke one of the CALLER's own device tokens.
+
+        Returns False, without distinguishing "not found" from "belongs
+        to someone else", if the token isn't owned by `identity` — this
+        is the authorization boundary that stops one user from revoking
+        (or probing the existence of) another user's device tokens.
+        """
+        with self._lock:
+            entry = self.session_tokens.get(token_id)
+            if not entry or entry.get("identity") != identity:
+                return False
+            del self.session_tokens[token_id]
+            self._hash_index.pop(entry.get("token_hash"), None)
+        self._save_sessions()
+        return True
+
+    def revoke_all_device_tokens(self, identity: str) -> int:
+        """Revoke every device token belonging to `identity`. Returns the
+        number of tokens revoked."""
+        with self._lock:
+            to_remove = [
+                tid
+                for tid, e in self.session_tokens.items()
+                if e.get("identity") == identity
+            ]
+            for tid in to_remove:
+                entry = self.session_tokens.pop(tid)
+                self._hash_index.pop(entry.get("token_hash"), None)
+        self._save_sessions()
+        return len(to_remove)
 
     def cleanup_expired(self):
         """Remove expired pairing codes and session tokens."""
@@ -781,15 +915,16 @@ class AuthManager:
             for code in list(self.pairing_codes):
                 if now > self.pairing_codes[code]["expires_at"]:
                     del self.pairing_codes[code]
-            for token in list(self.session_tokens):
-                entry = self.session_tokens[token]
+            for token_id in list(self.session_tokens):
+                entry = self.session_tokens[token_id]
                 created_at = entry.get("created_at", now)
                 absolute_expires_at = entry.get(
                     "absolute_expires_at", created_at + self.session_token_absolute_ttl
                 )
                 entry["absolute_expires_at"] = absolute_expires_at
                 if now > entry["expires_at"] or now > absolute_expires_at:
-                    del self.session_tokens[token]
+                    del self.session_tokens[token_id]
+                    self._hash_index.pop(entry.get("token_hash"), None)
         self._save_sessions()
 
 
@@ -11904,6 +12039,10 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
     class PairingVerification(BaseModel):
         code: str
         identity: str
+        # Optional per-device metadata (iOS/macOS clients) shown back to the
+        # user in the device-token management UI. Never security-sensitive.
+        device_name: Optional[str] = None
+        platform: Optional[str] = None
 
     class SessionCreate(BaseModel):
         session_id: Optional[str] = (
@@ -11982,6 +12121,7 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
                 "identity": token_data["identity"],
                 "channel": token_data["channel"],
                 "auth_type": "session_token",
+                "token_id": token_data["token_id"],
             }
 
         raise HTTPException(status_code=401, detail="Unrecognized token type")
@@ -12510,24 +12650,101 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
 
     @app.post("/api/v1/auth/verify-pairing")
     async def verify_pairing(body: PairingVerification):
-        token = auth_mgr.verify_pairing_code(body.code, body.identity)
-        if not token:
+        issued = auth_mgr.verify_pairing_code(
+            body.code, body.identity, body.device_name, body.platform
+        )
+        if not issued:
             raise HTTPException(
                 status_code=400, detail="Invalid or expired pairing code"
             )
-        token_data = auth_mgr.validate_session_token(token)
-        channel = token_data["channel"] if token_data else "unknown"
+        channel = issued["channel"]
         username = None
         if channel == "telegram":
             username = _get_telegram_username(body.identity)
         return {
-            "token": token,
+            "token": issued["token"],
+            "token_id": issued["token_id"],
             "expires_in": SESSION_TOKEN_TTL,
             "absolute_expires_in": SESSION_TOKEN_ABSOLUTE_TTL,
             "identity": body.identity,
             "channel": channel,
             "username": username,
         }
+
+    @app.post("/api/v1/auth/refresh")
+    async def refresh_session_token(
+        authorization: Optional[str] = Header(None),
+    ):
+        """Explicitly refresh the sliding expiration window for the
+        caller's own device token. Re-validating any session token already
+        refreshes it as a side effect, so this is a convenience endpoint
+        for clients that want to proactively extend their session (e.g. on
+        app foreground) without making an unrelated API call."""
+        if not authorization or not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401, detail="Missing or invalid authorization header"
+            )
+        token = authorization[7:]
+        if not token.startswith("session_"):
+            raise HTTPException(
+                status_code=400,
+                detail="Only per-device session tokens can be refreshed",
+            )
+        token_data = auth_mgr.validate_session_token(token)
+        if not token_data:
+            raise HTTPException(
+                status_code=401, detail="Invalid or expired session token"
+            )
+        return {
+            "token_id": token_data["token_id"],
+            "identity": token_data["identity"],
+            "channel": token_data["channel"],
+            "expires_at": token_data["expires_at"],
+        }
+
+    @app.get("/api/v1/auth/devices")
+    async def list_device_tokens(request: Request):
+        """List the caller's own long-lived device tokens/sessions. Never
+        returns raw tokens — metadata only."""
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        devices = auth_mgr.list_device_tokens(user["identity"])
+        current_token_id = user.get("token_id")
+        for d in devices:
+            d["current"] = current_token_id is not None and d["token_id"] == current_token_id
+        return {"devices": devices}
+
+    @app.delete("/api/v1/auth/devices/{token_id}")
+    async def revoke_device_token(token_id: str, request: Request):
+        """Revoke one of the caller's own device tokens. Cannot be used to
+        revoke another user's tokens — ownership is enforced server-side."""
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        ok = auth_mgr.revoke_device_token(user["identity"], token_id)
+        if not ok:
+            raise HTTPException(status_code=404, detail="Device token not found")
+        return {"revoked": token_id}
+
+    @app.post("/api/v1/auth/devices/revoke-all")
+    async def revoke_all_device_tokens(request: Request):
+        """Sign the caller out of every device, including the one making
+        this request."""
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        count = auth_mgr.revoke_all_device_tokens(user["identity"])
+        return {"revoked_count": count}
 
     @app.post("/api/v1/sessions/create")
     async def create_session(

--- a/ios/WeeOrchestratorClient/Sources/WeeOrchestratorClient/Models/Models.swift
+++ b/ios/WeeOrchestratorClient/Sources/WeeOrchestratorClient/Models/Models.swift
@@ -330,10 +330,23 @@ struct PairingRequestResponse: Codable {
 struct PairingVerificationBody: Codable {
     let code: String
     let identity: String
+    /// Shown back to the user in the device-token management UI (Settings,
+    /// WebUI) so they can tell devices apart when revoking. Not security
+    /// sensitive — purely a display label.
+    let deviceName: String?
+    let platform: String?
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case identity
+        case deviceName = "device_name"
+        case platform
+    }
 }
 
 struct PairingVerificationResponse: Codable {
     let token: String
+    let tokenId: String?
     let expiresIn: Int
     let absoluteExpiresIn: Int
     let identity: String
@@ -342,10 +355,44 @@ struct PairingVerificationResponse: Codable {
 
     enum CodingKeys: String, CodingKey {
         case token
+        case tokenId = "token_id"
         case expiresIn = "expires_in"
         case absoluteExpiresIn = "absolute_expires_in"
         case identity
         case channel
         case username
     }
+}
+
+/// One of the caller's own long-lived device tokens/sessions, as returned
+/// by `GET /api/v1/auth/devices`. Metadata only — the API never returns
+/// raw tokens after the initial pairing response.
+struct DeviceToken: Codable, Identifiable {
+    let tokenId: String
+    let deviceName: String
+    let platform: String
+    let channel: String
+    let createdAt: Double?
+    let lastUsed: Double?
+    let expiresAt: Double?
+    let absoluteExpiresAt: Double?
+    let current: Bool
+
+    var id: String { tokenId }
+
+    enum CodingKeys: String, CodingKey {
+        case tokenId = "token_id"
+        case deviceName = "device_name"
+        case platform
+        case channel
+        case createdAt = "created_at"
+        case lastUsed = "last_used"
+        case expiresAt = "expires_at"
+        case absoluteExpiresAt = "absolute_expires_at"
+        case current
+    }
+}
+
+struct DeviceTokensResponse: Codable {
+    let devices: [DeviceToken]
 }

--- a/ios/WeeOrchestratorClient/Sources/WeeOrchestratorClient/Networking/APIClient.swift
+++ b/ios/WeeOrchestratorClient/Sources/WeeOrchestratorClient/Networking/APIClient.swift
@@ -156,13 +156,52 @@ final class APIClient: NSObject {
         return try await send(request)
     }
 
-    /// Exchanges a pairing code for a session bearer token, mirroring the
-    /// WebUI's "Verify" step. No bearer token is required for this call.
-    func verifyPairing(code: String, identity: String) async throws -> PairingVerificationResponse {
-        let body = PairingVerificationBody(code: code, identity: identity)
+    /// Exchanges a pairing code for a per-device session bearer token,
+    /// mirroring the WebUI's "Verify" step. No bearer token is required for
+    /// this call. `deviceName`/`platform` are display-only metadata shown
+    /// back in the device-token management UI.
+    func verifyPairing(code: String, identity: String, deviceName: String? = nil, platform: String? = nil) async throws -> PairingVerificationResponse {
+        let body = PairingVerificationBody(code: code, identity: identity, deviceName: deviceName, platform: platform)
         let encoded = try JSONEncoder().encode(body)
         let request = try makeRequest(path: "/api/v1/auth/verify-pairing", method: "POST", body: encoded)
         return try await send(request)
+    }
+
+    // MARK: - Device token management
+
+    /// Lists the caller's own long-lived device tokens/sessions. Server
+    /// enforces that only the authenticated identity's own devices are
+    /// returned.
+    func fetchDeviceTokens() async throws -> [DeviceToken] {
+        let request = try makeRequest(path: "/api/v1/auth/devices")
+        let response: DeviceTokensResponse = try await send(request)
+        return response.devices
+    }
+
+    /// Revokes one of the caller's own device tokens by id.
+    func revokeDeviceToken(tokenId: String) async throws {
+        let request = try makeRequest(path: "/api/v1/auth/devices/\(tokenId)", method: "DELETE")
+        let _: RevokeDeviceResponse = try await send(request)
+    }
+
+    /// Signs the caller out of every device, including the one making the
+    /// call.
+    func revokeAllDeviceTokens() async throws -> Int {
+        let request = try makeRequest(path: "/api/v1/auth/devices/revoke-all", method: "POST")
+        let response: RevokeAllDevicesResponse = try await send(request)
+        return response.revokedCount
+    }
+}
+
+private struct RevokeDeviceResponse: Decodable {
+    let revoked: String
+}
+
+private struct RevokeAllDevicesResponse: Decodable {
+    let revokedCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case revokedCount = "revoked_count"
     }
 }
 
@@ -182,10 +221,18 @@ extension APIClient: AppStateAPI {}
 
 protocol AuthAPI {
     func requestPairing(identity: String, channel: String) async throws -> PairingRequestResponse
-    func verifyPairing(code: String, identity: String) async throws -> PairingVerificationResponse
+    func verifyPairing(code: String, identity: String, deviceName: String?, platform: String?) async throws -> PairingVerificationResponse
 }
 
 extension APIClient: AuthAPI {}
+
+protocol DeviceManagementAPI {
+    func fetchDeviceTokens() async throws -> [DeviceToken]
+    func revokeDeviceToken(tokenId: String) async throws
+    func revokeAllDeviceTokens() async throws -> Int
+}
+
+extension APIClient: DeviceManagementAPI {}
 
 extension APIClient: URLSessionDelegate {
     func urlSession(

--- a/ios/WeeOrchestratorClient/Sources/WeeOrchestratorClient/Stores/AuthStore.swift
+++ b/ios/WeeOrchestratorClient/Sources/WeeOrchestratorClient/Stores/AuthStore.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Combine
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// State of the Telegram/WebEx pairing login flow, mirroring the WebUI's
 /// auth overlay states (`IDLE` / `CODE_SENT` / `LOGGED_IN`) plus explicit
@@ -40,6 +43,28 @@ final class AuthStore: ObservableObject {
     private var pendingIdentity: String?
 
     private var cancellables = Set<AnyCancellable>()
+
+    /// Display label sent to `verify-pairing` and shown back in the
+    /// server's device-token management UI, e.g. "Foster's iPhone".
+    static var currentDeviceName: String {
+        #if canImport(UIKit)
+        return UIDevice.current.name
+        #else
+        return Host.current().localizedName ?? "Mac"
+        #endif
+    }
+
+    /// Coarse platform label for the device-token list, not used for any
+    /// security decision.
+    static var currentPlatform: String {
+        #if os(iOS)
+        return "iOS"
+        #elseif os(macOS)
+        return "macOS"
+        #else
+        return "unknown"
+        #endif
+    }
 
     enum Keys {
         static let identity = "wee.auth.identity"
@@ -137,7 +162,12 @@ final class AuthStore: ObservableObject {
         defer { isVerifyingCode = false }
 
         do {
-            let response = try await client.verifyPairing(code: trimmed, identity: identity)
+            let response = try await client.verifyPairing(
+                code: trimmed,
+                identity: identity,
+                deviceName: AuthStore.currentDeviceName,
+                platform: AuthStore.currentPlatform
+            )
             settings.bearerToken = response.token
             defaults.set(response.identity, forKey: Keys.identity)
             defaults.set(response.channel, forKey: Keys.channel)

--- a/ios/WeeOrchestratorClient/Tests/WeeOrchestratorClientTests/AuthStoreTests.swift
+++ b/ios/WeeOrchestratorClient/Tests/WeeOrchestratorClientTests/AuthStoreTests.swift
@@ -10,6 +10,7 @@ private final class FakeAuthAPI: AuthAPI {
     var verifyPairingResult: Result<PairingVerificationResponse, Error> = .success(
         PairingVerificationResponse(
             token: "session_abc123",
+            tokenId: "token_fake_1",
             expiresIn: 3600,
             absoluteExpiresIn: 86400,
             identity: "123456789",
@@ -19,15 +20,15 @@ private final class FakeAuthAPI: AuthAPI {
     )
 
     private(set) var requestPairingCalls: [(identity: String, channel: String)] = []
-    private(set) var verifyPairingCalls: [(code: String, identity: String)] = []
+    private(set) var verifyPairingCalls: [(code: String, identity: String, deviceName: String?, platform: String?)] = []
 
     func requestPairing(identity: String, channel: String) async throws -> PairingRequestResponse {
         requestPairingCalls.append((identity: identity, channel: channel))
         return try requestPairingResult.get()
     }
 
-    func verifyPairing(code: String, identity: String) async throws -> PairingVerificationResponse {
-        verifyPairingCalls.append((code: code, identity: identity))
+    func verifyPairing(code: String, identity: String, deviceName: String?, platform: String?) async throws -> PairingVerificationResponse {
+        verifyPairingCalls.append((code: code, identity: identity, deviceName: deviceName, platform: platform))
         return try verifyPairingResult.get()
     }
 }

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -49,38 +49,56 @@ class TestAuthManager(unittest.TestCase):
 
     def test_verify_pairing_code_success(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
-        token = self.auth.verify_pairing_code(code, "user123")
-        self.assertIsNotNone(token)
-        self.assertTrue(token.startswith("session_"))
+        issued = self.auth.verify_pairing_code(code, "user123")
+        self.assertIsNotNone(issued)
+        self.assertTrue(issued["token"].startswith("session_"))
+        self.assertIn("token_id", issued)
 
     def test_verify_pairing_code_wrong_identity(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
-        token = self.auth.verify_pairing_code(code, "wrong_user")
-        self.assertIsNone(token)
+        issued = self.auth.verify_pairing_code(code, "wrong_user")
+        self.assertIsNone(issued)
 
     def test_verify_pairing_code_wrong_code(self):
-        token = self.auth.verify_pairing_code("000000", "user123")
-        self.assertIsNone(token)
+        issued = self.auth.verify_pairing_code("000000", "user123")
+        self.assertIsNone(issued)
 
     def test_verify_pairing_code_consumed(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
         self.auth.verify_pairing_code(code, "user123")
-        token2 = self.auth.verify_pairing_code(code, "user123")
-        self.assertIsNone(token2)
+        issued2 = self.auth.verify_pairing_code(code, "user123")
+        self.assertIsNone(issued2)
 
     def test_verify_pairing_code_expired(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
         self.auth.pairing_codes[code]["expires_at"] = time.time() - 1
-        token = self.auth.verify_pairing_code(code, "user123")
-        self.assertIsNone(token)
+        issued = self.auth.verify_pairing_code(code, "user123")
+        self.assertIsNone(issued)
+
+    def test_verify_pairing_code_stores_device_metadata(self):
+        code = self.auth.generate_pairing_code("user123", "telegram")
+        issued = self.auth.verify_pairing_code(
+            code, "user123", device_name="Foster's iPhone", platform="iOS"
+        )
+        entry = self.auth.session_tokens[issued["token_id"]]
+        self.assertEqual(entry["device_name"], "Foster's iPhone")
+        self.assertEqual(entry["platform"], "iOS")
+
+    def test_verify_pairing_code_hashes_token_at_rest(self):
+        code = self.auth.generate_pairing_code("user123", "telegram")
+        issued = self.auth.verify_pairing_code(code, "user123")
+        entry = self.auth.session_tokens[issued["token_id"]]
+        self.assertNotEqual(entry["token_hash"], issued["token"])
+        self.assertEqual(entry["token_hash"], self.auth._hash_token(issued["token"]))
 
     def test_validate_session_token_success(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
-        token = self.auth.verify_pairing_code(code, "user123")
-        result = self.auth.validate_session_token(token)
+        issued = self.auth.verify_pairing_code(code, "user123")
+        result = self.auth.validate_session_token(issued["token"])
         self.assertIsNotNone(result)
         self.assertEqual(result["identity"], "user123")
         self.assertEqual(result["channel"], "telegram")
+        self.assertEqual(result["token_id"], issued["token_id"])
 
     def test_validate_session_token_invalid(self):
         result = self.auth.validate_session_token("session_bogus")
@@ -88,44 +106,46 @@ class TestAuthManager(unittest.TestCase):
 
     def test_validate_session_token_expired(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
-        token = self.auth.verify_pairing_code(code, "user123")
-        self.auth.session_tokens[token]["expires_at"] = time.time() - 1
-        result = self.auth.validate_session_token(token)
+        issued = self.auth.verify_pairing_code(code, "user123")
+        self.auth.session_tokens[issued["token_id"]]["expires_at"] = time.time() - 1
+        result = self.auth.validate_session_token(issued["token"])
         self.assertIsNone(result)
 
     def test_validate_session_token_updates_last_used(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
-        token = self.auth.verify_pairing_code(code, "user123")
-        before = self.auth.session_tokens[token]["last_used"]
+        issued = self.auth.verify_pairing_code(code, "user123")
+        before = self.auth.session_tokens[issued["token_id"]]["last_used"]
         time.sleep(0.01)
-        self.auth.validate_session_token(token)
-        after = self.auth.session_tokens[token]["last_used"]
+        self.auth.validate_session_token(issued["token"])
+        after = self.auth.session_tokens[issued["token_id"]]["last_used"]
         self.assertGreater(after, before)
 
     def test_validate_session_token_respects_absolute_expiry(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
-        token = self.auth.verify_pairing_code(code, "user123")
-        self.auth.session_tokens[token]["absolute_expires_at"] = time.time() - 1
-        result = self.auth.validate_session_token(token)
+        issued = self.auth.verify_pairing_code(code, "user123")
+        self.auth.session_tokens[issued["token_id"]]["absolute_expires_at"] = time.time() - 1
+        result = self.auth.validate_session_token(issued["token"])
         self.assertIsNone(result)
 
     def test_validate_session_token_does_not_extend_beyond_absolute_expiry(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
-        token = self.auth.verify_pairing_code(code, "user123")
+        issued = self.auth.verify_pairing_code(code, "user123")
         now = time.time()
-        self.auth.session_tokens[token]["absolute_expires_at"] = now + 10
-        self.auth.validate_session_token(token)
-        self.assertLessEqual(self.auth.session_tokens[token]["expires_at"], now + 10.1)
+        self.auth.session_tokens[issued["token_id"]]["absolute_expires_at"] = now + 10
+        self.auth.validate_session_token(issued["token"])
+        self.assertLessEqual(
+            self.auth.session_tokens[issued["token_id"]]["expires_at"], now + 10.1
+        )
 
     def test_cleanup_expired(self):
         code = self.auth.generate_pairing_code("user123", "telegram")
-        token = self.auth.verify_pairing_code(code, "user123")
+        issued = self.auth.verify_pairing_code(code, "user123")
         code2 = self.auth.generate_pairing_code("user456", "webex")
         self.auth.pairing_codes[code2]["expires_at"] = time.time() - 1
-        self.auth.session_tokens[token]["expires_at"] = time.time() - 1
+        self.auth.session_tokens[issued["token_id"]]["expires_at"] = time.time() - 1
         self.auth.cleanup_expired()
         self.assertNotIn(code2, self.auth.pairing_codes)
-        self.assertNotIn(token, self.auth.session_tokens)
+        self.assertNotIn(issued["token_id"], self.auth.session_tokens)
 
 
 class TestRateLimiter(unittest.TestCase):

--- a/tests/test_device_tokens.py
+++ b/tests/test_device_tokens.py
@@ -1,0 +1,443 @@
+"""Tests for long-lived, per-device authentication tokens.
+
+Covers the feature that lets iOS/macOS/WebUI clients pair once via
+Telegram/WebEx and stay signed in via a per-device token instead of
+re-pairing frequently:
+
+- Issuance: verify-pairing issues a per-device token with device metadata
+- Storage: tokens are hashed at rest (SHA-256), never stored in plaintext
+- Backward compatibility: legacy plaintext-keyed sessions.json migrates
+  transparently and continues to authenticate
+- Validation: sliding TTL refresh, hard absolute-TTL cap, revoked/unknown
+  tokens rejected
+- Listing: GET /api/v1/auth/devices returns only the caller's own devices
+- Revocation: DELETE /api/v1/auth/devices/{id} and POST .../revoke-all
+- Authorization isolation: one identity cannot list or revoke another
+  identity's device tokens
+- Refresh endpoint and backwards-compatible shared-key auth
+"""
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "8198")
+
+
+class TestAuthManagerDeviceTokens(unittest.TestCase):
+    """Unit tests directly against AuthManager — no HTTP layer."""
+
+    def setUp(self):
+        import agent_manager
+
+        self.tmpdir = tempfile.mkdtemp()
+        self.sessions_file = os.path.join(self.tmpdir, "sessions.json")
+        self.mgr = agent_manager.AuthManager(
+            shared_key="testkey",
+            pairing_code_ttl=300,
+            session_token_ttl=3600,
+            session_token_absolute_ttl=7200,
+            sessions_file=self.sessions_file,
+        )
+
+    def _issue(self, identity="alice", channel="telegram", device_name="iPhone", platform="iOS"):
+        code = self.mgr.generate_pairing_code(identity, channel)
+        return self.mgr.verify_pairing_code(code, identity, device_name, platform)
+
+    def test_issuance_returns_token_and_id(self):
+        issued = self._issue()
+        self.assertIsNotNone(issued)
+        self.assertTrue(issued["token"].startswith("session_"))
+        self.assertIn("token_id", issued)
+
+    def test_token_hashed_at_rest_not_plaintext(self):
+        issued = self._issue()
+        with open(self.sessions_file) as f:
+            on_disk = f.read()
+        self.assertNotIn(issued["token"], on_disk, "raw token must never be persisted")
+        entry = json.loads(on_disk)[issued["token_id"]]
+        self.assertEqual(
+            entry["token_hash"],
+            self.mgr._hash_token(issued["token"]),
+        )
+
+    def test_validate_accepts_freshly_issued_token(self):
+        issued = self._issue()
+        data = self.mgr.validate_session_token(issued["token"])
+        self.assertIsNotNone(data)
+        self.assertEqual(data["identity"], "alice")
+        self.assertEqual(data["token_id"], issued["token_id"])
+
+    def test_validate_rejects_unknown_token(self):
+        self.assertIsNone(self.mgr.validate_session_token("session_not-a-real-token"))
+
+    def test_validate_rejects_tampered_token(self):
+        issued = self._issue()
+        tampered = issued["token"][:-1] + ("x" if issued["token"][-1] != "x" else "y")
+        self.assertIsNone(self.mgr.validate_session_token(tampered))
+
+    def test_sliding_ttl_extends_on_use(self):
+        issued = self._issue()
+        first = self.mgr.validate_session_token(issued["token"])
+        with patch("time.time", return_value=time.time() + 100):
+            second = self.mgr.validate_session_token(issued["token"])
+        self.assertGreater(second["expires_at"], first["expires_at"])
+
+    def test_absolute_ttl_caps_sliding_window(self):
+        """Repeated use within the sliding TTL keeps extending expires_at,
+        but never past the hard absolute_expires_at cap."""
+        issued = self._issue()
+        base = time.time()
+
+        with patch("time.time", return_value=base + 3000):
+            data1 = self.mgr.validate_session_token(issued["token"])
+        self.assertIsNotNone(data1)
+
+        with patch("time.time", return_value=base + 6000):
+            data2 = self.mgr.validate_session_token(issued["token"])
+        self.assertIsNotNone(data2)
+
+        # Naive sliding would give base+6000+3600=base+9600; the absolute
+        # cap (base+7200) must win instead.
+        self.assertLess(data2["expires_at"], base + 6000 + 3600)
+        self.assertLessEqual(data2["expires_at"], base + 7200 + 1)
+
+    def test_token_expires_past_absolute_ttl(self):
+        issued = self._issue()
+        past_absolute = time.time() + 7300  # beyond absolute_ttl of 7200
+        with patch("time.time", return_value=past_absolute):
+            data = self.mgr.validate_session_token(issued["token"])
+        self.assertIsNone(data)
+
+    def test_list_device_tokens_returns_metadata_no_raw_token(self):
+        issued = self._issue(device_name="Foster's iPhone", platform="iOS")
+        devices = self.mgr.list_device_tokens("alice")
+        self.assertEqual(len(devices), 1)
+        d = devices[0]
+        self.assertEqual(d["token_id"], issued["token_id"])
+        self.assertEqual(d["device_name"], "Foster's iPhone")
+        self.assertEqual(d["platform"], "iOS")
+        self.assertNotIn("token", d)
+        self.assertNotIn("token_hash", d)
+
+    def test_list_device_tokens_isolated_per_identity(self):
+        self._issue(identity="alice")
+        self._issue(identity="bob")
+        self.assertEqual(len(self.mgr.list_device_tokens("alice")), 1)
+        self.assertEqual(len(self.mgr.list_device_tokens("bob")), 1)
+        self.assertEqual(len(self.mgr.list_device_tokens("carol")), 0)
+
+    def test_revoke_device_token_removes_it(self):
+        issued = self._issue()
+        ok = self.mgr.revoke_device_token("alice", issued["token_id"])
+        self.assertTrue(ok)
+        self.assertIsNone(self.mgr.validate_session_token(issued["token"]))
+        self.assertEqual(self.mgr.list_device_tokens("alice"), [])
+
+    def test_revoke_device_token_denies_cross_identity(self):
+        """Authorization boundary: bob cannot revoke alice's device token."""
+        issued = self._issue(identity="alice")
+        ok = self.mgr.revoke_device_token("bob", issued["token_id"])
+        self.assertFalse(ok)
+        # Token must still be valid — the revoke attempt had no effect.
+        self.assertIsNotNone(self.mgr.validate_session_token(issued["token"]))
+
+    def test_revoke_all_device_tokens_only_affects_owner(self):
+        a1 = self._issue(identity="alice", device_name="iPhone")
+        a2 = self._issue(identity="alice", device_name="iPad")
+        b1 = self._issue(identity="bob", device_name="MacBook")
+
+        count = self.mgr.revoke_all_device_tokens("alice")
+
+        self.assertEqual(count, 2)
+        self.assertIsNone(self.mgr.validate_session_token(a1["token"]))
+        self.assertIsNone(self.mgr.validate_session_token(a2["token"]))
+        self.assertIsNotNone(self.mgr.validate_session_token(b1["token"]))
+
+    def test_legacy_plaintext_sessions_migrate_and_still_validate(self):
+        """Backward compatibility: an existing plaintext-keyed sessions.json
+        (the pre-device-token format) must still authenticate, and get
+        transparently rewritten to the hashed, per-device format."""
+        import agent_manager
+
+        legacy_token = "session_legacy_abc123"
+        now = time.time()
+        with open(self.sessions_file, "w") as f:
+            json.dump(
+                {
+                    legacy_token: {
+                        "identity": "legacy_user",
+                        "channel": "webex",
+                        "created_at": now,
+                        "last_used": now,
+                        "expires_at": now + 3600,
+                        "absolute_expires_at": now + 7200,
+                    }
+                },
+                f,
+            )
+
+        mgr2 = agent_manager.AuthManager(
+            shared_key="testkey",
+            session_token_ttl=3600,
+            session_token_absolute_ttl=7200,
+            sessions_file=self.sessions_file,
+        )
+
+        data = mgr2.validate_session_token(legacy_token)
+        self.assertIsNotNone(data, "legacy plaintext token must still validate after migration")
+        self.assertEqual(data["identity"], "legacy_user")
+
+        # File on disk must now be hashed, not plaintext.
+        with open(self.sessions_file) as f:
+            on_disk = f.read()
+        self.assertNotIn(legacy_token, on_disk)
+
+        devices = mgr2.list_device_tokens("legacy_user")
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0]["device_name"], "Legacy device")
+
+    def test_expired_tokens_not_migrated(self):
+        import agent_manager
+
+        expired_token = "session_expired_xyz"
+        now = time.time()
+        with open(self.sessions_file, "w") as f:
+            json.dump(
+                {
+                    expired_token: {
+                        "identity": "someone",
+                        "channel": "webex",
+                        "created_at": now - 10000,
+                        "expires_at": now - 100,
+                        "absolute_expires_at": now - 50,
+                    }
+                },
+                f,
+            )
+        mgr2 = agent_manager.AuthManager(
+            shared_key="testkey", sessions_file=self.sessions_file
+        )
+        self.assertIsNone(mgr2.validate_session_token(expired_token))
+
+    def test_cleanup_expired_removes_hash_index_entry(self):
+        issued = self._issue()
+        with patch("time.time", return_value=time.time() + 7300):
+            self.mgr.cleanup_expired()
+        self.assertIsNone(self.mgr.validate_session_token(issued["token"]))
+        self.assertEqual(self.mgr._hash_index, {})
+
+
+class TestDeviceTokenAPI(unittest.TestCase):
+    """HTTP-level tests for the device token management endpoints."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi.testclient import TestClient
+
+        import agent_manager
+
+        cls.tmpdir = tempfile.mkdtemp()
+        cls._saved_scheduler_jobs_file = os.environ.get("SCHEDULER_JOBS_FILE")
+        os.environ["SCHEDULER_JOBS_FILE"] = os.path.join(cls.tmpdir, "scheduler_jobs.json")
+
+        cls._saved_api_key = os.environ.get("API_SHARED_KEY")
+        os.environ["API_SHARED_KEY"] = "testsharedkey"
+
+        cls._telegram_patch = patch.object(
+            agent_manager,
+            "_resolve_telegram_identity",
+            side_effect=lambda identity: identity,
+        )
+        cls._telegram_patch.start()
+        cls._send_pairing_patch = patch.object(
+            agent_manager, "_send_pairing_code", return_value=True
+        )
+        cls._send_pairing_patch.start()
+        cls._username_patch = patch.object(
+            agent_manager, "_get_telegram_username", return_value=None
+        )
+        cls._username_patch.start()
+
+        cls.app = agent_manager.create_api_app()
+        cls.client = TestClient(cls.app)
+        cls.shared_header = {"Authorization": "Bearer shared_testsharedkey"}
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._telegram_patch.stop()
+        cls._send_pairing_patch.stop()
+        cls._username_patch.stop()
+        if cls._saved_api_key is None:
+            os.environ.pop("API_SHARED_KEY", None)
+        else:
+            os.environ["API_SHARED_KEY"] = cls._saved_api_key
+        if cls._saved_scheduler_jobs_file is None:
+            os.environ.pop("SCHEDULER_JOBS_FILE", None)
+        else:
+            os.environ["SCHEDULER_JOBS_FILE"] = cls._saved_scheduler_jobs_file
+
+    def _pair(self, identity, channel="telegram", device_name="Test Device", platform="iOS"):
+        # Generate the pairing code directly rather than going through
+        # POST /api/v1/auth/request-pairing — that endpoint is rate limited
+        # to 5 requests/15min per client IP (tested elsewhere), and this
+        # test class issues many more pairings than that limit to exercise
+        # the device-token endpoints below.
+        import agent_manager
+
+        code = agent_manager._api_auth_manager.generate_pairing_code(identity, channel)
+        verify = self.client.post(
+            "/api/v1/auth/verify-pairing",
+            json={
+                "code": code,
+                "identity": identity,
+                "device_name": device_name,
+                "platform": platform,
+            },
+        )
+        self.assertEqual(verify.status_code, 200, verify.text)
+        return verify.json()
+
+    def _auth_header(self, token):
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_verify_pairing_returns_device_token(self):
+        result = self._pair("device-user-1", device_name="Foster's iPhone", platform="iOS")
+        self.assertTrue(result["token"].startswith("session_"))
+        self.assertIn("token_id", result)
+
+    def test_devices_endpoint_requires_auth(self):
+        resp = self.client.get("/api/v1/auth/devices")
+        self.assertEqual(resp.status_code, 401)
+
+    def test_devices_endpoint_lists_own_device(self):
+        result = self._pair("device-user-2", device_name="iPad Pro", platform="iOS")
+        resp = self.client.get(
+            "/api/v1/auth/devices", headers=self._auth_header(result["token"])
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        devices = resp.json()["devices"]
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0]["device_name"], "iPad Pro")
+        self.assertTrue(devices[0]["current"])
+        self.assertNotIn("token", devices[0])
+
+    def test_devices_isolated_between_identities(self):
+        """Authorization boundary: user A's device list must never include
+        user B's devices, even when both are authenticated."""
+        result_a = self._pair("device-user-a", device_name="A-Phone")
+        result_b = self._pair("device-user-b", device_name="B-Phone")
+
+        resp_a = self.client.get(
+            "/api/v1/auth/devices", headers=self._auth_header(result_a["token"])
+        )
+        names_a = [d["device_name"] for d in resp_a.json()["devices"]]
+        self.assertIn("A-Phone", names_a)
+        self.assertNotIn("B-Phone", names_a)
+
+        resp_b = self.client.get(
+            "/api/v1/auth/devices", headers=self._auth_header(result_b["token"])
+        )
+        names_b = [d["device_name"] for d in resp_b.json()["devices"]]
+        self.assertIn("B-Phone", names_b)
+        self.assertNotIn("A-Phone", names_b)
+
+    def test_revoke_own_device_succeeds(self):
+        result = self._pair("device-user-3", device_name="Revoke Me")
+        token_id = result["token_id"]
+        resp = self.client.delete(
+            f"/api/v1/auth/devices/{token_id}",
+            headers=self._auth_header(result["token"]),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+
+        # The revoked token itself is now invalid.
+        check = self.client.get(
+            "/api/v1/auth/devices", headers=self._auth_header(result["token"])
+        )
+        self.assertEqual(check.status_code, 401)
+
+    def test_revoke_other_users_device_returns_404(self):
+        """Authorization boundary: cannot revoke someone else's device
+        token even if you know its token_id."""
+        victim = self._pair("device-victim", device_name="Victim Phone")
+        attacker = self._pair("device-attacker", device_name="Attacker Phone")
+
+        resp = self.client.delete(
+            f"/api/v1/auth/devices/{victim['token_id']}",
+            headers=self._auth_header(attacker["token"]),
+        )
+        self.assertEqual(resp.status_code, 404)
+
+        # Victim's device must be unaffected.
+        check = self.client.get(
+            "/api/v1/auth/devices", headers=self._auth_header(victim["token"])
+        )
+        self.assertEqual(check.status_code, 200)
+        self.assertEqual(len(check.json()["devices"]), 1)
+
+    def test_revoke_all_only_revokes_callers_own_devices(self):
+        user_devices = [
+            self._pair("device-user-multi", device_name=f"Device {i}")
+            for i in range(3)
+        ]
+        other = self._pair("device-user-other", device_name="Other Device")
+
+        resp = self.client.post(
+            "/api/v1/auth/devices/revoke-all",
+            headers=self._auth_header(user_devices[0]["token"]),
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(resp.json()["revoked_count"], 3)
+
+        # All three of that user's tokens are now dead.
+        for d in user_devices:
+            check = self.client.get(
+                "/api/v1/auth/devices", headers=self._auth_header(d["token"])
+            )
+            self.assertEqual(check.status_code, 401)
+
+        # The other user's device is untouched.
+        other_check = self.client.get(
+            "/api/v1/auth/devices", headers=self._auth_header(other["token"])
+        )
+        self.assertEqual(other_check.status_code, 200)
+        self.assertEqual(len(other_check.json()["devices"]), 1)
+
+    def test_refresh_endpoint_extends_expiry(self):
+        result = self._pair("device-user-refresh", device_name="Refresh Phone")
+        resp = self.client.post(
+            "/api/v1/auth/refresh", headers=self._auth_header(result["token"])
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        self.assertEqual(body["token_id"], result["token_id"])
+        self.assertIn("expires_at", body)
+
+    def test_refresh_rejects_shared_key(self):
+        resp = self.client.post("/api/v1/auth/refresh", headers=self.shared_header)
+        self.assertEqual(resp.status_code, 400)
+
+    def test_shared_key_auth_still_works_backwards_compatible(self):
+        """Existing shared-key (non-per-device) auth must be unaffected by
+        the device-token feature."""
+        resp = self.client.get("/api/v1/agents", headers=self.shared_header)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_device_session_token_authenticates_other_endpoints(self):
+        result = self._pair("device-user-general", device_name="General Use")
+        resp = self.client.get(
+            "/api/v1/agents", headers=self._auth_header(result["token"])
+        )
+        self.assertEqual(resp.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue_376_configurable_ttls.py
+++ b/tests/test_issue_376_configurable_ttls.py
@@ -105,11 +105,11 @@ class TestIssue376ConfigurableTTLs(unittest.TestCase):
             session_token_absolute_ttl=172800,
         )
         code = mgr.generate_pairing_code("test_identity", "telegram")
-        token = mgr.verify_pairing_code(code, "test_identity")
-        self.assertIsNotNone(token)
-        result = mgr.validate_session_token(token)
+        issued = mgr.verify_pairing_code(code, "test_identity")
+        self.assertIsNotNone(issued)
+        result = mgr.validate_session_token(issued["token"])
         self.assertIsNotNone(result)
-        entry = mgr.session_tokens[token]
+        entry = mgr.session_tokens[issued["token_id"]]
         now = time.time()
         self.assertAlmostEqual(entry["expires_at"], now + 14400, delta=2)
         self.assertAlmostEqual(entry["absolute_expires_at"], now + 172800, delta=2)


### PR DESCRIPTION
## Summary

Per-device session tokens. Previously `session_tokens` was keyed by the raw
plaintext token string, and every device that identity paired from shared the
one token in the file. Revoking a lost phone meant deleting every session for
that user — there was no way to sign out one device.

- `session_tokens` keyed by `token_id` (uuid4). Only a SHA-256 hash of the raw
  token is persisted; the raw token is handed to the client exactly once, at
  pairing/refresh, and never stored.
- Legacy plaintext-keyed `sessions.json` migrates transparently on load and
  is rewritten in the new format on first write.
- Each token records `device_name`/`platform` (sent by iOS/macOS at pairing)
  plus `created_at`/`last_used`/`expires_at`, for a device-management UI.
- New endpoints: `GET /api/v1/auth/devices` (list caller's own devices),
  `DELETE /api/v1/auth/devices/{token_id}` (revoke one — ownership enforced
  server-side; not-found and not-yours are indistinguishable), `POST
  /api/v1/auth/devices/revoke-all`.
- `POST /api/v1/auth/refresh`: explicit sliding-window refresh for a client
  that wants to extend its session proactively (e.g. on app foreground)
  without an unrelated API call.
- iOS `AuthStore`/`APIClient`/`Models` updated for the new pairing response
  shape (`token` + `token_id`) and device metadata.

**Backward compatible.** `device_name`/`platform` are optional request
fields, and `token_id` is an additive response field — the macOS client
(which doesn't send/read either) needs no changes; `Codable` ignores
unrecognized JSON keys by default.

## Branch history note

This was originally built on a branch 34 commits behind `main` (found as
uncommitted, stashed work). I committed it there first, then created this
branch fresh off current `main` and cherry-picked it over — `git cherry-pick`
uses a real 3-way merge, so the only conflict was two lines both fixing the
same already-landed `NameError` bug from a different angle; trivial to
resolve in favor of `main`'s version. A second commit fixes an iOS test
double that still had the pre-change `verifyPairing` signature.

## Testing

`tests/test_device_tokens.py`, `test_api_auth.py`,
`test_issue_376_configurable_ttls.py` (updated for the new
`verify_pairing_code` return shape): 63/64 pass. The one failure
(`test_issue_28_timing_safe_key`) is pre-existing on unmodified `main` and
in an unrelated method (`validate_shared_key`, the shared API key path, not
per-device tokens) — confirmed via a clean worktree of `main`.

iOS: the full `Sources/` module (all 19 files) compiles cleanly against the
iOS 17 SDK, including the changed `Models.swift`/`APIClient.swift`/
`AuthStore.swift`. I could not get a full `xcodebuild test` run working for
this starter-kit client — it has no `schemes:` block or CI config, and
generating one from scratch hit unrelated Xcode test-host/Info.plist wiring
issues; this is pre-existing tooling gap, not something this PR touches.
Manually reviewed the test double fix against the new protocol signature.
