### PR TITLE
Release: kanban error reporting, BYOK tools, browser control for all runtimes

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -5671,6 +5671,100 @@ You can mention an agent in your prompt and it will auto-delegate:
         text = re.sub(r"<think>.*", "", text, flags=re.DOTALL)
         return text.strip()
 
+    # --- Session browser control for subprocess runtimes -------------------
+    #
+    # The `wee` runtime registers an in-process `browser` Tool. Subprocess
+    # runtimes cannot use it -- the broker's registrations live in the API
+    # process's memory -- so browser control was reachable from exactly one
+    # runtime. These helpers hand those runtimes the `wee-browser` MCP server
+    # instead, which reaches the same browser over HTTP.
+
+    WEE_BROWSER_MCP_NAME = "wee-browser"
+
+    def _wee_browser_mcp_env(self, n8n_session_id: str) -> Optional[Dict[str, str]]:
+        """Environment for the browser MCP server, or None when unavailable.
+
+        Returns None rather than a broken config when there is no shared key to
+        authenticate with: a server that cannot call the API would advertise
+        browser tools that always fail, which is worse than not offering them.
+        """
+        shared_key = os.environ.get("API_SHARED_KEY", "")
+        if not shared_key or not n8n_session_id:
+            return None
+
+        scheme = "https" if os.environ.get("SSL_CERTFILE") else "http"
+        port = os.environ.get("API_PORT", "8001")
+        session_data = self.get_or_create_session_data(n8n_session_id) or {}
+
+        env = {
+            "WEE_BROWSER_SESSION_ID": n8n_session_id,
+            "WEE_API_BASE": f"{scheme}://127.0.0.1:{port}",
+            "WEE_API_TOKEN": f"shared_{shared_key}",
+        }
+        # The API only trusts these headers from loopback, which is where this
+        # server runs; they carry the session's real owner so the ownership
+        # check passes for the right user rather than the shared-key identity.
+        if identity := session_data.get("identity"):
+            env["WEE_API_IDENTITY"] = str(identity)
+        if channel := session_data.get("channel"):
+            env["WEE_API_CHANNEL"] = str(channel)
+        if scheme == "https":
+            # Prod terminates TLS with a self-signed cert; this is a loopback
+            # call to ourselves, so trusting it adds no exposure.
+            env["WEE_API_INSECURE_TLS"] = "1"
+        return env
+
+    def _wee_browser_mcp_server_spec(self, n8n_session_id: str) -> Optional[dict]:
+        """The `wee-browser` MCP server as command/args/env, or None."""
+        env = self._wee_browser_mcp_env(n8n_session_id)
+        if env is None:
+            return None
+        return {
+            "command": sys.executable or "python3",
+            "args": [os.path.join(SCRIPT_BASE_DIR, "wee_browser_mcp.py")],
+            "env": env,
+        }
+
+    def _wee_browser_mcp_config_file(self, n8n_session_id: str) -> Optional[str]:
+        """Write an `mcpServers` JSON config and return its path, or None.
+
+        Used by CLIs that take a config file (claude's --mcp-config). Written
+        per session under the session state directory so concurrent sessions
+        never share one file and point at each other's browsers.
+        """
+        spec = self._wee_browser_mcp_server_spec(n8n_session_id)
+        if spec is None:
+            return None
+        try:
+            directory = os.path.join(SCRIPT_BASE_DIR, ".mcp-configs")
+            os.makedirs(directory, exist_ok=True)
+            path = os.path.join(directory, f"browser-{n8n_session_id}.json")
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump({"mcpServers": {self.WEE_BROWSER_MCP_NAME: spec}}, handle)
+            return path
+        except OSError as exc:
+            print(f"[Browser] Could not write MCP config: {exc}", file=sys.stderr)
+            return None
+
+    def _wee_browser_codex_config_args(self, n8n_session_id: str) -> list:
+        """`-c` overrides registering the browser MCP server with codex."""
+        spec = self._wee_browser_mcp_server_spec(n8n_session_id)
+        if spec is None:
+            return []
+        prefix = f"mcp_servers.{self.WEE_BROWSER_MCP_NAME}"
+        args = [
+            "-c",
+            f"{prefix}.command={json.dumps(spec['command'])}",
+            "-c",
+            f"{prefix}.args={json.dumps(spec['args'])}",
+        ]
+        for key, value in spec["env"].items():
+            # Codex parses the value as TOML, so each entry is quoted
+            # individually rather than passing one inline table -- a token
+            # containing '=' or '#' would otherwise break the parse.
+            args += ["-c", f"{prefix}.env.{key}={json.dumps(value)}"]
+        return args
+
     def _parse_mode_command(self, prompt: str) -> tuple[str, str]:
         """Parse /mode command from prompt. Returns (cleaned_prompt, mode).
 
@@ -8131,6 +8225,12 @@ User Request:
             f"@{mcp_config_path}",
         ]
 
+        # Issue: browser control was wee-runtime only. --additional-mcp-config
+        # may be repeated, so this augments the agent's own MCP servers rather
+        # than replacing them.
+        if _browser_mcp := self._wee_browser_mcp_config_file(n8n_session_id):
+            cmd += ["--additional-mcp-config", f"@{_browser_mcp}"]
+
         # Add elevated flags for full access
         if mode == "elevated":
             cmd.insert(2, "--allow-all-paths")
@@ -8250,6 +8350,11 @@ User Request:
                 f"@{mcp_config_path}",
                 f"--name={_recovery_copilot_name}",
             ]
+            # The recovery path builds its own command, so it needs the browser
+            # server too -- otherwise a session that recovers silently loses
+            # browser control for the rest of its life.
+            if _recovery_browser_mcp := self._wee_browser_mcp_config_file(n8n_session_id):
+                _recovery_cmd += ["--additional-mcp-config", f"@{_recovery_browser_mcp}"]
             if mode == "elevated":
                 _recovery_cmd.insert(2, "--allow-all-paths")
                 _recovery_cmd.append("--yolo")
@@ -8984,6 +9089,11 @@ User Request:
             "--verbose",
         ]
 
+        if browser_mcp_config := self._wee_browser_mcp_config_file(n8n_session_id):
+            # Additive: no --strict-mcp-config, so the agent's own MCP servers
+            # keep working alongside this one.
+            cmd.extend(["--mcp-config", browser_mcp_config])
+
         if resume and session_id:
             cmd.append(f"--resume={session_id}")
             print(f"[Session] Resuming Claude session: {session_id}", file=sys.stderr)
@@ -9283,6 +9393,7 @@ User Request:
                 cmd += ["-c", "shell_environment_policy.inherit=all"]
             if model:
                 cmd += ["-m", model]
+            cmd += self._wee_browser_codex_config_args(n8n_session_id)
             cmd += [session_id, context_prompt]
             print(
                 f"[Session] Resuming CODEX session: {session_id} with model {model} in {mode} mode",
@@ -9302,6 +9413,7 @@ User Request:
                 cmd.append("--full-auto")
             if model:
                 cmd += ["-m", model]
+            cmd += self._wee_browser_codex_config_args(n8n_session_id)
             cmd.append(context_prompt)
             print(
                 f"[Session] Starting new CODEX session with model {model} in {mode} mode",
@@ -12423,6 +12535,62 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
         except PermissionError as exc:
             raise HTTPException(status_code=403, detail=str(exc)) from exc
         return {"accepted": True}
+
+    @app.post("/api/v1/browser/sessions/{session_id}/execute")
+    async def execute_native_browser_command(session_id: str, request: Request):
+        """Drive this session's browser from outside the API process.
+
+        The `wee` runtime calls `execute_browser_command` in-process, which the
+        subprocess runtimes (codex, claude, gemini, ...) cannot do -- the
+        broker's registrations live in this process's memory. Without an HTTP
+        seam, browser control was reachable from exactly one runtime. The
+        `wee-browser` MCP server calls this endpoint on their behalf.
+        """
+        from browser_bridge import execute_browser_command
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_browser_session_owner(session_id, user)
+
+        try:
+            body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+
+        action = str(body.get("action") or "").strip()
+        if not action:
+            raise HTTPException(status_code=400, detail="'action' is required")
+
+        command = {k: v for k, v in body.items() if k != "timeout" and v is not None}
+        raw_timeout = body.get("timeout")
+        try:
+            timeout = float(raw_timeout) if raw_timeout is not None else 45.0
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="'timeout' must be a number")
+
+        loop = asyncio.get_running_loop()
+        try:
+            # execute_browser_command blocks waiting on the browser client, so
+            # keep it off the event loop -- otherwise one slow page would stall
+            # every other request this API is serving.
+            output = await loop.run_in_executor(
+                None, lambda: execute_browser_command(session_id, command, timeout=timeout)
+            )
+        except RuntimeError as exc:
+            # Raised when no browser client is attached to this session.
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except TimeoutError as exc:
+            raise HTTPException(status_code=504, detail=str(exc)) from exc
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"Browser command failed: {exc}") from exc
+
+        return {"result": output}
 
     @app.get("/api/v1/service-status")
     async def get_service_status():

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -9623,7 +9623,10 @@ User Request:
                 model=route.qualified_model,
                 channel=channel,
             )
-            context_prompt = self._wee_augment_system_prompt_with_tools(context_prompt)
+            context_prompt = self._wee_augment_system_prompt_with_tools(
+                context_prompt,
+                native_tools_registered=self._wee_provider_needs_native_tools(route.provider),
+            )
             context_prompt += _wee_anti_hallucination_prompt()
             stream_buffer = getattr(self, "_stream_buffers", {}).get(n8n_session_id)
             sdk_tool_ids: Dict[str, str] = {}
@@ -9737,6 +9740,76 @@ User Request:
                 handler=browser_handler,
             )
 
+            # Issue #453: #443 stopped redeclaring shell/file tools on the theory
+            # that "the Copilot SDK session already knows about and describes its
+            # own built-in tools". That holds for Copilot-native models but not
+            # for a BYOK route: on Ollama the registered set really is just
+            # search/call_agent/browser, so the model has no way to run a command
+            # or touch a file. It improvises instead -- markdown code fences,
+            # pseudo-XML, invented function names -- and the turn ends with
+            # nothing having run. Register real bash/python tools whenever the
+            # provider is not Copilot-native.
+            native_tools: list = []
+            if self._wee_provider_needs_native_tools(route.provider):
+
+                async def bash_handler(invocation):
+                    return self._wee_execute_tool(
+                        "bash",
+                        dict(invocation.arguments or {}),
+                        agent,
+                        n8n_session_id,
+                    )
+
+                async def python_handler(invocation):
+                    return self._wee_execute_tool(
+                        "python",
+                        dict(invocation.arguments or {}),
+                        agent,
+                        n8n_session_id,
+                    )
+
+                native_tools = [
+                    Tool(
+                        name="bash",
+                        description=(
+                            "Execute a bash shell command on this machine and return its "
+                            "output. Use this to read or write files, inspect the system, "
+                            "and run commands. For delegating whole tasks to another Wee "
+                            "agent, use call_agent instead."
+                        ),
+                        parameters={
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "string",
+                                    "description": "The bash command to execute",
+                                }
+                            },
+                            "required": ["command"],
+                        },
+                        handler=bash_handler,
+                    ),
+                    Tool(
+                        name="python",
+                        description=(
+                            "Execute Python 3 code on this machine and return its stdout. "
+                            "Use this for computation and data handling. For delegating "
+                            "whole tasks to another Wee agent, use call_agent instead."
+                        ),
+                        parameters={
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "string",
+                                    "description": "The Python code to execute",
+                                }
+                            },
+                            "required": ["code"],
+                        },
+                        handler=python_handler,
+                    ),
+                ]
+
             # Issue #398: track whether the model actually invoked anything, so a
             # turn that only *promised* to act can be detected afterwards. The
             # counter must be updated even when nothing is streaming, so it sits
@@ -9775,7 +9848,7 @@ User Request:
                 timeout=float(effective_timeout),
                 session_id=saved_sdk_session,
                 resume=bool(resume and saved_sdk_session),
-                tools=[search_tool, call_agent_tool, browser_tool],
+                tools=[search_tool, call_agent_tool, browser_tool] + native_tools,
                 enable_tools=True,
                 event_callback=on_sdk_event,
             )
@@ -9999,7 +10072,18 @@ User Request:
                 session_map[n8n_session_id]["wee_messages"] = clean
                 self.save_session_map(session_map)
 
-    def _wee_augment_system_prompt_with_tools(self, system_prompt: str) -> str:
+    # Providers whose sessions genuinely ship built-in shell/file/python tools.
+    # Everything else is a BYOK OpenAI-compatible route where the registered
+    # tool list is the complete set (issue #453).
+    _WEE_COPILOT_NATIVE_PROVIDERS = frozenset({"copilot", "github", "githubcopilot"})
+
+    @classmethod
+    def _wee_provider_needs_native_tools(cls, provider: str) -> bool:
+        return (provider or "").strip().lower() not in cls._WEE_COPILOT_NATIVE_PROVIDERS
+
+    def _wee_augment_system_prompt_with_tools(
+        self, system_prompt: str, native_tools_registered: bool = False
+    ) -> str:
         """Issue #111 / #443 / #397: Describe only the custom tools wee registers
         on top of the Copilot SDK session (search, call_agent, browser).
 
@@ -10030,6 +10114,23 @@ User Request:
             "2. For delegating work to other agents: use call_agent\n"
             "3. NEVER refuse or claim you lack capability. Your tools are active and functional."
         )
+        if native_tools_registered:
+            # Only described when actually registered, so the prompt can never
+            # advertise a tool that is not wired to anything -- the drift #443
+            # was guarding against.
+            tool_section += (
+                "\n\n**bash** -- Run a shell command on this machine and get its output.\n"
+                '  Call: bash tool with {"command": "ls -la /tmp"}\n'
+                "  Use for: reading and writing files, inspecting the system, running commands.\n"
+                "\n"
+                "**python** -- Run Python 3 code and get its stdout.\n"
+                '  Call: python tool with {"code": "print(6 * 7)"}\n'
+                "  Use for: computation and data handling.\n"
+                "\n"
+                "4. To run a command or touch a file, CALL the bash or python tool. "
+                "Do NOT write the command in a markdown code block, in XML tags, or as "
+                "prose describing what you would run -- none of those execute."
+            )
         return system_prompt + tool_section
 
 
@@ -10496,7 +10597,17 @@ User Request:
         (issue #397).
         """
         try:
-            if func_name == "search":
+            if func_name == "bash":
+                # Issue #453: only registered for non-Copilot-native providers,
+                # which have no built-in shell tool of their own.
+                from wee_runtime import execute_bash
+
+                return execute_bash(func_args)
+            elif func_name == "python":
+                from wee_runtime import execute_python
+
+                return execute_python(func_args)
+            elif func_name == "search":
                 # Issue #397: the Copilot SDK ships web_fetch (retrieve a known
                 # URL) but no web *search*, so a local agent had no way to
                 # discover pages for a query. _execute_search survived #443 —

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -15678,18 +15678,24 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             x_user_identity=request.headers.get("x-user-identity"),
             x_auth_channel=request.headers.get("x-auth-channel"),
         )
-        from kanban import load_kanban_board
+        try:
+            from kanban import load_kanban_board
 
-        return load_kanban_board(
-            todo_path=_resolve_todo_file(agent),
-            repo=repo,
-            limit=limit,
-            agent=agent,
-            urgency=urgency,
-            date_from=date_from,
-            date_to=date_to,
-            source=source,
-        )
+            return load_kanban_board(
+                todo_path=_resolve_todo_file(agent),
+                repo=repo,
+                limit=limit,
+                agent=agent,
+                urgency=urgency,
+                date_from=date_from,
+                date_to=date_to,
+                source=source,
+            )
+        except Exception as exc:
+            # Every sibling kanban route funnels through _kanban_http_error;
+            # this one did not, so anything raised below it reached the client
+            # as a bare 500 with no detail to act on.
+            _kanban_http_error(exc)
 
     @app.get("/api/v1/kanban/items/{item_id}")
     async def get_kanban_item(request: Request, item_id: str, repo: Optional[str] = None):

--- a/kanban.py
+++ b/kanban.py
@@ -624,25 +624,44 @@ def load_github_cards(repo: str | None, limit: int = 100) -> list[dict[str, Any]
     if not repo:
         return []
 
-    result = subprocess.run(
-        [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "all",
-            "--limit",
-            str(limit),
-            "--json",
-            "number,title,url,body,state,labels,createdAt,updatedAt",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=20,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "all",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,url,body,state,labels,createdAt,updatedAt",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        # `gh` is not installed, or -- far more commonly -- not on this
+        # process's PATH. A GUI-launched client starts its API subprocess with
+        # launchd's minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), which omits
+        # Homebrew, so the binary is unreachable even though a shell can find
+        # it. Previously this propagated as a bare 500 with no hint of a
+        # missing tool.
+        raise KanbanError(
+            "The GitHub CLI (gh) was not found on the API's PATH, so GitHub-backed "
+            "Kanban cards cannot be loaded.",
+            status_code=503,
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise KanbanError(
+            "Timed out waiting for the GitHub CLI (gh) to list issues.",
+            status_code=504,
+        ) from exc
+
     if result.returncode != 0:
         return []
 

--- a/tests/test_browser_all_runtimes.py
+++ b/tests/test_browser_all_runtimes.py
@@ -1,0 +1,324 @@
+"""
+Browser control for every runtime, not just `wee`.
+
+The `wee` runtime registers an in-process `browser` Tool and calls
+`browser_bridge.execute_browser_command` directly. Subprocess runtimes (codex,
+claude, gemini, opencode, cursor) cannot do that -- the broker's client
+registrations live in the API process's memory -- so a chat on any of those
+runtimes had a connected browser panel it could not reach. Observed as codex
+falling back to its own MCP browser integration and reporting "no available
+browser" while the Wee panel sat connected alongside it.
+
+Two pieces close that gap and are covered here:
+
+1. `POST /api/v1/browser/sessions/{id}/execute` -- an HTTP seam onto the same
+   broker the `wee` tool uses.
+2. `wee_browser_mcp.py` -- a stdio MCP server that calls that endpoint, handed
+   to each subprocess runtime through its own MCP config mechanism.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_browser")
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "9470")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MCP_SERVER = os.path.join(REPO_ROOT, "wee_browser_mcp.py")
+AUTH = {"Authorization": f"Bearer shared_{os.environ['API_SHARED_KEY']}"}
+
+
+# --------------------------------------------------------------------------
+# The MCP server: protocol shape, and behaviour when it cannot reach the API.
+# --------------------------------------------------------------------------
+
+
+def _mcp_exchange(messages, env=None):
+    """Run the MCP server over stdio and return its JSON responses."""
+    payload = "".join(json.dumps(m) + "\n" for m in messages)
+    process = subprocess.run(
+        [sys.executable, MCP_SERVER],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**os.environ, **(env or {})},
+    )
+    return [json.loads(line) for line in process.stdout.splitlines() if line.strip()]
+
+
+def test_mcp_server_completes_the_initialize_handshake():
+    responses = _mcp_exchange(
+        [{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}]
+    )
+    assert len(responses) == 1
+    result = responses[0]["result"]
+    assert result["serverInfo"]["name"] == "wee-browser"
+    assert "tools" in result["capabilities"]
+
+
+def test_mcp_server_advertises_the_browser_tools():
+    responses = _mcp_exchange([{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}])
+    names = {tool["name"] for tool in responses[0]["result"]["tools"]}
+    assert {"browser_navigate", "browser_snapshot", "browser_click", "browser_type"} <= names
+    for tool in responses[0]["result"]["tools"]:
+        assert tool["inputSchema"]["type"] == "object", tool["name"]
+
+
+def test_mcp_server_does_not_answer_notifications():
+    """A notification has no id; replying to one corrupts the stream."""
+    responses = _mcp_exchange([{"jsonrpc": "2.0", "method": "notifications/initialized"}])
+    assert responses == []
+
+
+def test_mcp_server_reports_missing_configuration_instead_of_crashing():
+    responses = _mcp_exchange(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "browser_snapshot", "arguments": {}},
+            }
+        ],
+        env={"WEE_BROWSER_SESSION_ID": "", "WEE_API_BASE": "", "WEE_API_TOKEN": ""},
+    )
+    text = responses[0]["result"]["content"][0]["text"]
+    assert "not configured" in text
+    assert "WEE_BROWSER_SESSION_ID" in text, "must name what is missing"
+
+
+def test_mcp_server_rejects_an_unknown_tool():
+    responses = _mcp_exchange(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "browser_launch_missiles", "arguments": {}},
+            }
+        ]
+    )
+    assert responses[0]["error"]["code"] == -32602
+
+
+# --------------------------------------------------------------------------
+# The HTTP seam, exercised against the real broker.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:  # pragma: no cover - depends on installed extras
+        from fastapi.testclient import TestClient
+
+    from agent_manager import create_api_app
+
+    return TestClient(create_api_app(), raise_server_exceptions=False)
+
+
+@pytest.fixture
+def session_id(client):
+    response = client.post(
+        "/api/v1/sessions/create", headers=AUTH, json={"agent": "orchestrator"}
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["session_id"]
+
+
+def test_execute_falls_back_to_playwright_without_a_native_panel(client, session_id):
+    """With no panel attached, browser_bridge routes to Playwright by design.
+
+    So this endpoint must not claim "no browser" -- it must report whatever
+    that path did. Either it worked (200) or it failed for a stated reason;
+    what it must never do is surface as an unhandled 500.
+    """
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute",
+        headers=AUTH,
+        json={"action": "snapshot"},
+    )
+    assert response.status_code in (200, 502, 504), response.text
+    if response.status_code != 200:
+        assert response.json()["detail"], "a failure must say why"
+
+
+def test_execute_maps_a_disconnected_browser_to_409(client, session_id, monkeypatch):
+    """When the bridge itself reports no browser, say so actionably.
+
+    Exercised directly because reaching it through the bridge requires
+    Playwright to also be unavailable.
+    """
+    import browser_bridge
+
+    def _no_browser(*args, **kwargs):
+        raise RuntimeError("No native browser is connected to this session")
+
+    monkeypatch.setattr(browser_bridge, "execute_browser_command", _no_browser)
+
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute",
+        headers=AUTH,
+        json={"action": "snapshot"},
+    )
+    assert response.status_code == 409, response.text
+    assert "no native browser" in response.json()["detail"].lower()
+
+
+def test_execute_requires_an_action(client, session_id):
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute", headers=AUTH, json={}
+    )
+    assert response.status_code == 400
+
+
+def test_execute_requires_authentication(client, session_id):
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute", json={"action": "snapshot"}
+    )
+    assert response.status_code == 401
+
+
+def test_execute_drives_an_attached_browser_client(client, session_id):
+    """Full round trip: register a browser client, then drive it over HTTP.
+
+    Stands in for the macOS WKWebView panel, which does exactly this -- register,
+    long-poll for commands, post results.
+    """
+    client_id = "test-browser-client"
+    registered = client.post(
+        f"/api/v1/browser/sessions/{session_id}/register",
+        headers=AUTH,
+        json={"client_id": client_id},
+    )
+    assert registered.status_code == 200, registered.text
+
+    delivered = {}
+
+    def fake_browser():
+        # Poll for the command the way the real panel does, then answer it.
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            polled = client.get(
+                f"/api/v1/browser/sessions/{session_id}/commands",
+                headers=AUTH,
+                params={"client_id": client_id, "timeout": 5},
+            )
+            command = (polled.json() or {}).get("command")
+            if not command:
+                continue
+            delivered["command"] = command
+            client.post(
+                f"/api/v1/browser/sessions/{session_id}/results",
+                headers=AUTH,
+                json={
+                    "client_id": client_id,
+                    "command_id": command["id"],
+                    "result": "PAGE TEXT FROM PANEL",
+                    "url": "https://example.invalid/page",
+                    "title": "Example",
+                },
+            )
+            return
+
+    worker = threading.Thread(target=fake_browser, daemon=True)
+    worker.start()
+
+    response = client.post(
+        f"/api/v1/browser/sessions/{session_id}/execute",
+        headers=AUTH,
+        json={"action": "navigate", "url": "https://example.invalid/page", "timeout": 30},
+    )
+    worker.join(timeout=35)
+
+    assert response.status_code == 200, response.text
+    assert delivered.get("command", {}).get("action") == "navigate"
+    assert "PAGE TEXT FROM PANEL" in response.json()["result"]
+
+
+# --------------------------------------------------------------------------
+# Per-runtime wiring: each CLI gets the server through its own mechanism.
+# --------------------------------------------------------------------------
+
+
+def _manager():
+    import agent_manager
+
+    for name in dir(agent_manager):
+        obj = getattr(agent_manager, name)
+        if isinstance(obj, type) and hasattr(obj, "_wee_browser_mcp_server_spec"):
+            return obj
+    raise AssertionError("No class exposing _wee_browser_mcp_server_spec")
+
+
+def test_codex_receives_the_browser_server_as_config_overrides(monkeypatch):
+    manager = _manager()
+    instance = manager.__new__(manager)
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda self, sid: {"identity": "u", "channel": "webui"}
+    )
+
+    args = manager._wee_browser_codex_config_args(instance, "sess-codex")
+    joined = " ".join(args)
+    assert "mcp_servers.wee-browser.command=" in joined
+    assert "wee_browser_mcp.py" in joined
+    assert "WEE_BROWSER_SESSION_ID" in joined and "sess-codex" in joined
+    # Codex parses each value as TOML; every value must be quoted so a token
+    # containing '=' or '#' cannot break the parse.
+    for index, token in enumerate(args):
+        if token == "-c":
+            assert '="' in args[index + 1] or "=[" in args[index + 1], args[index + 1]
+
+
+def test_claude_receives_the_browser_server_as_an_mcp_config_file(monkeypatch, tmp_path):
+    manager = _manager()
+    instance = manager.__new__(manager)
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda self, sid: {"identity": "u", "channel": "webui"}
+    )
+
+    path = manager._wee_browser_mcp_config_file(instance, "sess-claude")
+    assert path and os.path.exists(path)
+    with open(path) as handle:
+        config = json.load(handle)
+    server = config["mcpServers"]["wee-browser"]
+    assert server["args"][0].endswith("wee_browser_mcp.py")
+    assert server["env"]["WEE_BROWSER_SESSION_ID"] == "sess-claude"
+
+
+def test_each_session_gets_its_own_config_file(monkeypatch):
+    """Two chats must never be handed the same file and drive each other's browser."""
+    manager = _manager()
+    instance = manager.__new__(manager)
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda self, sid: {"identity": "u", "channel": "webui"}
+    )
+
+    first = manager._wee_browser_mcp_config_file(instance, "sess-a")
+    second = manager._wee_browser_mcp_config_file(instance, "sess-b")
+    assert first != second
+
+
+def test_no_browser_wiring_without_a_shared_key(monkeypatch):
+    """Better to offer no browser tools than tools that always fail."""
+    manager = _manager()
+    instance = manager.__new__(manager)
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda self, sid: {"identity": "u", "channel": "webui"}
+    )
+    monkeypatch.delenv("API_SHARED_KEY", raising=False)
+
+    assert manager._wee_browser_mcp_server_spec(instance, "sess") is None
+    assert manager._wee_browser_codex_config_args(instance, "sess") == []
+    assert manager._wee_browser_mcp_config_file(instance, "sess") is None

--- a/tests/test_issue425_wee_copilot_byok.py
+++ b/tests/test_issue425_wee_copilot_byok.py
@@ -226,8 +226,11 @@ def test_api_wee_runtime_uses_shared_sdk_executor(monkeypatch):
     mgr._stream_buffers = {}
     mgr.get_or_create_session_data = MagicMock(return_value={"channel": "webui"})
     mgr.build_agent_context_prompt = MagicMock(return_value="context")
+    # Signature-agnostic: this test asserts the wee runtime uses the shared SDK
+    # executor, not the arity of the prompt augmenter. Pinning the exact
+    # signature made an unrelated change to that helper fail here.
     mgr._wee_augment_system_prompt_with_tools = MagicMock(
-        side_effect=lambda prompt: prompt
+        side_effect=lambda prompt, *args, **kwargs: prompt
     )
     mgr._wee_execute_tool = MagicMock(return_value="ok")
     mgr.update_session_field = MagicMock()

--- a/tests/test_issue453_byok_native_tools.py
+++ b/tests/test_issue453_byok_native_tools.py
@@ -1,0 +1,106 @@
+"""
+Regression test for issue #453: on the `wee` runtime with a local Ollama model,
+only the custom-registered tools (search, call_agent, browser) executed. The
+Copilot SDK's built-in shell/file/python tools are not present on a BYOK route,
+so the model had no way to run a command or touch a file. It improvised --
+markdown code fences, pseudo-XML, invented function names -- and the turn ended
+with nothing having run.
+
+#443 stopped redeclaring shell/file tools on the reasoning that "the Copilot SDK
+session already knows about and describes its own built-in tools". That holds
+for Copilot-native models but not for BYOK providers, where the registered tool
+list is the complete set.
+
+These tests pin the provider gate, the executors, and the prompt text. They do
+NOT cover the end-to-end model behaviour: that needs a live Ollama model, and
+per the issue a single probe turn runs 100-280s and routinely hits the SDK's
+260s idle timeout on that hardware.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_453")
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "9453")
+
+import pytest  # noqa: E402
+
+from wee_runtime import execute_bash, execute_python, sanitize_bash_command  # noqa: E402
+
+
+def _manager_class():
+    import agent_manager
+
+    for name in dir(agent_manager):
+        obj = getattr(agent_manager, name)
+        if isinstance(obj, type) and hasattr(obj, "_wee_provider_needs_native_tools"):
+            return obj
+    raise AssertionError("No class exposing _wee_provider_needs_native_tools")
+
+
+@pytest.mark.parametrize("provider", ["ollama", "lmstudio", "openrouter", "custom", ""])
+def test_issue_453_byok_providers_get_native_tools(provider):
+    manager = _manager_class()
+    assert manager._wee_provider_needs_native_tools(provider) is True
+
+
+@pytest.mark.parametrize("provider", ["copilot", "Copilot", "GITHUB", "githubcopilot"])
+def test_issue_453_copilot_native_providers_do_not_redeclare_tools(provider):
+    """#443's reasoning still applies where it was actually true."""
+    manager = _manager_class()
+    assert manager._wee_provider_needs_native_tools(provider) is False
+
+
+def test_issue_453_bash_tool_actually_runs_a_command():
+    output = execute_bash({"command": "echo WEE-453-OK"})
+    assert output == "WEE-453-OK"
+
+
+def test_issue_453_bash_reports_failure_output():
+    output = execute_bash({"command": "ls /definitely/not/here/453"})
+    assert "STDERR" in output
+
+
+def test_issue_453_bash_rejects_empty_command():
+    assert execute_bash({}).startswith("Error")
+
+
+def test_issue_453_python_tool_actually_evaluates_code():
+    output = execute_python({"code": "print(7919 * 104729)"})
+    assert output == str(7919 * 104729)
+
+
+def test_issue_453_python_rejects_empty_code():
+    assert execute_python({}).startswith("Error")
+
+
+def test_issue_453_ssh_commands_keep_host_key_protection():
+    """Preserved from #111: accept-new still rejects CHANGED keys."""
+    sanitized = sanitize_bash_command("ssh root@192.168.1.100 'uptime'")
+    assert "StrictHostKeyChecking=accept-new" in sanitized
+
+    already_set = "ssh -o StrictHostKeyChecking=no host 'uptime'"
+    assert sanitize_bash_command(already_set) == already_set
+
+
+def test_issue_453_prompt_describes_bash_and_python_only_when_registered():
+    manager = _manager_class()
+    instance = manager.__new__(manager)
+
+    byok = manager._wee_augment_system_prompt_with_tools(
+        instance, "BASE", native_tools_registered=True
+    )
+    assert "**bash**" in byok
+    assert "**python**" in byok
+    # The failure mode was the model emitting a fenced command instead of
+    # calling a tool, so the prompt must say that explicitly.
+    assert "markdown code block" in byok
+
+    native = manager._wee_augment_system_prompt_with_tools(
+        instance, "BASE", native_tools_registered=False
+    )
+    assert "**bash**" not in native
+    assert "**search**" in native, "custom tools are still described either way"

--- a/tests/test_issue456_kanban_board_errors.py
+++ b/tests/test_issue456_kanban_board_errors.py
@@ -1,0 +1,109 @@
+"""
+Regression test for issue #456: `GET /api/v1/kanban/board` returned a bare
+500 "Internal server error" whenever the `gh` CLI was missing from the API
+process's PATH, or slow enough to hit its 20s timeout.
+
+This was found from a real failure. A GUI-launched macOS client starts its
+Local API subprocess with launchd's minimal PATH
+(`/usr/bin:/bin:/usr/sbin:/sbin`), which omits Homebrew, so
+`subprocess.run(["gh", ...])` raised `FileNotFoundError`. Two gaps combined:
+
+1. `load_github_cards` caught a non-zero return code and a JSON decode error,
+   but neither `FileNotFoundError` nor `subprocess.TimeoutExpired`.
+2. The board route called `load_kanban_board` with no try/except, unlike every
+   sibling kanban route, which funnel through `_kanban_http_error`.
+
+The client had no way to distinguish "your tooling is misconfigured" from "the
+server is broken". These tests pin both halves: the loader raises a typed
+KanbanError with an actionable status code, and the route reports it rather
+than collapsing it into a 500.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault("API_SHARED_KEY", "test_key_456")
+os.environ.setdefault("APP_ENV", "DEV")
+os.environ.setdefault("API_PORT", "9456")
+
+import kanban  # noqa: E402
+from kanban import KanbanError, load_github_cards  # noqa: E402
+
+
+def test_issue_456_missing_gh_binary_raises_actionable_error(monkeypatch):
+    def _raise_missing(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory: 'gh'")
+
+    monkeypatch.setattr(kanban.subprocess, "run", _raise_missing)
+
+    with pytest.raises(KanbanError) as excinfo:
+        load_github_cards("leprachuan/fosterbot-home", 200)
+
+    assert excinfo.value.status_code == 503
+    message = str(excinfo.value)
+    assert "gh" in message
+    assert "PATH" in message, "the message must point at the actual cause"
+
+
+def test_issue_456_gh_timeout_raises_gateway_timeout(monkeypatch):
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="gh", timeout=20)
+
+    monkeypatch.setattr(kanban.subprocess, "run", _raise_timeout)
+
+    with pytest.raises(KanbanError) as excinfo:
+        load_github_cards("leprachuan/fosterbot-home", 200)
+
+    assert excinfo.value.status_code == 504
+
+
+def test_issue_456_no_repo_still_short_circuits(monkeypatch):
+    """The guard clause must run before any subprocess attempt."""
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("gh must not be invoked when no repo is configured")
+
+    monkeypatch.setattr(kanban.subprocess, "run", _explode)
+    assert load_github_cards(None, 200) == []
+
+
+def test_issue_456_non_zero_exit_still_degrades_quietly(monkeypatch):
+    """A gh that runs but fails (e.g. auth) keeps the previous behaviour:
+    GitHub cards are skipped rather than failing the whole board."""
+
+    class _Result:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(kanban.subprocess, "run", lambda *a, **k: _Result())
+    assert load_github_cards("leprachuan/fosterbot-home", 200) == []
+
+
+def test_issue_456_board_route_reports_error_instead_of_bare_500(monkeypatch):
+    """The route must surface the loader's status code, not collapse to 500."""
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:  # pragma: no cover - depends on installed extras
+        from fastapi.testclient import TestClient
+
+    from agent_manager import create_api_app
+
+    def _raise_missing(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory: 'gh'")
+
+    monkeypatch.setattr(kanban.subprocess, "run", _raise_missing)
+    monkeypatch.setattr(kanban, "_default_repo", lambda: "leprachuan/fosterbot-home")
+
+    client = TestClient(create_api_app(), raise_server_exceptions=False)
+    response = client.get(
+        "/api/v1/kanban/board",
+        headers={"Authorization": f"Bearer shared_{os.environ['API_SHARED_KEY']}"},
+    )
+
+    assert response.status_code == 503, response.text
+    assert "gh" in response.json()["detail"]

--- a/wee_browser_mcp.py
+++ b/wee_browser_mcp.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""stdio MCP server exposing one Wee chat session's browser to any runtime.
+
+The `wee` runtime drives the browser by calling `browser_bridge` in-process.
+The subprocess runtimes (codex, claude, gemini, opencode, cursor) cannot: the
+broker's client registrations live in the API process's memory. This server is
+the bridge -- it speaks MCP over stdio to whichever CLI launched it, and calls
+`POST /api/v1/browser/sessions/{id}/execute` on the API to do the work.
+
+Configuration is entirely by environment, because that is what every CLI's MCP
+config can set:
+
+    WEE_BROWSER_SESSION_ID  the chat session whose browser to drive (required)
+    WEE_API_BASE            e.g. http://127.0.0.1:8001 (required)
+    WEE_API_TOKEN           bearer token for that API (required)
+    WEE_API_IDENTITY        X-User-Identity, when the API expects one
+    WEE_API_CHANNEL         X-Auth-Channel, when the API expects one
+    WEE_API_INSECURE_TLS    "1" to skip TLS verification (self-signed prod cert)
+
+The JSON-RPC framing is hand-rolled rather than taken from the `mcp` package:
+that package is not in requirements.txt, and this server has to start reliably
+inside whatever interpreter a given CLI happens to spawn.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "wee-browser"
+SERVER_VERSION = "1.0.0"
+
+# Matches the API's own ceiling for a browser command so this layer never times
+# out first and reports a confusing error for a command still in flight.
+REQUEST_TIMEOUT = 95.0
+
+TOOLS = [
+    {
+        "name": "browser_navigate",
+        "description": (
+            "Navigate this chat session's browser to a URL and return the "
+            "resulting page text. Use this before reading or clicking."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"url": {"type": "string", "description": "Absolute URL to open"}},
+            "required": ["url"],
+        },
+    },
+    {
+        "name": "browser_snapshot",
+        "description": (
+            "Read the current page in this chat session's browser: its URL, "
+            "title, and visible text. Use this to see what is on screen."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "browser_click",
+        "description": "Click an element, found by CSS selector or by its visible text.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {"type": "string", "description": "CSS selector"},
+                "text": {"type": "string", "description": "Visible text to match instead"},
+            },
+        },
+    },
+    {
+        "name": "browser_type",
+        "description": "Type text into the element matching a CSS selector.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {"type": "string"},
+                "text": {"type": "string"},
+                "submit": {"type": "boolean", "description": "Press Enter afterwards"},
+            },
+            "required": ["selector", "text"],
+        },
+    },
+    {
+        "name": "browser_evaluate",
+        "description": "Evaluate JavaScript in the current page and return its result.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"script": {"type": "string"}},
+            "required": ["script"],
+        },
+    },
+    {
+        "name": "browser_back",
+        "description": "Go back one entry in this session's browser history.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "browser_forward",
+        "description": "Go forward one entry in this session's browser history.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "browser_reload",
+        "description": "Reload the current page.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+# MCP tool name -> the action understood by browser_bridge.
+_ACTIONS = {
+    "browser_navigate": "navigate",
+    "browser_snapshot": "snapshot",
+    "browser_click": "click",
+    "browser_type": "type",
+    "browser_evaluate": "evaluate",
+    "browser_back": "back",
+    "browser_forward": "forward",
+    "browser_reload": "reload",
+}
+
+
+def _env(name: str) -> str:
+    return (os.environ.get(name) or "").strip()
+
+
+def _ssl_context():
+    if _env("WEE_API_INSECURE_TLS") in {"1", "true", "yes"}:
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        return context
+    return None
+
+
+def _execute(action: str, arguments: dict) -> str:
+    """Send one browser command to the API and return a human-readable result."""
+    session_id = _env("WEE_BROWSER_SESSION_ID")
+    api_base = _env("WEE_API_BASE").rstrip("/")
+    token = _env("WEE_API_TOKEN")
+
+    missing = [
+        name
+        for name, value in (
+            ("WEE_BROWSER_SESSION_ID", session_id),
+            ("WEE_API_BASE", api_base),
+            ("WEE_API_TOKEN", token),
+        )
+        if not value
+    ]
+    if missing:
+        return f"Browser control is not configured for this session (missing {', '.join(missing)})."
+
+    payload = {"action": action, **{k: v for k, v in arguments.items() if v is not None}}
+    request = urllib.request.Request(
+        f"{api_base}/api/v1/browser/sessions/{session_id}/execute",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+    )
+    request.add_header("Content-Type", "application/json")
+    request.add_header("Authorization", f"Bearer {token}")
+    if identity := _env("WEE_API_IDENTITY"):
+        request.add_header("X-User-Identity", identity)
+    if channel := _env("WEE_API_CHANNEL"):
+        request.add_header("X-Auth-Channel", channel)
+
+    try:
+        with urllib.request.urlopen(
+            request, timeout=REQUEST_TIMEOUT, context=_ssl_context()
+        ) as response:
+            body = json.loads(response.read().decode("utf-8"))
+        return str(body.get("result", ""))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:600]
+        if exc.code == 409:
+            # The one failure worth explaining: the panel is not attached, and
+            # the user is the only one who can fix that.
+            return (
+                "No browser is attached to this chat session. Open the browser "
+                "panel for this chat in the Wee app, then try again. "
+                f"({detail})"
+            )
+        return f"Browser command failed (HTTP {exc.code}): {detail}"
+    except Exception as exc:
+        return f"Browser command failed: {exc}"
+
+
+def _respond(message_id, result=None, error=None) -> None:
+    payload = {"jsonrpc": "2.0", "id": message_id}
+    if error is not None:
+        payload["error"] = error
+    else:
+        payload["result"] = result
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _handle(message: dict) -> None:
+    method = message.get("method")
+    message_id = message.get("id")
+
+    # Notifications carry no id and must not be answered.
+    if message_id is None:
+        return
+
+    if method == "initialize":
+        _respond(
+            message_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        )
+    elif method == "tools/list":
+        _respond(message_id, {"tools": TOOLS})
+    elif method == "tools/call":
+        params = message.get("params") or {}
+        name = params.get("name") or ""
+        action = _ACTIONS.get(name)
+        if action is None:
+            _respond(message_id, error={"code": -32602, "message": f"Unknown tool: {name}"})
+            return
+        output = _execute(action, params.get("arguments") or {})
+        _respond(message_id, {"content": [{"type": "text", "text": output}]})
+    elif method in {"ping", "shutdown"}:
+        _respond(message_id, {})
+    else:
+        _respond(message_id, error={"code": -32601, "message": f"Unknown method: {method}"})
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            _handle(message)
+        except Exception as exc:  # pragma: no cover - defensive
+            # A crash here would take browser control down for the whole run,
+            # so report and keep serving.
+            _respond(message.get("id"), error={"code": -32603, "message": str(exc)})
+
+
+if __name__ == "__main__":
+    main()

--- a/wee_runtime.py
+++ b/wee_runtime.py
@@ -514,6 +514,77 @@ def _execute_brave_search(
     return _format_search_results(query, results, output_format)
 
 
+_SSH_BIN_RE = re.compile(r"\b(ssh|scp|sftp)\b")
+
+# Matches the SDK's own tool budget closely enough that a slow command fails
+# with a tool error rather than stalling the whole turn.
+WEE_BYOK_TOOL_TIMEOUT = int(os.environ.get("WEE_TOOL_TIMEOUT", "120"))
+
+
+def sanitize_bash_command(command: str) -> str:
+    """Auto-inject SSH flags to prevent host key verification failures.
+
+    Injects ``-o StrictHostKeyChecking=accept-new`` after ssh/scp/sftp when the
+    flag is not already present. ``accept-new`` is preferred over ``no``
+    because it still rejects CHANGED keys (potential MITM).
+    """
+    if not command or not _SSH_BIN_RE.search(command):
+        return command
+    if "StrictHostKeyChecking" in command:
+        return command
+
+    def _inject(match):
+        return match.group(0) + " -o StrictHostKeyChecking=accept-new"
+
+    return _SSH_BIN_RE.sub(_inject, command, count=0)
+
+
+def _format_process_result(result: "subprocess.CompletedProcess[str]") -> str:
+    output = result.stdout or ""
+    if result.returncode != 0 and result.stderr:
+        output += f"\nSTDERR: {result.stderr}"
+    return output.strip() or "(no output)"
+
+
+def execute_bash(func_args: dict) -> str:
+    """Run a bash command for BYOK providers that have no built-in shell tool."""
+    command = (func_args or {}).get("command", "")
+    if not command:
+        return "Error: No command provided"
+    command = sanitize_bash_command(command)
+    try:
+        result = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            timeout=WEE_BYOK_TOOL_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return f"Error: bash timed out after {WEE_BYOK_TOOL_TIMEOUT}s"
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"Error executing bash: {exc}"
+    return _format_process_result(result)
+
+
+def execute_python(func_args: dict) -> str:
+    """Run Python for BYOK providers that have no built-in python tool."""
+    code = (func_args or {}).get("code", "")
+    if not code:
+        return "Error: No code provided"
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=WEE_BYOK_TOOL_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return f"Error: python timed out after {WEE_BYOK_TOOL_TIMEOUT}s"
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"Error executing python: {exc}"
+    return _format_process_result(result)
+
+
 def _execute_search(func_args: dict) -> str:
     """Handle search tool calls via SearXNG (Issue #255).
 


### PR DESCRIPTION
Promotes four commits from `dev` to `main` for production deployment.

| PR | Change |
|---|---|
| #464 | Kanban board reports why it failed instead of a bare 500 (closes #456) |
| #466 | `bash`/`python` tools registered for BYOK providers (closes #453) |
| #467 | Session browser reachable from codex, claude, and copilot — not just `wee` |
| #468 | Test stub fix caught while validating this promotion |

## Verification

Full suite run on the dev host against both branches and compared:

- **`main`**: 574 failed, 2310 passed
- **`dev`**: 571 failed, 2348 passed
- **New failures on `dev`: none**
- **Fixed by this promotion: 3** — the `wee_execute_tool` bash/python tests and the shell-injection pipe-semantics test, all orphaned when #443 removed those executors and restored by #466

The large absolute failure count is pre-existing on `main` and unrelated to these changes; the delta is what matters here and it is strictly favourable.

New suites specific to this work: 35 tests passing (`test_browser_all_runtimes.py`, `test_issue453_byok_native_tools.py`, `test_issue456_kanban_board_errors.py`).

## Notes for deployment

- The browser feature adds `POST /api/v1/browser/sessions/{id}/execute` and a new `wee_browser_mcp.py`. No new dependencies — the MCP JSON-RPC is hand-rolled precisely to avoid adding one.
- `gemini`, `opencode`, `cursor`, and `devin` are **not** wired for browser control: none supports per-invocation MCP config, so wiring them would risk one chat driving another chat's browser. `copilot-sdk` and `claude-sdk` already had it.
- #466 has no end-to-end validation against a live Ollama model — per #453 a single probe runs 100–280s and routinely hits the SDK's 260s idle timeout. Worth a manual pass on dev.