### PR TITLE
feat(browser): make the session browser reachable from every runtime

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -5671,6 +5671,100 @@ You can mention an agent in your prompt and it will auto-delegate:
         text = re.sub(r"<think>.*", "", text, flags=re.DOTALL)
         return text.strip()
 
+    # --- Session browser control for subprocess runtimes -------------------
+    #
+    # The `wee` runtime registers an in-process `browser` Tool. Subprocess
+    # runtimes cannot use it -- the broker's registrations live in the API
+    # process's memory -- so browser control was reachable from exactly one
+    # runtime. These helpers hand those runtimes the `wee-browser` MCP server
+    # instead, which reaches the same browser over HTTP.
+
+    WEE_BROWSER_MCP_NAME = "wee-browser"
+
+    def _wee_browser_mcp_env(self, n8n_session_id: str) -> Optional[Dict[str, str]]:
+        """Environment for the browser MCP server, or None when unavailable.
+
+        Returns None rather than a broken config when there is no shared key to
+        authenticate with: a server that cannot call the API would advertise
+        browser tools that always fail, which is worse than not offering them.
+        """
+        shared_key = os.environ.get("API_SHARED_KEY", "")
+        if not shared_key or not n8n_session_id:
+            return None
+
+        scheme = "https" if os.environ.get("SSL_CERTFILE") else "http"
+        port = os.environ.get("API_PORT", "8001")
+        session_data = self.get_or_create_session_data(n8n_session_id) or {}
+
+        env = {
+            "WEE_BROWSER_SESSION_ID": n8n_session_id,
+            "WEE_API_BASE": f"{scheme}://127.0.0.1:{port}",
+            "WEE_API_TOKEN": f"shared_{shared_key}",
+        }
+        # The API only trusts these headers from loopback, which is where this
+        # server runs; they carry the session's real owner so the ownership
+        # check passes for the right user rather than the shared-key identity.
+        if identity := session_data.get("identity"):
+            env["WEE_API_IDENTITY"] = str(identity)
+        if channel := session_data.get("channel"):
+            env["WEE_API_CHANNEL"] = str(channel)
+        if scheme == "https":
+            # Prod terminates TLS with a self-signed cert; this is a loopback
+            # call to ourselves, so trusting it adds no exposure.
+            env["WEE_API_INSECURE_TLS"] = "1"
+        return env
+
+    def _wee_browser_mcp_server_spec(self, n8n_session_id: str) -> Optional[dict]:
+        """The `wee-browser` MCP server as command/args/env, or None."""
+        env = self._wee_browser_mcp_env(n8n_session_id)
+        if env is None:
+            return None
+        return {
+            "command": sys.executable or "python3",
+            "args": [os.path.join(SCRIPT_BASE_DIR, "wee_browser_mcp.py")],
+            "env": env,
+        }
+
+    def _wee_browser_mcp_config_file(self, n8n_session_id: str) -> Optional[str]:
+        """Write an `mcpServers` JSON config and return its path, or None.
+
+        Used by CLIs that take a config file (claude's --mcp-config). Written
+        per session under the session state directory so concurrent sessions
+        never share one file and point at each other's browsers.
+        """
+        spec = self._wee_browser_mcp_server_spec(n8n_session_id)
+        if spec is None:
+            return None
+        try:
+            directory = os.path.join(SCRIPT_BASE_DIR, ".mcp-configs")
+            os.makedirs(directory, exist_ok=True)
+            path = os.path.join(directory, f"browser-{n8n_session_id}.json")
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump({"mcpServers": {self.WEE_BROWSER_MCP_NAME: spec}}, handle)
+            return path
+        except OSError as exc:
+            print(f"[Browser] Could not write MCP config: {exc}", file=sys.stderr)
+            return None
+
+    def _wee_browser_codex_config_args(self, n8n_session_id: str) -> list:
+        """`-c` overrides registering the browser MCP server with codex."""
+        spec = self._wee_browser_mcp_server_spec(n8n_session_id)
+        if spec is None:
+            return []
+        prefix = f"mcp_servers.{self.WEE_BROWSER_MCP_NAME}"
+        args = [
+            "-c",
+            f"{prefix}.command={json.dumps(spec['command'])}",
+            "-c",
+            f"{prefix}.args={json.dumps(spec['args'])}",
+        ]
+        for key, value in spec["env"].items():
+            # Codex parses the value as TOML, so each entry is quoted
+            # individually rather than passing one inline table -- a token
+            # containing '=' or '#' would otherwise break the parse.
+            args += ["-c", f"{prefix}.env.{key}={json.dumps(value)}"]
+        return args
+
     def _parse_mode_command(self, prompt: str) -> tuple[str, str]:
         """Parse /mode command from prompt. Returns (cleaned_prompt, mode).
 
@@ -8984,6 +9078,11 @@ User Request:
             "--verbose",
         ]
 
+        if browser_mcp_config := self._wee_browser_mcp_config_file(n8n_session_id):
+            # Additive: no --strict-mcp-config, so the agent's own MCP servers
+            # keep working alongside this one.
+            cmd.extend(["--mcp-config", browser_mcp_config])
+
         if resume and session_id:
             cmd.append(f"--resume={session_id}")
             print(f"[Session] Resuming Claude session: {session_id}", file=sys.stderr)
@@ -9283,6 +9382,7 @@ User Request:
                 cmd += ["-c", "shell_environment_policy.inherit=all"]
             if model:
                 cmd += ["-m", model]
+            cmd += self._wee_browser_codex_config_args(n8n_session_id)
             cmd += [session_id, context_prompt]
             print(
                 f"[Session] Resuming CODEX session: {session_id} with model {model} in {mode} mode",
@@ -9302,6 +9402,7 @@ User Request:
                 cmd.append("--full-auto")
             if model:
                 cmd += ["-m", model]
+            cmd += self._wee_browser_codex_config_args(n8n_session_id)
             cmd.append(context_prompt)
             print(
                 f"[Session] Starting new CODEX session with model {model} in {mode} mode",
@@ -12312,6 +12413,62 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc)) from exc
         return {"accepted": True}
+
+    @app.post("/api/v1/browser/sessions/{session_id}/execute")
+    async def execute_native_browser_command(session_id: str, request: Request):
+        """Drive this session's browser from outside the API process.
+
+        The `wee` runtime calls `execute_browser_command` in-process, which the
+        subprocess runtimes (codex, claude, gemini, ...) cannot do -- the
+        broker's registrations live in this process's memory. Without an HTTP
+        seam, browser control was reachable from exactly one runtime. The
+        `wee-browser` MCP server calls this endpoint on their behalf.
+        """
+        from browser_bridge import execute_browser_command
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_browser_session_owner(session_id, user)
+
+        try:
+            body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+
+        action = str(body.get("action") or "").strip()
+        if not action:
+            raise HTTPException(status_code=400, detail="'action' is required")
+
+        command = {k: v for k, v in body.items() if k != "timeout" and v is not None}
+        raw_timeout = body.get("timeout")
+        try:
+            timeout = float(raw_timeout) if raw_timeout is not None else 45.0
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="'timeout' must be a number")
+
+        loop = asyncio.get_running_loop()
+        try:
+            # execute_browser_command blocks waiting on the browser client, so
+            # keep it off the event loop -- otherwise one slow page would stall
+            # every other request this API is serving.
+            output = await loop.run_in_executor(
+                None, lambda: execute_browser_command(session_id, command, timeout=timeout)
+            )
+        except RuntimeError as exc:
+            # Raised when no browser client is attached to this session.
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except TimeoutError as exc:
+            raise HTTPException(status_code=504, detail=str(exc)) from exc
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"Browser command failed: {exc}") from exc
+
+        return {"result": output}
 
     @app.get("/api/v1/service-status")
     async def get_service_status():

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -8225,6 +8225,12 @@ User Request:
             f"@{mcp_config_path}",
         ]
 
+        # Issue: browser control was wee-runtime only. --additional-mcp-config
+        # may be repeated, so this augments the agent's own MCP servers rather
+        # than replacing them.
+        if _browser_mcp := self._wee_browser_mcp_config_file(n8n_session_id):
+            cmd += ["--additional-mcp-config", f"@{_browser_mcp}"]
+
         # Add elevated flags for full access
         if mode == "elevated":
             cmd.insert(2, "--allow-all-paths")
@@ -8344,6 +8350,11 @@ User Request:
                 f"@{mcp_config_path}",
                 f"--name={_recovery_copilot_name}",
             ]
+            # The recovery path builds its own command, so it needs the browser
+            # server too -- otherwise a session that recovers silently loses
+            # browser control for the rest of its life.
+            if _recovery_browser_mcp := self._wee_browser_mcp_config_file(n8n_session_id):
+                _recovery_cmd += ["--additional-mcp-config", f"@{_recovery_browser_mcp}"]
             if mode == "elevated":
                 _recovery_cmd.insert(2, "--allow-all-paths")
                 _recovery_cmd.append("--yolo")

--- a/tests/test_browser_all_runtimes.py
+++ b/tests/test_browser_all_runtimes.py
@@ -1,0 +1,324 @@
+"""
+Browser control for every runtime, not just `wee`.
+
+The `wee` runtime registers an in-process `browser` Tool and calls
+`browser_bridge.execute_browser_command` directly. Subprocess runtimes (codex,
+claude, gemini, opencode, cursor) cannot do that -- the broker's client
+registrations live in the API process's memory -- so a chat on any of those
+runtimes had a connected browser panel it could not reach. Observed as codex
+falling back to its own MCP browser integration and reporting "no available
+browser" while the Wee panel sat connected alongside it.
+
+Two pieces close that gap and are covered here:
+
+1. `POST /api/v1/browser/sessions/{id}/execute` -- an HTTP seam onto the same
+   broker the `wee` tool uses.
+2. `wee_browser_mcp.py` -- a stdio MCP server that calls that endpoint, handed
+   to each subprocess runtime through its own MCP config mechanism.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_browser")
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "9470")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MCP_SERVER = os.path.join(REPO_ROOT, "wee_browser_mcp.py")
+AUTH = {"Authorization": f"Bearer shared_{os.environ['API_SHARED_KEY']}"}
+
+
+# --------------------------------------------------------------------------
+# The MCP server: protocol shape, and behaviour when it cannot reach the API.
+# --------------------------------------------------------------------------
+
+
+def _mcp_exchange(messages, env=None):
+    """Run the MCP server over stdio and return its JSON responses."""
+    payload = "".join(json.dumps(m) + "\n" for m in messages)
+    process = subprocess.run(
+        [sys.executable, MCP_SERVER],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**os.environ, **(env or {})},
+    )
+    return [json.loads(line) for line in process.stdout.splitlines() if line.strip()]
+
+
+def test_mcp_server_completes_the_initialize_handshake():
+    responses = _mcp_exchange(
+        [{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}]
+    )
+    assert len(responses) == 1
+    result = responses[0]["result"]
+    assert result["serverInfo"]["name"] == "wee-browser"
+    assert "tools" in result["capabilities"]
+
+
+def test_mcp_server_advertises_the_browser_tools():
+    responses = _mcp_exchange([{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}])
+    names = {tool["name"] for tool in responses[0]["result"]["tools"]}
+    assert {"browser_navigate", "browser_snapshot", "browser_click", "browser_type"} <= names
+    for tool in responses[0]["result"]["tools"]:
+        assert tool["inputSchema"]["type"] == "object", tool["name"]
+
+
+def test_mcp_server_does_not_answer_notifications():
+    """A notification has no id; replying to one corrupts the stream."""
+    responses = _mcp_exchange([{"jsonrpc": "2.0", "method": "notifications/initialized"}])
+    assert responses == []
+
+
+def test_mcp_server_reports_missing_configuration_instead_of_crashing():
+    responses = _mcp_exchange(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "browser_snapshot", "arguments": {}},
+            }
+        ],
+        env={"WEE_BROWSER_SESSION_ID": "", "WEE_API_BASE": "", "WEE_API_TOKEN": ""},
+    )
+    text = responses[0]["result"]["content"][0]["text"]
+    assert "not configured" in text
+    assert "WEE_BROWSER_SESSION_ID" in text, "must name what is missing"
+
+
+def test_mcp_server_rejects_an_unknown_tool():
+    responses = _mcp_exchange(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "browser_launch_missiles", "arguments": {}},
+            }
+        ]
+    )
+    assert responses[0]["error"]["code"] == -32602
+
+
+# --------------------------------------------------------------------------
+# The HTTP seam, exercised against the real broker.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:  # pragma: no cover - depends on installed extras
+        from fastapi.testclient import TestClient
+
+    from agent_manager import create_api_app
+
+    return TestClient(create_api_app(), raise_server_exceptions=False)
+
+
+@pytest.fixture
+def session_id(client):
+    response = client.post(
+        "/api/v1/sessions/create", headers=AUTH, json={"agent": "orchestrator"}
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["session_id"]
+
+
+def test_execute_falls_back_to_playwright_without_a_native_panel(client, session_id):
+    """With no panel attached, browser_bridge routes to Playwright by design.
+
+    So this endpoint must not claim "no browser" -- it must report whatever
+    that path did. Either it worked (200) or it failed for a stated reason;
+    what it must never do is surface as an unhandled 500.
+    """
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute",
+        headers=AUTH,
+        json={"action": "snapshot"},
+    )
+    assert response.status_code in (200, 502, 504), response.text
+    if response.status_code != 200:
+        assert response.json()["detail"], "a failure must say why"
+
+
+def test_execute_maps_a_disconnected_browser_to_409(client, session_id, monkeypatch):
+    """When the bridge itself reports no browser, say so actionably.
+
+    Exercised directly because reaching it through the bridge requires
+    Playwright to also be unavailable.
+    """
+    import browser_bridge
+
+    def _no_browser(*args, **kwargs):
+        raise RuntimeError("No native browser is connected to this session")
+
+    monkeypatch.setattr(browser_bridge, "execute_browser_command", _no_browser)
+
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute",
+        headers=AUTH,
+        json={"action": "snapshot"},
+    )
+    assert response.status_code == 409, response.text
+    assert "no native browser" in response.json()["detail"].lower()
+
+
+def test_execute_requires_an_action(client, session_id):
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute", headers=AUTH, json={}
+    )
+    assert response.status_code == 400
+
+
+def test_execute_requires_authentication(client, session_id):
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute", json={"action": "snapshot"}
+    )
+    assert response.status_code == 401
+
+
+def test_execute_drives_an_attached_browser_client(client, session_id):
+    """Full round trip: register a browser client, then drive it over HTTP.
+
+    Stands in for the macOS WKWebView panel, which does exactly this -- register,
+    long-poll for commands, post results.
+    """
+    client_id = "test-browser-client"
+    registered = client.post(
+        f"/api/v1/browser/sessions/{session_id}/register",
+        headers=AUTH,
+        json={"client_id": client_id},
+    )
+    assert registered.status_code == 200, registered.text
+
+    delivered = {}
+
+    def fake_browser():
+        # Poll for the command the way the real panel does, then answer it.
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            polled = client.get(
+                f"/api/v1/browser/sessions/{session_id}/commands",
+                headers=AUTH,
+                params={"client_id": client_id, "timeout": 5},
+            )
+            command = (polled.json() or {}).get("command")
+            if not command:
+                continue
+            delivered["command"] = command
+            client.post(
+                f"/api/v1/browser/sessions/{session_id}/results",
+                headers=AUTH,
+                json={
+                    "client_id": client_id,
+                    "command_id": command["id"],
+                    "result": "PAGE TEXT FROM PANEL",
+                    "url": "https://example.invalid/page",
+                    "title": "Example",
+                },
+            )
+            return
+
+    worker = threading.Thread(target=fake_browser, daemon=True)
+    worker.start()
+
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute",
+        headers=AUTH,
+        json={"action": "navigate", "url": "https://example.invalid/page", "timeout": 30},
+    )
+    worker.join(timeout=35)
+
+    assert response.status_code == 200, response.text
+    assert delivered.get("command", {}).get("action") == "navigate"
+    assert "PAGE TEXT FROM PANEL" in response.json()["result"]
+
+
+# --------------------------------------------------------------------------
+# Per-runtime wiring: each CLI gets the server through its own mechanism.
+# --------------------------------------------------------------------------
+
+
+def _manager():
+    import agent_manager
+
+    for name in dir(agent_manager):
+        obj = getattr(agent_manager, name)
+        if isinstance(obj, type) and hasattr(obj, "_wee_browser_mcp_server_spec"):
+            return obj
+    raise AssertionError("No class exposing _wee_browser_mcp_server_spec")
+
+
+def test_codex_receives_the_browser_server_as_config_overrides(monkeypatch):
+    manager = _manager()
+    instance = manager.__new__(manager)
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda self, sid: {"identity": "u", "channel": "webui"}
+    )
+
+    args = manager._wee_browser_codex_config_args(instance, "sess-codex")
+    joined = " ".join(args)
+    assert "mcp_servers.wee-browser.command=" in joined
+    assert "wee_browser_mcp.py" in joined
+    assert "WEE_BROWSER_SESSION_ID" in joined and "sess-codex" in joined
+    # Codex parses each value as TOML; every value must be quoted so a token
+    # containing '=' or '#' cannot break the parse.
+    for index, token in enumerate(args):
+        if token == "-c":
+            assert '="' in args[index + 1] or "=[" in args[index + 1], args[index + 1]
+
+
+def test_claude_receives_the_browser_server_as_an_mcp_config_file(monkeypatch, tmp_path):
+    manager = _manager()
+    instance = manager.__new__(manager)
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda self, sid: {"identity": "u", "channel": "webui"}
+    )
+
+    path = manager._wee_browser_mcp_config_file(instance, "sess-claude")
+    assert path and os.path.exists(path)
+    with open(path) as handle:
+        config = json.load(handle)
+    server = config["mcpServers"]["wee-browser"]
+    assert server["args"][0].endswith("wee_browser_mcp.py")
+    assert server["env"]["WEE_BROWSER_SESSION_ID"] == "sess-claude"
+
+
+def test_each_session_gets_its_own_config_file(monkeypatch):
+    """Two chats must never be handed the same file and drive each other's browser."""
+    manager = _manager()
+    instance = manager.__new__(manager)
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda self, sid: {"identity": "u", "channel": "webui"}
+    )
+
+    first = manager._wee_browser_mcp_config_file(instance, "sess-a")
+    second = manager._wee_browser_mcp_config_file(instance, "sess-b")
+    assert first != second
+
+
+def test_no_browser_wiring_without_a_shared_key(monkeypatch):
+    """Better to offer no browser tools than tools that always fail."""
+    manager = _manager()
+    instance = manager.__new__(manager)
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda self, sid: {"identity": "u", "channel": "webui"}
+    )
+    monkeypatch.delenv("API_SHARED_KEY", raising=False)
+
+    assert manager._wee_browser_mcp_server_spec(instance, "sess") is None
+    assert manager._wee_browser_codex_config_args(instance, "sess") == []
+    assert manager._wee_browser_mcp_config_file(instance, "sess") is None

--- a/wee_browser_mcp.py
+++ b/wee_browser_mcp.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""stdio MCP server exposing one Wee chat session's browser to any runtime.
+
+The `wee` runtime drives the browser by calling `browser_bridge` in-process.
+The subprocess runtimes (codex, claude, gemini, opencode, cursor) cannot: the
+broker's client registrations live in the API process's memory. This server is
+the bridge -- it speaks MCP over stdio to whichever CLI launched it, and calls
+`POST /api/v1/browser/sessions/{id}/execute` on the API to do the work.
+
+Configuration is entirely by environment, because that is what every CLI's MCP
+config can set:
+
+    WEE_BROWSER_SESSION_ID  the chat session whose browser to drive (required)
+    WEE_API_BASE            e.g. http://127.0.0.1:8001 (required)
+    WEE_API_TOKEN           bearer token for that API (required)
+    WEE_API_IDENTITY        X-User-Identity, when the API expects one
+    WEE_API_CHANNEL         X-Auth-Channel, when the API expects one
+    WEE_API_INSECURE_TLS    "1" to skip TLS verification (self-signed prod cert)
+
+The JSON-RPC framing is hand-rolled rather than taken from the `mcp` package:
+that package is not in requirements.txt, and this server has to start reliably
+inside whatever interpreter a given CLI happens to spawn.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "wee-browser"
+SERVER_VERSION = "1.0.0"
+
+# Matches the API's own ceiling for a browser command so this layer never times
+# out first and reports a confusing error for a command still in flight.
+REQUEST_TIMEOUT = 95.0
+
+TOOLS = [
+    {
+        "name": "browser_navigate",
+        "description": (
+            "Navigate this chat session's browser to a URL and return the "
+            "resulting page text. Use this before reading or clicking."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"url": {"type": "string", "description": "Absolute URL to open"}},
+            "required": ["url"],
+        },
+    },
+    {
+        "name": "browser_snapshot",
+        "description": (
+            "Read the current page in this chat session's browser: its URL, "
+            "title, and visible text. Use this to see what is on screen."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "browser_click",
+        "description": "Click an element, found by CSS selector or by its visible text.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {"type": "string", "description": "CSS selector"},
+                "text": {"type": "string", "description": "Visible text to match instead"},
+            },
+        },
+    },
+    {
+        "name": "browser_type",
+        "description": "Type text into the element matching a CSS selector.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {"type": "string"},
+                "text": {"type": "string"},
+                "submit": {"type": "boolean", "description": "Press Enter afterwards"},
+            },
+            "required": ["selector", "text"],
+        },
+    },
+    {
+        "name": "browser_evaluate",
+        "description": "Evaluate JavaScript in the current page and return its result.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"script": {"type": "string"}},
+            "required": ["script"],
+        },
+    },
+    {
+        "name": "browser_back",
+        "description": "Go back one entry in this session's browser history.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "browser_forward",
+        "description": "Go forward one entry in this session's browser history.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "browser_reload",
+        "description": "Reload the current page.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+# MCP tool name -> the action understood by browser_bridge.
+_ACTIONS = {
+    "browser_navigate": "navigate",
+    "browser_snapshot": "snapshot",
+    "browser_click": "click",
+    "browser_type": "type",
+    "browser_evaluate": "evaluate",
+    "browser_back": "back",
+    "browser_forward": "forward",
+    "browser_reload": "reload",
+}
+
+
+def _env(name: str) -> str:
+    return (os.environ.get(name) or "").strip()
+
+
+def _ssl_context():
+    if _env("WEE_API_INSECURE_TLS") in {"1", "true", "yes"}:
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        return context
+    return None
+
+
+def _execute(action: str, arguments: dict) -> str:
+    """Send one browser command to the API and return a human-readable result."""
+    session_id = _env("WEE_BROWSER_SESSION_ID")
+    api_base = _env("WEE_API_BASE").rstrip("/")
+    token = _env("WEE_API_TOKEN")
+
+    missing = [
+        name
+        for name, value in (
+            ("WEE_BROWSER_SESSION_ID", session_id),
+            ("WEE_API_BASE", api_base),
+            ("WEE_API_TOKEN", token),
+        )
+        if not value
+    ]
+    if missing:
+        return f"Browser control is not configured for this session (missing {', '.join(missing)})."
+
+    payload = {"action": action, **{k: v for k, v in arguments.items() if v is not None}}
+    request = urllib.request.Request(
+        f"{api_base}/api/v1/browser/sessions/{session_id}/execute",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+    )
+    request.add_header("Content-Type", "application/json")
+    request.add_header("Authorization", f"Bearer {token}")
+    if identity := _env("WEE_API_IDENTITY"):
+        request.add_header("X-User-Identity", identity)
+    if channel := _env("WEE_API_CHANNEL"):
+        request.add_header("X-Auth-Channel", channel)
+
+    try:
+        with urllib.request.urlopen(
+            request, timeout=REQUEST_TIMEOUT, context=_ssl_context()
+        ) as response:
+            body = json.loads(response.read().decode("utf-8"))
+        return str(body.get("result", ""))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:600]
+        if exc.code == 409:
+            # The one failure worth explaining: the panel is not attached, and
+            # the user is the only one who can fix that.
+            return (
+                "No browser is attached to this chat session. Open the browser "
+                "panel for this chat in the Wee app, then try again. "
+                f"({detail})"
+            )
+        return f"Browser command failed (HTTP {exc.code}): {detail}"
+    except Exception as exc:
+        return f"Browser command failed: {exc}"
+
+
+def _respond(message_id, result=None, error=None) -> None:
+    payload = {"jsonrpc": "2.0", "id": message_id}
+    if error is not None:
+        payload["error"] = error
+    else:
+        payload["result"] = result
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _handle(message: dict) -> None:
+    method = message.get("method")
+    message_id = message.get("id")
+
+    # Notifications carry no id and must not be answered.
+    if message_id is None:
+        return
+
+    if method == "initialize":
+        _respond(
+            message_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        )
+    elif method == "tools/list":
+        _respond(message_id, {"tools": TOOLS})
+    elif method == "tools/call":
+        params = message.get("params") or {}
+        name = params.get("name") or ""
+        action = _ACTIONS.get(name)
+        if action is None:
+            _respond(message_id, error={"code": -32602, "message": f"Unknown tool: {name}"})
+            return
+        output = _execute(action, params.get("arguments") or {})
+        _respond(message_id, {"content": [{"type": "text", "text": output}]})
+    elif method in {"ping", "shutdown"}:
+        _respond(message_id, {})
+    else:
+        _respond(message_id, error={"code": -32601, "message": f"Unknown method: {method}"})
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            _handle(message)
+        except Exception as exc:  # pragma: no cover - defensive
+            # A crash here would take browser control down for the whole run,
+            # so report and keep serving.
+            _respond(message.get("id"), error={"code": -32603, "message": str(exc)})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The browser panel only ever worked on the **`wee`** runtime.

## Cause

`run_wee_native` registers an in-process `browser` Tool and calls `browser_bridge.execute_browser_command` directly. It is the only caller. No other runtime can do that — the broker's client registrations live in the **API process's memory**, so a subprocess runtime has nothing to reach.

Observed live: a chat on codex had a connected panel it could not use. Codex fell back to its own MCP browser integration, reported "no available browser", and asked the user to attach a Chrome extension — while the Wee panel sat registered and healthy alongside it.

## Change

**`POST /api/v1/browser/sessions/{id}/execute`** — an HTTP seam onto the same broker the `wee` tool uses, with the same ownership check as its sibling browser routes. The blocking bridge call runs in an executor so one slow page cannot stall the event loop for every other request this API serves.

**`wee_browser_mcp.py`** — a stdio MCP server exposing `navigate`, `snapshot`, `click`, `type`, `evaluate`, `back`, `forward`, `reload`, which calls that endpoint. JSON-RPC is hand-rolled rather than taken from the `mcp` package: that package is not in `requirements.txt`, and this has to start reliably inside whatever interpreter a given CLI spawns.

**Per-runtime wiring**, since every CLI does MCP differently:

| Runtime | Mechanism |
|---|---|
| `wee` | already worked (in-process Tool) |
| `codex` | `-c mcp_servers.wee-browser.*` config overrides |
| `claude` | `--mcp-config <file>`, additive — the agent's own MCP servers keep working |

Config is written **per session**, so two concurrent chats can never be handed the same file and drive each other's browser. Every codex value is JSON-quoted because codex parses each `-c` value as TOML — an unquoted token containing `=` or `#` would break the parse.

If there is no shared key to authenticate with, **no browser tools are offered at all**. A server that cannot call the API would advertise tools that always fail, which is worse than not having them.

## Testing

On the dev host (192.168.1.100): **14 tests pass**, covering the MCP handshake and tool schemas, notifications correctly going unanswered, unknown-tool rejection, the missing-config and disconnected-browser messages, auth and validation on the endpoint, per-session config isolation, and the no-shared-key case.

The important one is a **full round trip**: it registers a browser client, polls for the command, and answers it — the same protocol the macOS panel speaks — then asserts the result comes back through `/execute`.

The codex syntax was **verified against the real binary**, not assumed: `codex mcp list` with these overrides shows `wee-browser` enabled with the right command, args, and env.

No new failures against the `dev` baseline (2 pre-existing, identical before and after).

## Not included

`gemini`, `opencode`, `cursor`, and `devin` are not wired yet — each needs its own MCP mechanism, and those are best done with the CLI in front of you to verify the syntax the way codex's was here. The SDK runtimes (`copilot-sdk`, `claude-sdk`) could instead register a native tool the way `wee` does, which is simpler than MCP.

One behaviour worth knowing, unchanged here: when no panel is attached, `browser_bridge` falls back to headless Playwright. So an agent may browse invisibly rather than in the panel you are watching. That predates this PR, but it is more reachable now that every runtime can call it.