### PR TITLE
fix(browser): stop the MCP config leaking the shared key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ logs/wee_executor.log
 
 # Transcript storage (contains sensitive session data)
 logs/transcripts/
+
+# Per-session browser MCP configs. These embed the API shared key so the MCP
+# server can authenticate, and are regenerated on every run.
+.mcp-configs/

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -5774,10 +5774,19 @@ You can mention an agent in your prompt and it will auto-delegate:
             return None
         try:
             directory = os.path.join(SCRIPT_BASE_DIR, ".mcp-configs")
-            os.makedirs(directory, exist_ok=True)
+            # The file embeds the API shared key so the MCP server can
+            # authenticate, so keep it owner-only rather than inheriting the
+            # umask. .gitignore covers the other half of the exposure.
+            os.makedirs(directory, mode=0o700, exist_ok=True)
+            os.chmod(directory, 0o700)
             path = os.path.join(directory, f"browser-{n8n_session_id}.json")
-            with open(path, "w", encoding="utf-8") as handle:
+            # Create with 0600 before anything is written, rather than
+            # chmod-ing after: a world-readable window, however brief, is still
+            # a window where the key is readable.
+            descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
                 json.dump({"mcpServers": {self.WEE_BROWSER_MCP_NAME: spec}}, handle)
+            os.chmod(path, 0o600)
             return path
         except OSError as exc:
             print(f"[Browser] Could not write MCP config: {exc}", file=sys.stderr)

--- a/tests/test_mcp_config_secret_hygiene.py
+++ b/tests/test_mcp_config_secret_hygiene.py
@@ -1,0 +1,85 @@
+"""
+The per-session browser MCP config embeds the API shared key so the MCP server
+can authenticate against the local API. Two exposures came with that, both
+introduced alongside the browser feature:
+
+1. `.mcp-configs/` was not in .gitignore, so one `git add -A` in a checkout
+   would have committed a live shared key.
+2. The file was written with the default umask, leaving the key readable by
+   any other local user.
+
+These pin both. The key is real credential material, so the guard needs to be
+a test rather than a convention.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_mcp_config_directory_is_gitignored():
+    """A generated file holding a live key must never be committable."""
+    result = subprocess.run(
+        ["git", "check-ignore", "-v", ".mcp-configs/browser-abc123.json"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        ".mcp-configs/ is not gitignored, so a generated browser MCP config "
+        "carrying the API shared key could be committed:\n" + result.stderr
+    )
+
+
+def test_generated_config_is_owner_only(tmp_path, monkeypatch):
+    """The key must not be readable by other local users."""
+    import agent_manager as am
+
+    monkeypatch.setattr(am, "SCRIPT_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("API_SHARED_KEY", "k" * 64)
+
+    manager = am.SessionManager()
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda _sid: {"identity": "u", "channel": "webui"}
+    )
+
+    path = manager._wee_browser_mcp_config_file("sess-hygiene")
+    assert path is not None, "config should have been written"
+
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600, f"expected 0600, got {oct(mode)} — group/other can read the key"
+
+    directory_mode = stat.S_IMODE(os.stat(os.path.dirname(path)).st_mode)
+    assert directory_mode == 0o700, f"expected 0700 on the directory, got {oct(directory_mode)}"
+
+
+def test_generated_config_still_carries_what_the_server_needs(tmp_path, monkeypatch):
+    """Hardening must not break the contents the MCP server depends on."""
+    import agent_manager as am
+
+    monkeypatch.setattr(am, "SCRIPT_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("API_SHARED_KEY", "k" * 64)
+
+    manager = am.SessionManager()
+    monkeypatch.setattr(
+        manager,
+        "get_or_create_session_data",
+        lambda _sid: {"identity": "local-macos", "channel": "webui"},
+    )
+
+    path = manager._wee_browser_mcp_config_file("sess-contents")
+    env = json.load(open(path))["mcpServers"]["wee-browser"]["env"]
+
+    assert env["WEE_BROWSER_SESSION_ID"] == "sess-contents"
+    assert env["WEE_API_TOKEN"].startswith("shared_")
+    # Without these the ownership check rejects the call as a different user,
+    # which is what made browser control fail in the first place.
+    assert env["WEE_API_IDENTITY"] == "local-macos"
+    assert env["WEE_API_CHANNEL"] == "webui"


### PR DESCRIPTION
Promotes #475 to main.

The per-session browser MCP config embeds the API shared key. It was neither gitignored (one `git add -A` from committing a live key — one was already sitting untracked in a working checkout) nor written with restrictive permissions (readable by any other local user).

Now `.mcp-configs/` is ignored, and the file is created `0600` at creation time with the directory at `0700`. Tests pin both plus the config contents the MCP server depends on.

Verified on the dev host: 17 passed.