### PR TITLE
Add session-scoped shell control, mirroring browser control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,6 @@ logs/wee_executor.log
 # Transcript storage (contains sensitive session data)
 logs/transcripts/
 
-# Per-session browser MCP configs. These embed the API shared key so the MCP
-# server can authenticate, and are regenerated on every run.
+# Per-session browser/shell MCP configs. These embed the API shared key so
+# the MCP server can authenticate, and are regenerated on every run.
 .mcp-configs/

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ telegram_downloads/
 *.env
 *.env.local
 *.env.*.local
+# Catch .env variants that don't END in .env — backups (.env.bak-*),
+# .env.save, .env.old. `*.env` alone misses these, which is how
+# plaintext secret copies end up untracked-but-committable.
+.env.*
+!.env.example
 webex_config.json
 telegram_config.json
 .env.prod

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -5811,6 +5811,113 @@ You can mention an agent in your prompt and it will auto-delegate:
             args += ["-c", f"{prefix}.env.{key}={json.dumps(value)}"]
         return args
 
+    # Same shape as the browser helpers above, for the session shell (#477).
+    # The `wee` runtime registers an in-process `shell` Tool; subprocess
+    # runtimes get the `wee-shell` MCP server instead, for the same reason.
+
+    WEE_SHELL_MCP_NAME = "wee-shell"
+    WEE_SHELL_MCP_RUNTIMES = frozenset({"codex", "claude", "copilot"})
+
+    def _wee_shell_prompt_note(self, n8n_session_id: str) -> str:
+        """Point the agent at this session's shell, or "" when there is none.
+
+        Unlike the browser, codex/claude/copilot each already ship a working
+        native shell tool, so there is no "reports nothing available" failure
+        to redirect around. The problem here is different: without an explicit
+        nudge, the agent has no reason to prefer the one shell the user can
+        actually see and type into over its own private one.
+        """
+        if self._wee_shell_mcp_server_spec(n8n_session_id) is None:
+            return ""
+        return (
+            "\n\n[Session Shell]\n"
+            "This chat has its own shell attached, and the user can see it and "
+            "may type commands into it themselves. "
+            f"Control it with the `{self.WEE_SHELL_MCP_NAME}` MCP tools: "
+            "shell_run (run a command line), shell_write (type raw text, no "
+            "Enter -- for answering an interactive prompt), shell_key (send "
+            "ctrl-c/tab/arrows/etc.), shell_read (see recent output without "
+            "sending input, including anything the user typed).\n"
+            "Use these -- not your own built-in shell/bash/terminal tool -- for "
+            "anything the user might want to see or that responds to what the "
+            "user typed in \"the shell\", \"the terminal\", or \"this session\". "
+            "It is a shared terminal: check shell_read before assuming a "
+            "command failed or that nothing happened."
+        )
+
+    def _wee_shell_mcp_env(self, n8n_session_id: str) -> Optional[Dict[str, str]]:
+        shared_key = os.environ.get("API_SHARED_KEY", "")
+        if not shared_key or not n8n_session_id:
+            return None
+
+        scheme = "https" if os.environ.get("SSL_CERTFILE") else "http"
+        port = os.environ.get("API_PORT", "8001")
+        session_data = self.get_or_create_session_data(n8n_session_id) or {}
+
+        env = {
+            "WEE_SHELL_SESSION_ID": n8n_session_id,
+            "WEE_API_BASE": f"{scheme}://127.0.0.1:{port}",
+            "WEE_API_TOKEN": f"shared_{shared_key}",
+        }
+        if identity := session_data.get("identity"):
+            env["WEE_API_IDENTITY"] = str(identity)
+        if channel := session_data.get("channel"):
+            env["WEE_API_CHANNEL"] = str(channel)
+        if scheme == "https":
+            env["WEE_API_INSECURE_TLS"] = "1"
+        return env
+
+    def _wee_shell_mcp_server_spec(self, n8n_session_id: str) -> Optional[dict]:
+        """The `wee-shell` MCP server as command/args/env, or None."""
+        env = self._wee_shell_mcp_env(n8n_session_id)
+        if env is None:
+            return None
+        return {
+            "command": sys.executable or "python3",
+            "args": [os.path.join(SCRIPT_BASE_DIR, "wee_shell_mcp.py")],
+            "env": env,
+        }
+
+    def _wee_shell_mcp_config_file(self, n8n_session_id: str) -> Optional[str]:
+        """Write an `mcpServers` JSON config and return its path, or None.
+
+        Same secret-hygiene requirements as the browser config: the file
+        embeds the API shared key, so it is owner-only from creation and the
+        containing directory is gitignored.
+        """
+        spec = self._wee_shell_mcp_server_spec(n8n_session_id)
+        if spec is None:
+            return None
+        try:
+            directory = os.path.join(SCRIPT_BASE_DIR, ".mcp-configs")
+            os.makedirs(directory, mode=0o700, exist_ok=True)
+            os.chmod(directory, 0o700)
+            path = os.path.join(directory, f"shell-{n8n_session_id}.json")
+            descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                json.dump({"mcpServers": {self.WEE_SHELL_MCP_NAME: spec}}, handle)
+            os.chmod(path, 0o600)
+            return path
+        except OSError as exc:
+            print(f"[Shell] Could not write MCP config: {exc}", file=sys.stderr)
+            return None
+
+    def _wee_shell_codex_config_args(self, n8n_session_id: str) -> list:
+        """`-c` overrides registering the shell MCP server with codex."""
+        spec = self._wee_shell_mcp_server_spec(n8n_session_id)
+        if spec is None:
+            return []
+        prefix = f"mcp_servers.{self.WEE_SHELL_MCP_NAME}"
+        args = [
+            "-c",
+            f"{prefix}.command={json.dumps(spec['command'])}",
+            "-c",
+            f"{prefix}.args={json.dumps(spec['args'])}",
+        ]
+        for key, value in spec["env"].items():
+            args += ["-c", f"{prefix}.env.{key}={json.dumps(value)}"]
+        return args
+
     def _parse_mode_command(self, prompt: str) -> tuple[str, str]:
         """Parse /mode command from prompt. Returns (cleaned_prompt, mode).
 
@@ -7285,11 +7392,16 @@ Do NOT emit status updates for quick operations (< 15 seconds)."""
             if runtime in self.WEE_BROWSER_MCP_RUNTIMES
             else ""
         )
+        shell_instruction = (
+            self._wee_shell_prompt_note(n8n_session_id)
+            if runtime in self.WEE_SHELL_MCP_RUNTIMES
+            else ""
+        )
 
         context = f"""{handoff_prefix}[Session ID: {n8n_session_id}]
 {runtime_instruction}{injection_text}{mobile_channel_instruction}{silent_mode_instruction}{memory_section}
 
-{agent_desc}{files_context}{render_instruction}{bg_task_instruction}{canvas_instruction}{wee_executor_instruction}{timeout_instruction}{browser_instruction}
+{agent_desc}{files_context}{render_instruction}{bg_task_instruction}{canvas_instruction}{wee_executor_instruction}{timeout_instruction}{browser_instruction}{shell_instruction}
 
 User Request:
 {prompt}"""
@@ -8282,6 +8394,8 @@ User Request:
         # than replacing them.
         if _browser_mcp := self._wee_browser_mcp_config_file(n8n_session_id):
             cmd += ["--additional-mcp-config", f"@{_browser_mcp}"]
+        if _shell_mcp := self._wee_shell_mcp_config_file(n8n_session_id):
+            cmd += ["--additional-mcp-config", f"@{_shell_mcp}"]
 
         # Add elevated flags for full access
         if mode == "elevated":
@@ -8407,6 +8521,8 @@ User Request:
             # browser control for the rest of its life.
             if _recovery_browser_mcp := self._wee_browser_mcp_config_file(n8n_session_id):
                 _recovery_cmd += ["--additional-mcp-config", f"@{_recovery_browser_mcp}"]
+            if _recovery_shell_mcp := self._wee_shell_mcp_config_file(n8n_session_id):
+                _recovery_cmd += ["--additional-mcp-config", f"@{_recovery_shell_mcp}"]
             if mode == "elevated":
                 _recovery_cmd.insert(2, "--allow-all-paths")
                 _recovery_cmd.append("--yolo")
@@ -9145,6 +9261,8 @@ User Request:
             # Additive: no --strict-mcp-config, so the agent's own MCP servers
             # keep working alongside this one.
             cmd.extend(["--mcp-config", browser_mcp_config])
+        if shell_mcp_config := self._wee_shell_mcp_config_file(n8n_session_id):
+            cmd.extend(["--mcp-config", shell_mcp_config])
 
         if resume and session_id:
             cmd.append(f"--resume={session_id}")
@@ -9446,6 +9564,7 @@ User Request:
             if model:
                 cmd += ["-m", model]
             cmd += self._wee_browser_codex_config_args(n8n_session_id)
+            cmd += self._wee_shell_codex_config_args(n8n_session_id)
             cmd += [session_id, context_prompt]
             print(
                 f"[Session] Resuming CODEX session: {session_id} with model {model} in {mode} mode",
@@ -9466,6 +9585,7 @@ User Request:
             if model:
                 cmd += ["-m", model]
             cmd += self._wee_browser_codex_config_args(n8n_session_id)
+            cmd += self._wee_shell_codex_config_args(n8n_session_id)
             cmd.append(context_prompt)
             print(
                 f"[Session] Starting new CODEX session with model {model} in {mode} mode",
@@ -9904,6 +10024,47 @@ User Request:
                 handler=browser_handler,
             )
 
+            async def shell_handler(invocation):
+                return await asyncio.to_thread(
+                    self._wee_execute_tool,
+                    "session_shell",
+                    dict(invocation.arguments or {}),
+                    agent,
+                    n8n_session_id,
+                )
+
+            shell_tool = Tool(
+                name="session_shell",
+                description=(
+                    "Control the shell attached to this chat session, which the "
+                    "user can see and may type into themselves. Use shell_read "
+                    "before assuming a command failed -- it may still be running "
+                    "or the user may have already handled it. This is NOT your "
+                    "own private shell/bash tool; it is a shared terminal."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["run", "write", "key", "read"],
+                        },
+                        "command": {"type": "string", "description": "For action=run"},
+                        "text": {"type": "string", "description": "For action=write"},
+                        "key": {
+                            "type": "string",
+                            "description": "For action=key",
+                            "enum": [
+                                "ctrl-c", "ctrl-d", "tab", "up", "down", "left",
+                                "right", "enter", "escape", "backspace",
+                            ],
+                        },
+                    },
+                    "required": ["action"],
+                },
+                handler=shell_handler,
+            )
+
             # Issue #453: #443 stopped redeclaring shell/file tools on the theory
             # that "the Copilot SDK session already knows about and describes its
             # own built-in tools". That holds for Copilot-native models but not
@@ -10012,7 +10173,7 @@ User Request:
                 timeout=float(effective_timeout),
                 session_id=saved_sdk_session,
                 resume=bool(resume and saved_sdk_session),
-                tools=[search_tool, call_agent_tool, browser_tool] + native_tools,
+                tools=[search_tool, call_agent_tool, browser_tool, shell_tool] + native_tools,
                 enable_tools=True,
                 event_callback=on_sdk_event,
             )
@@ -10041,7 +10202,7 @@ User Request:
                         timeout=float(effective_timeout),
                         session_id=retry_session,
                         resume=bool(retry_session),
-                        tools=[search_tool, call_agent_tool, browser_tool],
+                        tools=[search_tool, call_agent_tool, browser_tool, shell_tool],
                         enable_tools=True,
                         event_callback=on_sdk_event,
                     )
@@ -10795,10 +10956,20 @@ User Request:
                     func_args,
                     timeout=min(float(self.command_timeout), 90.0),
                 )
+            elif func_name == "session_shell":
+                if not n8n_session_id:
+                    return "Error: Shell tool requires a chat session"
+                from shell_bridge import execute_shell_command
+
+                return execute_shell_command(
+                    n8n_session_id,
+                    func_args,
+                    timeout=min(float(self.command_timeout), 90.0),
+                )
             else:
                 return (
                     f"Error: Unknown tool '{func_name}'. "
-                    "Available: search, call_agent, browser"
+                    "Available: search, call_agent, browser, session_shell"
                 )
         except Exception as e:
             return f"Error executing {func_name}: {e}"
@@ -12641,6 +12812,159 @@ def create_api_app():  # noqa: C901 – factory kept in one place intentionally
             raise HTTPException(status_code=504, detail=str(exc)) from exc
         except Exception as exc:
             raise HTTPException(status_code=502, detail=f"Browser command failed: {exc}") from exc
+
+        return {"result": output}
+
+    def _assert_shell_session_owner(session_id: str, user: dict) -> None:
+        data = session_mgr.load_session_data(session_id)
+        if not data:
+            raise HTTPException(status_code=404, detail="Session not found")
+        owner = data.get("identity")
+        channel = data.get("channel")
+        if owner and owner != user["identity"]:
+            raise HTTPException(
+                status_code=403, detail="Shell session belongs to another user"
+            )
+        if channel and channel != user["channel"]:
+            raise HTTPException(
+                status_code=403, detail="Shell session belongs to another channel"
+            )
+
+    @app.post("/api/v1/shell/sessions/{session_id}/register")
+    async def register_native_shell(session_id: str, request: Request):
+        """Attach a native shell controller to one authenticated chat session."""
+        from shell_bridge import native_shell_broker
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_shell_session_owner(session_id, user)
+        body = await request.json()
+        client_id = str(body.get("client_id") or "").strip()
+        if not client_id:
+            raise HTTPException(status_code=400, detail="client_id is required")
+        try:
+            native_shell_broker.register(
+                session_id, user["identity"], user["channel"], client_id
+            )
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        return {"registered": True, "session_id": session_id}
+
+    @app.get("/api/v1/shell/sessions/{session_id}/commands")
+    async def poll_native_shell_commands(
+        session_id: str, request: Request, client_id: str, timeout: float = 25.0
+    ):
+        """Long-poll the next command for a native session shell."""
+        from shell_bridge import native_shell_broker
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_shell_session_owner(session_id, user)
+        try:
+            command = await asyncio.to_thread(
+                native_shell_broker.poll,
+                session_id,
+                user["identity"],
+                user["channel"],
+                client_id,
+                timeout,
+            )
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        return {"command": command}
+
+    @app.post("/api/v1/shell/sessions/{session_id}/results")
+    async def submit_native_shell_result(session_id: str, request: Request):
+        """Return a native PTY command result to the waiting Wee tool."""
+        from shell_bridge import native_shell_broker
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_shell_session_owner(session_id, user)
+        body = await request.json()
+        client_id = str(body.get("client_id") or "").strip()
+        command_id = str(body.get("command_id") or "").strip()
+        if not client_id or not command_id:
+            raise HTTPException(
+                status_code=400, detail="client_id and command_id are required"
+            )
+        try:
+            native_shell_broker.submit_result(
+                session_id,
+                user["identity"],
+                user["channel"],
+                client_id,
+                command_id,
+                output=body.get("output"),
+                error=body.get("error"),
+            )
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        return {"accepted": True}
+
+    @app.post("/api/v1/shell/sessions/{session_id}/execute")
+    async def execute_native_shell_command(session_id: str, request: Request):
+        """Drive this session's shell from outside the API process.
+
+        Same seam as `/api/v1/browser/sessions/{id}/execute`: the `wee-shell`
+        MCP server calls this on behalf of the subprocess runtimes, since the
+        broker's registrations live in this process's memory.
+        """
+        from shell_bridge import execute_shell_command
+
+        user = await authenticate(
+            request,
+            authorization=request.headers.get("authorization"),
+            x_user_identity=request.headers.get("x-user-identity"),
+            x_auth_channel=request.headers.get("x-auth-channel"),
+        )
+        _assert_shell_session_owner(session_id, user)
+
+        try:
+            body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+
+        action = str(body.get("action") or "").strip()
+        if not action:
+            raise HTTPException(status_code=400, detail="'action' is required")
+
+        command = {k: v for k, v in body.items() if k != "timeout" and v is not None}
+        raw_timeout = body.get("timeout")
+        try:
+            timeout = float(raw_timeout) if raw_timeout is not None else 45.0
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="'timeout' must be a number")
+
+        loop = asyncio.get_running_loop()
+        try:
+            # execute_shell_command blocks waiting on the shell client, so keep
+            # it off the event loop -- otherwise one slow command would stall
+            # every other request this API is serving.
+            output = await loop.run_in_executor(
+                None, lambda: execute_shell_command(session_id, command, timeout=timeout)
+            )
+        except RuntimeError as exc:
+            # Raised when no shell client is attached to this session.
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except TimeoutError as exc:
+            raise HTTPException(status_code=504, detail=str(exc)) from exc
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"Shell command failed: {exc}") from exc
 
         return {"result": output}
 

--- a/shell_bridge.py
+++ b/shell_bridge.py
@@ -1,0 +1,148 @@
+"""Session-scoped shell control for Wee native clients.
+
+Mirrors browser_bridge.py's native broker: a native client (the macOS app)
+registers a PTY-backed shell against a chat session and long-polls a small
+authenticated command queue. The LLM (in-process for wee/copilot-sdk/claude-sdk,
+or via the wee-shell MCP server for codex/claude/copilot) sends run/write/key/read
+commands and gets back the terminal output those commands produced.
+
+Unlike the browser, there is no headless fallback. A shell nobody can see
+defeats the point of "the user should also be able to run commands in it" --
+if no native shell is attached, the tool should say so, not silently spin up
+something the user can't watch or type into.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Any, Optional
+from uuid import uuid4
+
+
+@dataclass
+class ShellRegistration:
+    identity: str
+    channel: str
+    client_id: str
+    last_seen: float = field(default_factory=time.monotonic)
+
+
+class NativeShellBroker:
+    def __init__(self, active_ttl: float = 45.0):
+        self.active_ttl = active_ttl
+        self._condition = threading.Condition()
+        self._registrations: dict[str, ShellRegistration] = {}
+        self._commands: dict[str, deque[dict[str, Any]]] = defaultdict(deque)
+        self._results: dict[str, dict[str, Any]] = {}
+
+    def register(
+        self, session_id: str, identity: str, channel: str, client_id: str
+    ) -> None:
+        with self._condition:
+            current = self._registrations.get(session_id)
+            if current and (current.identity, current.channel) != (identity, channel):
+                raise PermissionError("Shell session belongs to another user")
+            self._registrations[session_id] = ShellRegistration(
+                identity=identity, channel=channel, client_id=client_id
+            )
+            self._condition.notify_all()
+
+    def _registration(
+        self, session_id: str, identity: str, channel: str, client_id: str
+    ) -> ShellRegistration:
+        registration = self._registrations.get(session_id)
+        if not registration or (
+            registration.identity,
+            registration.channel,
+            registration.client_id,
+        ) != (identity, channel, client_id):
+            raise PermissionError("Native shell is not registered for this session")
+        return registration
+
+    def poll(
+        self,
+        session_id: str,
+        identity: str,
+        channel: str,
+        client_id: str,
+        timeout: float = 25.0,
+    ) -> Optional[dict[str, Any]]:
+        deadline = time.monotonic() + max(0.0, min(timeout, 30.0))
+        with self._condition:
+            registration = self._registration(
+                session_id, identity, channel, client_id
+            )
+            registration.last_seen = time.monotonic()
+            while not self._commands[session_id]:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    registration.last_seen = time.monotonic()
+                    return None
+                self._condition.wait(remaining)
+                registration = self._registration(
+                    session_id, identity, channel, client_id
+                )
+                registration.last_seen = time.monotonic()
+            return self._commands[session_id].popleft()
+
+    def submit_result(
+        self,
+        session_id: str,
+        identity: str,
+        channel: str,
+        client_id: str,
+        command_id: str,
+        output: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        with self._condition:
+            registration = self._registration(
+                session_id, identity, channel, client_id
+            )
+            registration.last_seen = time.monotonic()
+            self._results[command_id] = {"output": output, "error": error}
+            self._condition.notify_all()
+
+    def is_active(self, session_id: str) -> bool:
+        with self._condition:
+            registration = self._registrations.get(session_id)
+            return bool(
+                registration
+                and time.monotonic() - registration.last_seen <= self.active_ttl
+            )
+
+    def execute(
+        self, session_id: str, command: dict[str, Any], timeout: float = 45.0
+    ) -> dict[str, Any]:
+        command_id = str(uuid4())
+        payload = {"id": command_id, **command}
+        deadline = time.monotonic() + max(1.0, min(timeout, 90.0))
+        with self._condition:
+            if not self.is_active(session_id):
+                raise RuntimeError("No native shell is connected to this session")
+            self._commands[session_id].append(payload)
+            self._condition.notify_all()
+            while command_id not in self._results:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("Native shell command timed out")
+                self._condition.wait(remaining)
+            result = self._results.pop(command_id)
+        if result.get("error"):
+            raise RuntimeError(str(result["error"]))
+        return result
+
+
+native_shell_broker = NativeShellBroker()
+
+
+def execute_shell_command(
+    session_id: str, command: dict[str, Any], timeout: float = 45.0
+) -> str:
+    response = native_shell_broker.execute(session_id, command, timeout=timeout)
+    output = response.get("output") or ""
+    return output[:16_000]

--- a/tests/test_issue397_wee_search_tool.py
+++ b/tests/test_issue397_wee_search_tool.py
@@ -83,7 +83,7 @@ class TestIssue397SearchToolIsWired(unittest.TestCase):
 
         self.assertIn('name="search"', source, "search must be a registered SDK Tool")
         self.assertIn(
-            "tools=[search_tool, call_agent_tool, browser_tool]",
+            "tools=[search_tool, call_agent_tool, browser_tool, shell_tool]",
             source,
             "the search tool must be passed to the SDK session",
         )
@@ -91,7 +91,7 @@ class TestIssue397SearchToolIsWired(unittest.TestCase):
         # same tools, otherwise a retry would be less capable than the turn it
         # is retrying.
         self.assertEqual(
-            source.count("tools=[search_tool, call_agent_tool, browser_tool]"),
+            source.count("tools=[search_tool, call_agent_tool, browser_tool, shell_tool]"),
             2,
             "both the initial turn and the #398 retry must register search",
         )

--- a/tests/test_mcp_config_secret_hygiene.py
+++ b/tests/test_mcp_config_secret_hygiene.py
@@ -1,15 +1,16 @@
 """
-The per-session browser MCP config embeds the API shared key so the MCP server
-can authenticate against the local API. Two exposures came with that, both
-introduced alongside the browser feature:
+The per-session browser and shell MCP configs embed the API shared key so the
+MCP server can authenticate against the local API. Two exposures came with
+that, both introduced alongside the browser feature and inherited verbatim by
+the shell feature (#477) since it writes into the same directory the same way:
 
 1. `.mcp-configs/` was not in .gitignore, so one `git add -A` in a checkout
    would have committed a live shared key.
 2. The file was written with the default umask, leaving the key readable by
    any other local user.
 
-These pin both. The key is real credential material, so the guard needs to be
-a test rather than a convention.
+These pin both, for both features. The key is real credential material, so
+the guard needs to be a test rather than a convention.
 """
 
 import json
@@ -81,5 +82,65 @@ def test_generated_config_still_carries_what_the_server_needs(tmp_path, monkeypa
     assert env["WEE_API_TOKEN"].startswith("shared_")
     # Without these the ownership check rejects the call as a different user,
     # which is what made browser control fail in the first place.
+    assert env["WEE_API_IDENTITY"] == "local-macos"
+    assert env["WEE_API_CHANNEL"] == "webui"
+
+
+def test_shell_mcp_config_directory_is_gitignored():
+    """Same exposure, same file, different prefix -- pin it separately anyway."""
+    result = subprocess.run(
+        ["git", "check-ignore", "-v", ".mcp-configs/shell-abc123.json"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        ".mcp-configs/ is not gitignored, so a generated shell MCP config "
+        "carrying the API shared key could be committed:\n" + result.stderr
+    )
+
+
+def test_generated_shell_config_is_owner_only(tmp_path, monkeypatch):
+    """The key must not be readable by other local users."""
+    import agent_manager as am
+
+    monkeypatch.setattr(am, "SCRIPT_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("API_SHARED_KEY", "k" * 64)
+
+    manager = am.SessionManager()
+    monkeypatch.setattr(
+        manager, "get_or_create_session_data", lambda _sid: {"identity": "u", "channel": "webui"}
+    )
+
+    path = manager._wee_shell_mcp_config_file("sess-shell-hygiene")
+    assert path is not None, "config should have been written"
+
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600, f"expected 0600, got {oct(mode)} — group/other can read the key"
+
+    directory_mode = stat.S_IMODE(os.stat(os.path.dirname(path)).st_mode)
+    assert directory_mode == 0o700, f"expected 0700 on the directory, got {oct(directory_mode)}"
+
+
+def test_generated_shell_config_still_carries_what_the_server_needs(tmp_path, monkeypatch):
+    """Hardening must not break the contents the MCP server depends on."""
+    import agent_manager as am
+
+    monkeypatch.setattr(am, "SCRIPT_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("API_SHARED_KEY", "k" * 64)
+
+    manager = am.SessionManager()
+    monkeypatch.setattr(
+        manager,
+        "get_or_create_session_data",
+        lambda _sid: {"identity": "local-macos", "channel": "webui"},
+    )
+
+    path = manager._wee_shell_mcp_config_file("sess-shell-contents")
+    env = json.load(open(path))["mcpServers"]["wee-shell"]["env"]
+
+    assert env["WEE_SHELL_SESSION_ID"] == "sess-shell-contents"
+    assert env["WEE_API_TOKEN"].startswith("shared_")
     assert env["WEE_API_IDENTITY"] == "local-macos"
     assert env["WEE_API_CHANNEL"] == "webui"

--- a/wee_shell_mcp.py
+++ b/wee_shell_mcp.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""stdio MCP server exposing one Wee chat session's shell to any runtime.
+
+The `wee` runtime drives the shell by calling `shell_bridge` in-process. The
+subprocess runtimes (codex, claude, gemini, opencode, cursor) cannot: the
+broker's client registrations live in the API process's memory. This server is
+the bridge -- it speaks MCP over stdio to whichever CLI launched it, and calls
+`POST /api/v1/shell/sessions/{id}/execute` on the API to do the work.
+
+There is no headless fallback here (unlike the browser). If no native shell is
+attached, the right answer is to say so, not to spin up something the user
+can't see or type into -- that would defeat the point of a shell the user is
+meant to share with the agent.
+
+Configuration is entirely by environment, because that is what every CLI's MCP
+config can set:
+
+    WEE_SHELL_SESSION_ID    the chat session whose shell to drive (required)
+    WEE_API_BASE            e.g. http://127.0.0.1:8001 (required)
+    WEE_API_TOKEN           bearer token for that API (required)
+    WEE_API_IDENTITY        X-User-Identity, when the API expects one
+    WEE_API_CHANNEL         X-Auth-Channel, when the API expects one
+    WEE_API_INSECURE_TLS    "1" to skip TLS verification (self-signed prod cert)
+
+The JSON-RPC framing is hand-rolled rather than taken from the `mcp` package:
+that package is not in requirements.txt, and this server has to start reliably
+inside whatever interpreter a given CLI happens to spawn.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "wee-shell"
+SERVER_VERSION = "1.0.0"
+
+# Matches the API's own ceiling for a shell command so this layer never times
+# out first and reports a confusing error for a command still in flight.
+REQUEST_TIMEOUT = 95.0
+
+TOOLS = [
+    {
+        "name": "shell_run",
+        "description": (
+            "Run a command line in this chat session's shell (as if the user "
+            "typed it and pressed Enter) and return the terminal output it "
+            "produced. The user can see this shell and everything run in it, "
+            "and may have typed commands of their own -- read the output "
+            "carefully, it is a shared terminal, not a private scratch shell."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"command": {"type": "string", "description": "Command line to run"}},
+            "required": ["command"],
+        },
+    },
+    {
+        "name": "shell_write",
+        "description": (
+            "Type raw text into this session's shell without pressing Enter. "
+            "Use this to answer an interactive prompt (e.g. a password or "
+            "y/n confirmation) that a running command is waiting on."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "shell_key",
+        "description": (
+            "Send a control key to this session's shell: ctrl-c, ctrl-d, "
+            "tab, up, down, left, right, enter, escape, or backspace."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "enum": [
+                        "ctrl-c", "ctrl-d", "tab", "up", "down", "left",
+                        "right", "enter", "escape", "backspace",
+                    ],
+                }
+            },
+            "required": ["key"],
+        },
+    },
+    {
+        "name": "shell_read",
+        "description": (
+            "Read this session's shell without sending any input -- use this "
+            "to see what the user just typed, or the output of a long-running "
+            "command since you last looked."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+# MCP tool name -> the action understood by shell_bridge.
+_ACTIONS = {
+    "shell_run": "run",
+    "shell_write": "write",
+    "shell_key": "key",
+    "shell_read": "read",
+}
+
+
+def _env(name: str) -> str:
+    return (os.environ.get(name) or "").strip()
+
+
+def _ssl_context():
+    if _env("WEE_API_INSECURE_TLS") in {"1", "true", "yes"}:
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        return context
+    return None
+
+
+def _execute(action: str, arguments: dict) -> str:
+    """Send one shell command to the API and return the resulting output."""
+    session_id = _env("WEE_SHELL_SESSION_ID")
+    api_base = _env("WEE_API_BASE").rstrip("/")
+    token = _env("WEE_API_TOKEN")
+
+    missing = [
+        name
+        for name, value in (
+            ("WEE_SHELL_SESSION_ID", session_id),
+            ("WEE_API_BASE", api_base),
+            ("WEE_API_TOKEN", token),
+        )
+        if not value
+    ]
+    if missing:
+        return f"Shell control is not configured for this session (missing {', '.join(missing)})."
+
+    payload = {"action": action, **{k: v for k, v in arguments.items() if v is not None}}
+    request = urllib.request.Request(
+        f"{api_base}/api/v1/shell/sessions/{session_id}/execute",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+    )
+    request.add_header("Content-Type", "application/json")
+    request.add_header("Authorization", f"Bearer {token}")
+    if identity := _env("WEE_API_IDENTITY"):
+        request.add_header("X-User-Identity", identity)
+    if channel := _env("WEE_API_CHANNEL"):
+        request.add_header("X-Auth-Channel", channel)
+
+    try:
+        with urllib.request.urlopen(
+            request, timeout=REQUEST_TIMEOUT, context=_ssl_context()
+        ) as response:
+            body = json.loads(response.read().decode("utf-8"))
+        return str(body.get("result", ""))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:600]
+        if exc.code == 409:
+            # The one failure worth explaining: the panel is not attached, and
+            # the user is the only one who can fix that.
+            return (
+                "No shell is attached to this chat session. Open the shell "
+                "panel for this chat in the Wee app, then try again. "
+                f"({detail})"
+            )
+        return f"Shell command failed (HTTP {exc.code}): {detail}"
+    except Exception as exc:
+        return f"Shell command failed: {exc}"
+
+
+def _respond(message_id, result=None, error=None) -> None:
+    payload = {"jsonrpc": "2.0", "id": message_id}
+    if error is not None:
+        payload["error"] = error
+    else:
+        payload["result"] = result
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _handle(message: dict) -> None:
+    method = message.get("method")
+    message_id = message.get("id")
+
+    # Notifications carry no id and must not be answered.
+    if message_id is None:
+        return
+
+    if method == "initialize":
+        _respond(
+            message_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        )
+    elif method == "tools/list":
+        _respond(message_id, {"tools": TOOLS})
+    elif method == "tools/call":
+        params = message.get("params") or {}
+        name = params.get("name") or ""
+        action = _ACTIONS.get(name)
+        if action is None:
+            _respond(message_id, error={"code": -32602, "message": f"Unknown tool: {name}"})
+            return
+        output = _execute(action, params.get("arguments") or {})
+        _respond(message_id, {"content": [{"type": "text", "text": output}]})
+    elif method in {"ping", "shutdown"}:
+        _respond(message_id, {})
+    else:
+        _respond(message_id, error={"code": -32601, "message": f"Unknown method: {method}"})
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            _handle(message)
+        except Exception as exc:  # pragma: no cover - defensive
+            # A crash here would take shell control down for the whole run,
+            # so report and keep serving.
+            _respond(message.get("id"), error={"code": -32603, "message": str(exc)})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #477.

## What

Server side of a shell attached to each chat session that both the LLM and
the user can drive, sharing one buffer:

- `shell_bridge.py` — register/poll/execute broker, same shape as
  `browser_bridge.py`'s `NativeBrowserBroker`. No headless fallback: a shell
  nobody can see defeats the point of "the user should also be able to run
  commands in it."
- `wee_shell_mcp.py` — stdio MCP server for codex/claude/copilot, exposing
  `shell_run` / `shell_write` / `shell_key` / `shell_read`.
- `agent_manager.py` wiring, mirroring every `WEE_BROWSER_*` touch point:
  in-process `session_shell` Tool for wee/copilot-sdk/claude-sdk, MCP config
  injection (`--additional-mcp-config` / `--mcp-config` / codex `-c`
  overrides) for the subprocess runtimes, a prompt note steering the agent
  to the shared shell instead of its own private bash/shell tool, and
  `register` / `commands` / `results` / `execute` endpoints under
  `/api/v1/shell/sessions/{id}/...` with the same per-session ownership
  check as browser.
- Same secret hygiene as the browser MCP config (0600 file / 0700 dir at
  creation, gitignored) since it carries the same API shared key — pinned by
  three new tests in `tests/test_mcp_config_secret_hygiene.py`.

The macOS client (the actual PTY, and the panel the user types into) is
tracked separately and will land in the `wee-orchestrator-macos` repo.

## Testing

- `pytest tests/test_mcp_config_secret_hygiene.py` — 6/6 pass (3 existing
  browser + 3 new shell).
- Full suite diffed against `dev`: identical failure set before/after (one
  test, `test_issue397_wee_search_tool.py`, pinned the exact SDK tools list
  and was updated to include `shell_tool` — a legitimate change, not a
  regression).
- Deployed to the dev host and restarted the service cleanly, no errors in
  logs.
- Full live round trip against a local instance of the updated API: created
  a session, registered a fake native shell client, drove it through
  `wee_shell_mcp.py` as a real subprocess speaking JSON-RPC over stdio
  (`initialize` → `tools/list` → `tools/call shell_run`), confirmed the
  command reached the simulated native client via long-poll and the output
  round-tripped back through `/execute` correctly. Also confirmed `/execute`
  returns 409 when no native client is registered for a session.

Note: the dev host's `API_SHARED_KEY` isn't currently set in its running
environment (pre-existing gap, not introduced by this PR — it affects the
existing browser MCP wiring identically), so the live round trip above ran
against a local instance with a test key rather than against the dev host
directly.