### PR TITLE
fix(wee): register bash/python tools for BYOK providers

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9623,7 +9623,10 @@ User Request:
                 model=route.qualified_model,
                 channel=channel,
             )
-            context_prompt = self._wee_augment_system_prompt_with_tools(context_prompt)
+            context_prompt = self._wee_augment_system_prompt_with_tools(
+                context_prompt,
+                native_tools_registered=self._wee_provider_needs_native_tools(route.provider),
+            )
             context_prompt += _wee_anti_hallucination_prompt()
             stream_buffer = getattr(self, "_stream_buffers", {}).get(n8n_session_id)
             sdk_tool_ids: Dict[str, str] = {}
@@ -9737,6 +9740,76 @@ User Request:
                 handler=browser_handler,
             )
 
+            # Issue #453: #443 stopped redeclaring shell/file tools on the theory
+            # that "the Copilot SDK session already knows about and describes its
+            # own built-in tools". That holds for Copilot-native models but not
+            # for a BYOK route: on Ollama the registered set really is just
+            # search/call_agent/browser, so the model has no way to run a command
+            # or touch a file. It improvises instead -- markdown code fences,
+            # pseudo-XML, invented function names -- and the turn ends with
+            # nothing having run. Register real bash/python tools whenever the
+            # provider is not Copilot-native.
+            native_tools: list = []
+            if self._wee_provider_needs_native_tools(route.provider):
+
+                async def bash_handler(invocation):
+                    return self._wee_execute_tool(
+                        "bash",
+                        dict(invocation.arguments or {}),
+                        agent,
+                        n8n_session_id,
+                    )
+
+                async def python_handler(invocation):
+                    return self._wee_execute_tool(
+                        "python",
+                        dict(invocation.arguments or {}),
+                        agent,
+                        n8n_session_id,
+                    )
+
+                native_tools = [
+                    Tool(
+                        name="bash",
+                        description=(
+                            "Execute a bash shell command on this machine and return its "
+                            "output. Use this to read or write files, inspect the system, "
+                            "and run commands. For delegating whole tasks to another Wee "
+                            "agent, use call_agent instead."
+                        ),
+                        parameters={
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "string",
+                                    "description": "The bash command to execute",
+                                }
+                            },
+                            "required": ["command"],
+                        },
+                        handler=bash_handler,
+                    ),
+                    Tool(
+                        name="python",
+                        description=(
+                            "Execute Python 3 code on this machine and return its stdout. "
+                            "Use this for computation and data handling. For delegating "
+                            "whole tasks to another Wee agent, use call_agent instead."
+                        ),
+                        parameters={
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "string",
+                                    "description": "The Python code to execute",
+                                }
+                            },
+                            "required": ["code"],
+                        },
+                        handler=python_handler,
+                    ),
+                ]
+
             # Issue #398: track whether the model actually invoked anything, so a
             # turn that only *promised* to act can be detected afterwards. The
             # counter must be updated even when nothing is streaming, so it sits
@@ -9775,7 +9848,7 @@ User Request:
                 timeout=float(effective_timeout),
                 session_id=saved_sdk_session,
                 resume=bool(resume and saved_sdk_session),
-                tools=[search_tool, call_agent_tool, browser_tool],
+                tools=[search_tool, call_agent_tool, browser_tool] + native_tools,
                 enable_tools=True,
                 event_callback=on_sdk_event,
             )
@@ -9999,7 +10072,18 @@ User Request:
                 session_map[n8n_session_id]["wee_messages"] = clean
                 self.save_session_map(session_map)
 
-    def _wee_augment_system_prompt_with_tools(self, system_prompt: str) -> str:
+    # Providers whose sessions genuinely ship built-in shell/file/python tools.
+    # Everything else is a BYOK OpenAI-compatible route where the registered
+    # tool list is the complete set (issue #453).
+    _WEE_COPILOT_NATIVE_PROVIDERS = frozenset({"copilot", "github", "githubcopilot"})
+
+    @classmethod
+    def _wee_provider_needs_native_tools(cls, provider: str) -> bool:
+        return (provider or "").strip().lower() not in cls._WEE_COPILOT_NATIVE_PROVIDERS
+
+    def _wee_augment_system_prompt_with_tools(
+        self, system_prompt: str, native_tools_registered: bool = False
+    ) -> str:
         """Issue #111 / #443 / #397: Describe only the custom tools wee registers
         on top of the Copilot SDK session (search, call_agent, browser).
 
@@ -10030,6 +10114,23 @@ User Request:
             "2. For delegating work to other agents: use call_agent\n"
             "3. NEVER refuse or claim you lack capability. Your tools are active and functional."
         )
+        if native_tools_registered:
+            # Only described when actually registered, so the prompt can never
+            # advertise a tool that is not wired to anything -- the drift #443
+            # was guarding against.
+            tool_section += (
+                "\n\n**bash** -- Run a shell command on this machine and get its output.\n"
+                '  Call: bash tool with {"command": "ls -la /tmp"}\n'
+                "  Use for: reading and writing files, inspecting the system, running commands.\n"
+                "\n"
+                "**python** -- Run Python 3 code and get its stdout.\n"
+                '  Call: python tool with {"code": "print(6 * 7)"}\n'
+                "  Use for: computation and data handling.\n"
+                "\n"
+                "4. To run a command or touch a file, CALL the bash or python tool. "
+                "Do NOT write the command in a markdown code block, in XML tags, or as "
+                "prose describing what you would run -- none of those execute."
+            )
         return system_prompt + tool_section
 
 
@@ -10496,7 +10597,17 @@ User Request:
         (issue #397).
         """
         try:
-            if func_name == "search":
+            if func_name == "bash":
+                # Issue #453: only registered for non-Copilot-native providers,
+                # which have no built-in shell tool of their own.
+                from wee_runtime import execute_bash
+
+                return execute_bash(func_args)
+            elif func_name == "python":
+                from wee_runtime import execute_python
+
+                return execute_python(func_args)
+            elif func_name == "search":
                 # Issue #397: the Copilot SDK ships web_fetch (retrieve a known
                 # URL) but no web *search*, so a local agent had no way to
                 # discover pages for a query. _execute_search survived #443 —

--- a/tests/test_issue453_byok_native_tools.py
+++ b/tests/test_issue453_byok_native_tools.py
@@ -1,0 +1,106 @@
+"""
+Regression test for issue #453: on the `wee` runtime with a local Ollama model,
+only the custom-registered tools (search, call_agent, browser) executed. The
+Copilot SDK's built-in shell/file/python tools are not present on a BYOK route,
+so the model had no way to run a command or touch a file. It improvised --
+markdown code fences, pseudo-XML, invented function names -- and the turn ended
+with nothing having run.
+
+#443 stopped redeclaring shell/file tools on the reasoning that "the Copilot SDK
+session already knows about and describes its own built-in tools". That holds
+for Copilot-native models but not for BYOK providers, where the registered tool
+list is the complete set.
+
+These tests pin the provider gate, the executors, and the prompt text. They do
+NOT cover the end-to-end model behaviour: that needs a live Ollama model, and
+per the issue a single probe turn runs 100-280s and routinely hits the SDK's
+260s idle timeout on that hardware.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_453")
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "9453")
+
+import pytest  # noqa: E402
+
+from wee_runtime import execute_bash, execute_python, sanitize_bash_command  # noqa: E402
+
+
+def _manager_class():
+    import agent_manager
+
+    for name in dir(agent_manager):
+        obj = getattr(agent_manager, name)
+        if isinstance(obj, type) and hasattr(obj, "_wee_provider_needs_native_tools"):
+            return obj
+    raise AssertionError("No class exposing _wee_provider_needs_native_tools")
+
+
+@pytest.mark.parametrize("provider", ["ollama", "lmstudio", "openrouter", "custom", ""])
+def test_issue_453_byok_providers_get_native_tools(provider):
+    manager = _manager_class()
+    assert manager._wee_provider_needs_native_tools(provider) is True
+
+
+@pytest.mark.parametrize("provider", ["copilot", "Copilot", "GITHUB", "githubcopilot"])
+def test_issue_453_copilot_native_providers_do_not_redeclare_tools(provider):
+    """#443's reasoning still applies where it was actually true."""
+    manager = _manager_class()
+    assert manager._wee_provider_needs_native_tools(provider) is False
+
+
+def test_issue_453_bash_tool_actually_runs_a_command():
+    output = execute_bash({"command": "echo WEE-453-OK"})
+    assert output == "WEE-453-OK"
+
+
+def test_issue_453_bash_reports_failure_output():
+    output = execute_bash({"command": "ls /definitely/not/here/453"})
+    assert "STDERR" in output
+
+
+def test_issue_453_bash_rejects_empty_command():
+    assert execute_bash({}).startswith("Error")
+
+
+def test_issue_453_python_tool_actually_evaluates_code():
+    output = execute_python({"code": "print(7919 * 104729)"})
+    assert output == str(7919 * 104729)
+
+
+def test_issue_453_python_rejects_empty_code():
+    assert execute_python({}).startswith("Error")
+
+
+def test_issue_453_ssh_commands_keep_host_key_protection():
+    """Preserved from #111: accept-new still rejects CHANGED keys."""
+    sanitized = sanitize_bash_command("ssh root@192.168.1.100 'uptime'")
+    assert "StrictHostKeyChecking=accept-new" in sanitized
+
+    already_set = "ssh -o StrictHostKeyChecking=no host 'uptime'"
+    assert sanitize_bash_command(already_set) == already_set
+
+
+def test_issue_453_prompt_describes_bash_and_python_only_when_registered():
+    manager = _manager_class()
+    instance = manager.__new__(manager)
+
+    byok = manager._wee_augment_system_prompt_with_tools(
+        instance, "BASE", native_tools_registered=True
+    )
+    assert "**bash**" in byok
+    assert "**python**" in byok
+    # The failure mode was the model emitting a fenced command instead of
+    # calling a tool, so the prompt must say that explicitly.
+    assert "markdown code block" in byok
+
+    native = manager._wee_augment_system_prompt_with_tools(
+        instance, "BASE", native_tools_registered=False
+    )
+    assert "**bash**" not in native
+    assert "**search**" in native, "custom tools are still described either way"

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -514,6 +514,77 @@ def _execute_brave_search(
     return _format_search_results(query, results, output_format)
 
 
+_SSH_BIN_RE = re.compile(r"\b(ssh|scp|sftp)\b")
+
+# Matches the SDK's own tool budget closely enough that a slow command fails
+# with a tool error rather than stalling the whole turn.
+WEE_BYOK_TOOL_TIMEOUT = int(os.environ.get("WEE_TOOL_TIMEOUT", "120"))
+
+
+def sanitize_bash_command(command: str) -> str:
+    """Auto-inject SSH flags to prevent host key verification failures.
+
+    Injects ``-o StrictHostKeyChecking=accept-new`` after ssh/scp/sftp when the
+    flag is not already present. ``accept-new`` is preferred over ``no``
+    because it still rejects CHANGED keys (potential MITM).
+    """
+    if not command or not _SSH_BIN_RE.search(command):
+        return command
+    if "StrictHostKeyChecking" in command:
+        return command
+
+    def _inject(match):
+        return match.group(0) + " -o StrictHostKeyChecking=accept-new"
+
+    return _SSH_BIN_RE.sub(_inject, command, count=0)
+
+
+def _format_process_result(result: "subprocess.CompletedProcess[str]") -> str:
+    output = result.stdout or ""
+    if result.returncode != 0 and result.stderr:
+        output += f"\nSTDERR: {result.stderr}"
+    return output.strip() or "(no output)"
+
+
+def execute_bash(func_args: dict) -> str:
+    """Run a bash command for BYOK providers that have no built-in shell tool."""
+    command = (func_args or {}).get("command", "")
+    if not command:
+        return "Error: No command provided"
+    command = sanitize_bash_command(command)
+    try:
+        result = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            timeout=WEE_BYOK_TOOL_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return f"Error: bash timed out after {WEE_BYOK_TOOL_TIMEOUT}s"
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"Error executing bash: {exc}"
+    return _format_process_result(result)
+
+
+def execute_python(func_args: dict) -> str:
+    """Run Python for BYOK providers that have no built-in python tool."""
+    code = (func_args or {}).get("code", "")
+    if not code:
+        return "Error: No code provided"
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=WEE_BYOK_TOOL_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return f"Error: python timed out after {WEE_BYOK_TOOL_TIMEOUT}s"
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"Error executing python: {exc}"
+    return _format_process_result(result)
+
+
 def _execute_search(func_args: dict) -> str:
     """Handle search tool calls via SearXNG (Issue #255).
 


### PR DESCRIPTION
Closes #453.

On the `wee` runtime with a local Ollama model, only the custom-registered tools (`search`, `call_agent`, `browser`) executed. The model had no way to run a command or touch a file, so it improvised — markdown code fences, pseudo-XML, invented function names — and the turn ended with nothing having run.

## Cause

#443 stopped redeclaring shell/file tools, reasoning that "the Copilot SDK session already knows about and describes its own built-in tools". That holds for Copilot-native models but **not** for a BYOK route: on Ollama, `tools=[search_tool, call_agent_tool, browser_tool]` is the complete set.

## Change

- Register real `bash` and `python` tools whenever the resolved provider is **not** Copilot-native, restoring executors #443 removed with the legacy loop.
- The system prompt describes them **only when actually registered**, so it can never advertise a tool that isn't wired to anything — the drift #443 was guarding against. It also states plainly that a fenced command does not execute, since emitting one was the observed failure.
- The #111 SSH host-key sanitizer returns alongside `bash` rather than being dropped.

**Scoped to bash and python.** Those cover the failing filesystem and compute probes (file work goes through the shell) and are self-contained; restoring `edit_file` would pull back a larger helper chain for no coverage the shell doesn't already provide.

## Testing

Run on the dev host (192.168.1.100):

- **16 new tests pass** — provider gate both ways (`ollama`/`lmstudio`/`openrouter`/`custom` get tools; `copilot`/`github` don't), both executors actually running a command and evaluating code, the SSH sanitizer, and the conditional prompt text.
- **No new failures.** Compared the wee/tool suites against the unmodified `dev` baseline: the 17 failures there are byte-identical before and after this branch, so they're pre-existing.

## Not covered

End-to-end behaviour against a live Ollama model. Per the issue, one probe turn runs 100–280s and routinely hits the SDK's 260s idle timeout on that hardware, so it needs a deliberate manual pass on dev before this reaches prod.

The issue's secondary findings (`num_ctx` defaults, context bleed, latency vs. the idle timeout) are untouched here and still stand on their own.