### PR TITLE
test(wee): make the prompt-augmenter stub signature-agnostic

### DIFF
--- a/tests/test_issue425_wee_copilot_byok.py
+++ b/tests/test_issue425_wee_copilot_byok.py
@@ -226,8 +226,11 @@ def test_api_wee_runtime_uses_shared_sdk_executor(monkeypatch):
     mgr._stream_buffers = {}
     mgr.get_or_create_session_data = MagicMock(return_value={"channel": "webui"})
     mgr.build_agent_context_prompt = MagicMock(return_value="context")
+    # Signature-agnostic: this test asserts the wee runtime uses the shared SDK
+    # executor, not the arity of the prompt augmenter. Pinning the exact
+    # signature made an unrelated change to that helper fail here.
     mgr._wee_augment_system_prompt_with_tools = MagicMock(
-        side_effect=lambda prompt: prompt
+        side_effect=lambda prompt, *args, **kwargs: prompt
     )
     mgr._wee_execute_tool = MagicMock(return_value="ok")
     mgr.update_session_field = MagicMock()


### PR DESCRIPTION
Follow-up to #467, caught by comparing the full suite on `dev` against `main` before promoting to prod.

`test_api_wee_runtime_uses_shared_sdk_executor` stubbed `_wee_augment_system_prompt_with_tools` with a single-arg lambda. #467 added a `native_tools_registered` keyword, so the stub raised `TypeError` and the assertion saw `Error: Wee Copilot SDK failed` instead of the SDK response.

The test asserts that the wee runtime routes through the shared SDK executor — not the arity of that helper — so the stub now accepts any signature and won't pin future changes to it.

Verified on the dev host: 12 passed. This was the only new failure `dev` had over `main`.