### PR TITLE
ci: stop the six-hour hang and bound future ones

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,12 +4,19 @@ on:
   push:
     branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Without this a hung test runs until GitHub's 6-hour ceiling. Every run
+    # from 2026-07-27 onward was cancelled at exactly 6h for that reason, so
+    # required checks could never report and nothing could merge to main.
+    timeout-minutes: 20
     strategy:
+      # Report both interpreters even when one fails; a 3.13-only break should
+      # not hide 3.12's result.
+      fail-fast: false
       matrix:
         python-version: ['3.12', '3.13']
 
@@ -20,15 +27,20 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
+        # pytest-timeout turns a hang into a failing test with a stack trace
+        # instead of a silent six-hour stall.
+        pip install pytest pytest-timeout
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Run tests
       env:
         PYTHON_KEYRING_BACKEND: keyrings.alt.file.PlaintextKeyring
       run: |
-        python -m pytest tests/ -v --tb=short
+        python -m pytest tests/ -v --tb=short \
+          --timeout=120 --timeout-method=thread \
+          --ignore=tests/opencode_agentic_tests

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ telegram_downloads/
 *.env
 *.env.local
 *.env.*.local
+# Catch .env variants that don't END in .env — backups (.env.bak-*),
+# .env.save, .env.old. `*.env` alone misses these, which is how
+# plaintext secret copies end up untracked-but-committable.
+.env.*
+!.env.example
 webex_config.json
 telegram_config.json
 .env.prod

--- a/secret_tool/__init__.py
+++ b/secret_tool/__init__.py
@@ -1,0 +1,28 @@
+"""Credential storage backends for Wee Orchestrator.
+
+`secret_tool` was a single module before it became a package, and the move left
+this file empty. Anything doing `import secret_tool; secret_tool.FileBackend`
+broke, because the names moved one level down into `secret_tool.secret_tool`
+without being re-exported here.
+
+Re-exporting restores the original public surface. Both spellings work:
+
+    from secret_tool import FileBackend              # pre-package callers
+    from secret_tool.secret_tool import FileBackend  # post-package, e.g. wee_runtime
+"""
+
+from secret_tool.secret_tool import (
+    FileBackend,
+    KeyringBackend,
+    PassBackend,
+    main,
+    parse_args,
+)
+
+__all__ = [
+    "FileBackend",
+    "KeyringBackend",
+    "PassBackend",
+    "main",
+    "parse_args",
+]

--- a/tests/test_issue_292_bg_task_model_validation.py
+++ b/tests/test_issue_292_bg_task_model_validation.py
@@ -143,16 +143,14 @@ class TestIssue292BgTaskModelValidation(unittest.TestCase):
         }
         mock_create.return_value = mock_task
 
-        with patch("asyncio.get_running_loop") as mock_loop:
-            mock_loop.return_value = MagicMock()
-            resp = self._post_bg_task(
-                {
-                    "prompt": "Say hello",
-                    "agent": "fosterbot",
-                    "runtime": "copilot",
-                    # no "model" field
-                }
-            )
+        resp = self._post_bg_task(
+            {
+                "prompt": "Say hello",
+                "agent": "fosterbot",
+                "runtime": "copilot",
+                # no "model" field
+            }
+        )
 
         self.assertNotEqual(
             resp.status_code,
@@ -187,16 +185,14 @@ class TestIssue292BgTaskModelValidation(unittest.TestCase):
         }
         mock_create.return_value = mock_task
 
-        with patch("asyncio.get_running_loop") as mock_loop:
-            mock_loop.return_value = MagicMock()
-            resp = self._post_bg_task(
-                {
-                    "prompt": "Say hello",
-                    "agent": "fosterbot",
-                    "runtime": "claude",
-                    "model": "claude-sonnet-4.6",
-                }
-            )
+        resp = self._post_bg_task(
+            {
+                "prompt": "Say hello",
+                "agent": "fosterbot",
+                "runtime": "claude",
+                "model": "claude-sonnet-4.6",
+            }
+        )
 
         self.assertNotEqual(
             resp.status_code,


### PR DESCRIPTION
CI has **never completed**. Every run since 2026-07-27 finished as `cancelled` at exactly six hours — GitHub's hard job ceiling — so required status checks could never report, and nothing could merge to `main` without an admin override.

## Cause

Not runner availability. A runner was always assigned (`GitHub Actions 1000006400`, `started_at 00:28:07` → `completed_at 06:28:22`). The suite hung.

`test_issue_292_bg_task_model_validation` patched `asyncio.get_running_loop` with a `MagicMock` around two `TestClient` POSTs. Starlette and anyio call that internally to drive the request, so they got a mock instead of the real loop and the request never completed:

```
starlette/testclient.py:352 in handle_request
    response_complete = portal.call(anyio.Event)
concurrent/futures/_base.py:451 in result
    self._condition.wait(timeout)
threading.py:355 in wait
    waiter.acquire()          # forever
```

Neither patch was needed — `BackgroundTaskManager.create_task` is already mocked in both tests, and that mock is what they actually assert against.

**With both removed the suite finishes in 109 seconds.**

## Also hardened

So this can never cost six hours again:

- `timeout-minutes: 20` on the job
- `pytest-timeout` at 120s per test — a hang now fails with a stack trace naming the test instead of stalling silently
- `fail-fast: false` — a 3.13-only break no longer hides 3.12's result
- pip caching, and the same `opencode_agentic_tests` exclusion used locally
- runs on `pull_request` to `dev` too, so branches are checked before they reach the release PR

## What this does not fix

The suite is **not green**: 575 tests fail for reasons that predate this change. The taxonomy is dominated by stale patches against refactored internals — 167 `AttributeError: module ... has no attribute`, 94 on `SessionManager`/`BackgroundTaskManager` attributes, 83 auth `401`s, 22 `ImportError`. That is test rot accumulated against refactors like #443 and #29, and it needs its own effort.

What changes here is that **CI reports at all**, in under two minutes, so it can start being useful.