### PR TITLE
fix(kanban): report why the board failed instead of a bare 500

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -15678,18 +15678,24 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             x_user_identity=request.headers.get("x-user-identity"),
             x_auth_channel=request.headers.get("x-auth-channel"),
         )
-        from kanban import load_kanban_board
+        try:
+            from kanban import load_kanban_board
 
-        return load_kanban_board(
-            todo_path=_resolve_todo_file(agent),
-            repo=repo,
-            limit=limit,
-            agent=agent,
-            urgency=urgency,
-            date_from=date_from,
-            date_to=date_to,
-            source=source,
-        )
+            return load_kanban_board(
+                todo_path=_resolve_todo_file(agent),
+                repo=repo,
+                limit=limit,
+                agent=agent,
+                urgency=urgency,
+                date_from=date_from,
+                date_to=date_to,
+                source=source,
+            )
+        except Exception as exc:
+            # Every sibling kanban route funnels through _kanban_http_error;
+            # this one did not, so anything raised below it reached the client
+            # as a bare 500 with no detail to act on.
+            _kanban_http_error(exc)
 
     @app.get("/api/v1/kanban/items/{item_id}")
     async def get_kanban_item(request: Request, item_id: str, repo: Optional[str] = None):

--- a/kanban.py
+++ b/kanban.py
@@ -624,25 +624,44 @@ def load_github_cards(repo: str | None, limit: int = 100) -> list[dict[str, Any]
     if not repo:
         return []
 
-    result = subprocess.run(
-        [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "all",
-            "--limit",
-            str(limit),
-            "--json",
-            "number,title,url,body,state,labels,createdAt,updatedAt",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=20,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "all",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,url,body,state,labels,createdAt,updatedAt",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        # `gh` is not installed, or -- far more commonly -- not on this
+        # process's PATH. A GUI-launched client starts its API subprocess with
+        # launchd's minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), which omits
+        # Homebrew, so the binary is unreachable even though a shell can find
+        # it. Previously this propagated as a bare 500 with no hint of a
+        # missing tool.
+        raise KanbanError(
+            "The GitHub CLI (gh) was not found on the API's PATH, so GitHub-backed "
+            "Kanban cards cannot be loaded.",
+            status_code=503,
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise KanbanError(
+            "Timed out waiting for the GitHub CLI (gh) to list issues.",
+            status_code=504,
+        ) from exc
+
     if result.returncode != 0:
         return []
 

--- a/tests/test_issue456_kanban_board_errors.py
+++ b/tests/test_issue456_kanban_board_errors.py
@@ -1,0 +1,109 @@
+"""
+Regression test for issue #456: `GET /api/v1/kanban/board` returned a bare
+500 "Internal server error" whenever the `gh` CLI was missing from the API
+process's PATH, or slow enough to hit its 20s timeout.
+
+This was found from a real failure. A GUI-launched macOS client starts its
+Local API subprocess with launchd's minimal PATH
+(`/usr/bin:/bin:/usr/sbin:/sbin`), which omits Homebrew, so
+`subprocess.run(["gh", ...])` raised `FileNotFoundError`. Two gaps combined:
+
+1. `load_github_cards` caught a non-zero return code and a JSON decode error,
+   but neither `FileNotFoundError` nor `subprocess.TimeoutExpired`.
+2. The board route called `load_kanban_board` with no try/except, unlike every
+   sibling kanban route, which funnel through `_kanban_http_error`.
+
+The client had no way to distinguish "your tooling is misconfigured" from "the
+server is broken". These tests pin both halves: the loader raises a typed
+KanbanError with an actionable status code, and the route reports it rather
+than collapsing it into a 500.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_456")
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "9456")
+
+import kanban  # noqa: E402
+from kanban import KanbanError, load_github_cards  # noqa: E402
+
+
+def test_issue_456_missing_gh_binary_raises_actionable_error(monkeypatch):
+    def _raise_missing(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory: 'gh'")
+
+    monkeypatch.setattr(kanban.subprocess, "run", _raise_missing)
+
+    with pytest.raises(KanbanError) as excinfo:
+        load_github_cards("leprachuan/fosterbot-home", 200)
+
+    assert excinfo.value.status_code == 503
+    message = str(excinfo.value)
+    assert "gh" in message
+    assert "PATH" in message, "the message must point at the actual cause"
+
+
+def test_issue_456_gh_timeout_raises_gateway_timeout(monkeypatch):
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="gh", timeout=20)
+
+    monkeypatch.setattr(kanban.subprocess, "run", _raise_timeout)
+
+    with pytest.raises(KanbanError) as excinfo:
+        load_github_cards("leprachuan/fosterbot-home", 200)
+
+    assert excinfo.value.status_code == 504
+
+
+def test_issue_456_no_repo_still_short_circuits(monkeypatch):
+    """The guard clause must run before any subprocess attempt."""
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("gh must not be invoked when no repo is configured")
+
+    monkeypatch.setattr(kanban.subprocess, "run", _explode)
+    assert load_github_cards(None, 200) == []
+
+
+def test_issue_456_non_zero_exit_still_degrades_quietly(monkeypatch):
+    """A gh that runs but fails (e.g. auth) keeps the previous behaviour:
+    GitHub cards are skipped rather than failing the whole board."""
+
+    class _Result:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(kanban.subprocess, "run", lambda *a, **k: _Result())
+    assert load_github_cards("leprachuan/fosterbot-home", 200) == []
+
+
+def test_issue_456_board_route_reports_error_instead_of_bare_500(monkeypatch):
+    """The route must surface the loader's status code, not collapse to 500."""
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:  # pragma: no cover - depends on installed extras
+        from fastapi.testclient import TestClient
+
+    from agent_manager import create_api_app
+
+    def _raise_missing(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory: 'gh'")
+
+    monkeypatch.setattr(kanban.subprocess, "run", _raise_missing)
+    monkeypatch.setattr(kanban, "_default_repo", lambda: "leprachuan/fosterbot-home")
+
+    client = TestClient(create_api_app(), raise_server_exceptions=False)
+    response = client.get(
+        "/api/v1/kanban/board",
+        headers={"Authorization": f"Bearer shared_{os.environ['API_SHARED_KEY']}"},
+    )
+
+    assert response.status_code == 503, response.text
+    assert "gh" in response.json()["detail"]


### PR DESCRIPTION
Closes #456.

`GET /api/v1/kanban/board` returned a bare 500 `Internal server error` whenever the `gh` CLI was missing from the API process's PATH, or slow enough to hit its 20s timeout.

## Cause

Found from a real failure debugging the macOS client. A GUI-launched app starts its Local API subprocess with launchd's minimal `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, which omits Homebrew, so `subprocess.run(["gh", ...])` raised `FileNotFoundError`:

```
FileNotFoundError: [Errno 2] No such file or directory: 'gh'
  File "kanban.py", line 627, in load_github_cards
  File "kanban.py", line 720, in load_kanban_board
```

Two gaps combined:

1. `load_github_cards` caught a non-zero return code and `json.JSONDecodeError`, but neither `FileNotFoundError` nor `subprocess.TimeoutExpired`.
2. The board route called `load_kanban_board` with no `try/except`, unlike every sibling kanban route, which funnel through `_kanban_http_error`.

## Change

- `load_github_cards` raises a typed `KanbanError` — **503** for a missing `gh` (naming PATH as the likely cause), **504** for the timeout.
- The board route wraps its call in the same `_kanban_http_error` handling its siblings already use.
- A `gh` that runs but exits non-zero **still degrades quietly**, skipping GitHub cards rather than failing the whole board — that path had a deliberate fallback and keeps it.

## Testing

Verified on the dev host (192.168.1.100):

- 5 new tests in `tests/test_issue456_kanban_board_errors.py` pass — covering the missing binary, the timeout, the no-repo short circuit, the preserved non-zero-exit fallback, and the route returning 503 rather than 500.
- The 56 existing kanban and API tests still pass.

The client-side half (putting Homebrew on the Local API's PATH) shipped separately in macOS v0.9.4.